### PR TITLE
Use the existing machinery for generalization from Lean.Meta.Tactic.Cases instead of rolling our own

### DIFF
--- a/LF/CustomTactics.lean
+++ b/LF/CustomTactics.lean
@@ -94,7 +94,7 @@ partial def unifyEqs (eqs : List FVarId) (mvarId : MVarId) (subst : FVarSubst) (
   | eq :: eqs =>
     let some { mvarId, subst, numNewEqs } ← Option.join <$> (observing? $ unifyEq? mvarId eq subst MVarId.acyclic caseName?)
       | return (mvarId, subst)
-    let (newEqs, mvarId) ← mvarId.introNP numNewEqs
+    let (newEqs, mvarId) ← mvarId.introN numNewEqs
     let eqs := eqs.map (Expr.fvarId! ∘ subst.get)
     unifyEqs (newEqs.toList ++ eqs) mvarId subst caseName?
 
@@ -160,7 +160,7 @@ def inversionCore (h : FVarId) (config : InversionConfig) : TacticM (List MVarId
     let some ctx ← mkCasesContext? h
     | throwTacticEx `cases goal "not applicable to the given hypothesis"
     let gis@⟨newGoal, _, newTarget, numEqs⟩ ← generalizeIndices goal h
-    let (newEqs, newGoal) ← newGoal.introNP numEqs
+    let (newEqs, newGoal) ← newGoal.introN numEqs
     let subgoals ← inductionCasesOn newGoal newTarget default ctx
     let subgoals ← elimAuxIndices gis subgoals
     let subgoals ← unifyCasesEqs newEqs.toList subgoals
@@ -217,12 +217,14 @@ end -- meta section
 
 namespace Tests
 
-example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : 0 = f n := by
-  -- cases le /- Dependent elimination failed: Failed to solve equation 0 = f n -/
-  inversion le; exact h
+set_option pp.proofs true
 
 example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : 0 = f n := by
-  inversion +clear le; exact h
+  -- cases le /- Dependent elimination failed: Failed to solve equation 0 = f n -/
+  inversion le; assumption
+
+example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : 0 = f n := by
+  inversion +clear le; assumption
 
 /-- warning: declaration uses `sorry` -/
 #guard_msgs(warning) in

--- a/LF/CustomTactics.lean
+++ b/LF/CustomTactics.lean
@@ -30,8 +30,10 @@ syntax (" | " caseArg)+ " => " tacticSeq : invAlts
 /--
   `inversion t` generalizes nonvariable indices of the type of `t` before invoking `cases t`,
   then solves away contradictory generated goals.
-  * If `inversion +clear t` is set, `t` is `clear`ed from the context.
-    By default, `t` will remain in the context.
+  `t` itself will also be generalized with a heterogeneous equality `heq`
+  if trying to generalize the indices produces an ill-typed result.
+  * If `inversion +clear t` is set, then `heq` will be `clear`ed from the context if present,
+    along with `t` if there are no dependencies on it.
   * The form `inversion t with | tag₁ x ... => tac ... | ... | tagₙ z ... => tac ...` is supported,
     similar to that of `cases` and `inversion`.
 -/
@@ -93,7 +95,7 @@ partial def unifyEqs (eqs : List FVarId) (mvarId : MVarId) (subst : FVarSubst) (
   | [] => return (mvarId, subst)
   | eq :: eqs =>
     let some { mvarId, subst, numNewEqs } ← Option.join <$> (observing? $ unifyEq? mvarId eq subst MVarId.acyclic caseName?)
-      | return (mvarId, subst)
+      | unifyEqs eqs mvarId subst caseName?
     let (newEqs, mvarId) ← mvarId.introN numNewEqs
     let eqs := eqs.map (Expr.fvarId! ∘ subst.get)
     unifyEqs (newEqs.toList ++ eqs) mvarId subst caseName?
@@ -109,6 +111,16 @@ def unifyCasesEqs (eqs : List FVarId) (subgoals : Array CasesSubgoal) : MetaM (A
       subst  := subst,
       fields := s.fields.map (subst.apply ·)
     }
+
+/-- Try to clear the given fvars from the local context of each subgoal,
+  using the subgoals' substitution mappings to find the fvars.
+
+  As with [MVarId.tryClearMany], the fvars must be in the order they appear in the context.  -/
+def casesClearMany (subgoals : Array CasesSubgoal) (fvarIds : Array FVarId) : MetaM (Array CasesSubgoal) :=
+  subgoals.mapM fun s => do
+    let fvarIds := fvarIds.filterMap (Expr.fvarId? ∘ s.subst.get)
+    let mvarId ← s.mvarId.tryClearMany fvarIds
+    return { s with mvarId }
 
 end Lean.Meta
 
@@ -151,19 +163,19 @@ declare_config_elab elabInversionConfig InversionConfig
 open Cases in
 def inversionCore (h : FVarId) (config : InversionConfig) : TacticM (List MVarId) := withMainContext do
   let goal ← getMainGoal
-  let hypType ← h.getType
-  let hypName ← h.getUserName
-  let (_, goal) ←
-    if config.clear then pure (h, goal)
-    else (← goal.assert hypName hypType (.fvar h)).intro1P
   goal.withContext do
     let some ctx ← mkCasesContext? h
-    | throwTacticEx `cases goal "not applicable to the given hypothesis"
+    | throwTacticEx `inversion goal "Not applicable to the given hypothesis"
     let gis@⟨newGoal, _, newTarget, numEqs⟩ ← generalizeIndices goal h
     let (newEqs, newGoal) ← newGoal.introN numEqs
+    let some targetEq := newEqs.back?
+    | throwTacticEx `inversion newGoal "Failed to generalize target"
     let subgoals ← inductionCasesOn newGoal newTarget default ctx
     let subgoals ← elimAuxIndices gis subgoals
     let subgoals ← unifyCasesEqs newEqs.toList subgoals
+    let subgoals ← if config.clear
+      then casesClearMany subgoals #[h, targetEq]
+      else pure subgoals
     return subgoals.toList.map (·.mvarId)
 
 /-- Given an inversion alternative and a list of goals,
@@ -216,28 +228,43 @@ end Lean.Elab.Tactic
 end -- meta section
 
 namespace Tests
+open Nat
 
 set_option pp.proofs true
+set_option pp.fieldNotation false
 
-example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : 0 = f n := by
+inductive IsZero : Nat → Prop where
+  | iszero : IsZero 0
+
+example (n : Nat) (isz : IsZero n) : n = 0 := by
+  inversion isz; rfl
+
+example (f : Nat → Nat) (n : Nat) (leq : f n ≤ 0) : 0 = f n := by
   -- cases le /- Dependent elimination failed: Failed to solve equation 0 = f n -/
-  inversion le; assumption
+  inversion leq; assumption
 
-example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : 0 = f n := by
-  inversion +clear le; assumption
+example (f : Nat → Nat) (n : Nat) (leq : f n ≤ 0) : 0 = f n := by
+  inversion +clear leq; assumption
+
+example (f : Nat → Nat) (n : Nat) (leq : f n ≤ 0) : 0 = f n := by
+  inversion leq with
+  | refl heq eq =>
+    guard_hyp heq : leq ≍ le.refl
+    guard_hyp eq : 0 = f n
+    assumption
 
 /-- warning: declaration uses `sorry` -/
 #guard_msgs(warning) in
-example (f : Nat → Nat) (n m : Nat) (le : f n ≤ f m) : f n = 0 := by
-  inversion +clear le with
-  | refl e | step k _ e =>
-    try rw [← e]
+example (f : Nat → Nat) (n m : Nat) (leq : f n ≤ f m) : f n = 0 := by
+  inversion leq with
+  | refl e _ | step k _ e _ =>
+    try rw [← eq]
     sorry
 
 /-- error: Invalid wildcard alternative: There are no unhandled alternatives -/
 #guard_msgs(error) in
-example (f : Nat → Nat) (n m : Nat) (le : f n ≤ f m) : f n = 0 := by
-  inversion +clear le with
+example (f : Nat → Nat) (n m : Nat) (leq : f n ≤ f m) : f n = 0 := by
+  inversion +clear leq with
   | refl e | step k _ e =>
     try rw [← e]
     sorry
@@ -245,8 +272,8 @@ example (f : Nat → Nat) (n m : Nat) (le : f n ≤ f m) : f n = 0 := by
 
 /-- error: Invalid alternative name `step`: There are no unhandled alternatives -/
 #guard_msgs(error) in
-example (f : Nat → Nat) (n m : Nat) (le : f n ≤ f m) : f n = 0 := by
-  inversion +clear le with
+example (f : Nat → Nat) (n m : Nat) (leq : f n ≤ f m) : f n = 0 := by
+  inversion +clear leq with
   | _ e | step k _ e =>
     try rw [← e]
     sorry
@@ -255,7 +282,7 @@ example (n m o : Nat) : [n, m] = [o, o] → [n] = [m] := by
   intro h
   inversion h; rfl
 
-inductive NoStutter {α:Type} : List α → Prop where
+inductive NoStutter {α : Type} : List α → Prop where
   | nostutter0: NoStutter []
   | nostutter1 n : NoStutter (n::[])
   | nostutter2 a b r (hneq : a ≠ b) (h : NoStutter (b::r)) : NoStutter (a::b::r)
@@ -281,10 +308,13 @@ inductive Wec α : Nat → Type where
 
 /-- warning: declaration uses `sorry` -/
 #guard_msgs(warning) in
-example {α} (n : Nat) (v : Wec α (Nat.succ n)) :
-    ∃ hd tl, v = Wec.cons Nat.succ hd tl := by
-  inversion +clear v with
-  | cons hd tl e => sorry -- don't actually know that f = succ
+example {α} (n : Nat) (v : Wec α (succ n)) :
+    ∃ hd tl, v = Wec.cons succ hd tl := by
+  inversion v with
+  | cons m f hd tl eq heq =>
+    guard_hyp eq : succ n = f m
+    guard_hyp heq : v ≍ Wec.cons f hd tl
+    sorry
 
 example (H : Bool → Nat → False) (n : Nat) : False := by
   apply H at n; apply n; exact true

--- a/LF/CustomTactics.lean
+++ b/LF/CustomTactics.lean
@@ -246,6 +246,12 @@ example (f : Nat → Nat) (n : Nat) (leq : f n ≤ 0) : 0 = f n := by
 example (f : Nat → Nat) (n : Nat) (leq : f n ≤ 0) : 0 = f n := by
   inversion +clear leq; assumption
 
+/-- error: Unknown identifier `leq` -/
+#guard_msgs(error) in
+example (f : Nat → Nat) (n : Nat) (leq : f n ≤ 0) : 0 = f n := by
+  inversion +clear leq
+  guard_hyp leq
+
 example (f : Nat → Nat) (n : Nat) (leq : f n ≤ 0) : 0 = f n := by
   inversion leq with
   | refl heq eq =>

--- a/LF/CustomTactics.lean
+++ b/LF/CustomTactics.lean
@@ -8,9 +8,10 @@ public meta import Lean.Elab.Tactic.BuiltinTactic
 meta import all Lean.Elab.Tactic.BuiltinTactic
 
 public meta import Lean.Meta.Tactic.Generalize
-public meta import Lean.Meta.Tactic.Cases
 public meta import Lean.Meta.Tactic.Injection
 public meta import Lean.Meta.Tactic.Contradiction
+public meta import Lean.Meta.Tactic.Cases
+meta import all Lean.Meta.Tactic.Cases
 
 meta section
 
@@ -78,25 +79,6 @@ def forallMetaTelescopeReducingUntilDefEq
 def _root_.Lean.MVarId.getUserName (mvarId : MVarId) : MetaM Name := do
   let decl ← mvarId.getDecl
   return decl.userName
-
-/-- Given a fully applied inductive type,
-  return a deduplicated array of its nonvariable indices to generalize. -/
-def mkGeneralizeArgs (mvarId : MVarId) (indType : Expr) (name : Name := .anonymous) : MetaM (Array GeneralizeArg) := do
-  let indType ← whnf indType
-  let (ind, args) := indType.getAppFnArgs
-  match ← isInductive? ind with
-  | some val =>
-    let indices := args.drop val.numParams
-    let mut genArgs : Array GeneralizeArg := #[]
-    for idx in indices do
-      unless idx.isFVar || genArgs.any (·.expr == idx) do
-        genArgs := genArgs.push
-          { expr := idx
-            hName? := some (← mkFreshUserName $ name.append `eq) }
-    return genArgs
-  | none =>
-    throwTacticEx `inversion mvarId
-      m!"Target is not an inductive type{indentExpr indType}"
 
 /-- Given equations `eqs` in the local context of `mvarId`,
   unify them using [Lean.Meta.unifyEq?],
@@ -166,23 +148,23 @@ structure InversionConfig where
 
 declare_config_elab elabInversionConfig InversionConfig
 
+open Cases in
 def inversionCore (h : FVarId) (config : InversionConfig) : TacticM (List MVarId) := withMainContext do
   let goal ← getMainGoal
   let hypType ← h.getType
   let hypName ← h.getUserName
-  let (target, goal) ←
+  let (_, goal) ←
     if config.clear then pure (h, goal)
     else (← goal.assert hypName hypType (.fvar h)).intro1P
-  let genArgs ← goal.withContext do
-    mkGeneralizeArgs goal hypType hypName
-  let (subst, genFVars, goal) ← goal.withContext do
-    goal.generalizeHyp genArgs #[target]
-  -- [Lean.Meta.generalizeCore] returns all equations at the end
-  let genEqs := genFVars.toList.drop genArgs.size
-  -- [Lean.MVarId.generalizeHyp] maps hyps to fvars
-  let subgoals ← goal.cases (subst.get target).fvarId!
-  let subgoals ← unifyCasesEqs genEqs subgoals
-  return subgoals.toList.map (·.mvarId)
+  goal.withContext do
+    let some ctx ← mkCasesContext? h
+    | throwTacticEx `cases goal "not applicable to the given hypothesis"
+    let gis@⟨newGoal, _, newTarget, numEqs⟩ ← generalizeIndices goal h
+    let (newEqs, newGoal) ← newGoal.introNP numEqs
+    let subgoals ← inductionCasesOn newGoal newTarget default ctx
+    let subgoals ← elimAuxIndices gis subgoals
+    let subgoals ← unifyCasesEqs newEqs.toList subgoals
+    return subgoals.toList.map (·.mvarId)
 
 /-- Given an inversion alternative and a list of goals,
   solve the tagged goal with the provided tactics,
@@ -233,12 +215,14 @@ end Lean.Elab.Tactic
 
 end -- meta section
 
-example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : f n = 0 := by
-  -- cases le /- Dependent elimination failed: Failed to solve equation 0 = f n -/
-  inversion le; rfl
+namespace Tests
 
-example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : f n = 0 := by
-  inversion +clear le; rfl
+example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : 0 = f n := by
+  -- cases le /- Dependent elimination failed: Failed to solve equation 0 = f n -/
+  inversion le; exact h
+
+example (f : Nat → Nat) (n : Nat) (le : f n ≤ 0) : 0 = f n := by
+  inversion +clear le; exact h
 
 /-- warning: declaration uses `sorry` -/
 #guard_msgs(warning) in
@@ -281,8 +265,29 @@ example : ¬ (NoStutter [3, 1, 1, 4]) := by
   apply h
   rfl
 
+inductive Vec α : Nat → Type where
+  | nil : Vec α 0
+  | cons {n} : α → Vec α n → Vec α (n + 1)
+
+example {α} (n : Nat) (v : Vec α (n + 1)) : ∃ hd tl, v = Vec.cons hd tl := by
+  inversion v with
+  | cons hd tl => exists hd, tl
+
+inductive Wec α : Nat → Type where
+  | nil : Wec α 0
+  | cons {n} (f : Nat → Nat) : α → Wec α n → Wec α (f n)
+
+/-- warning: declaration uses `sorry` -/
+#guard_msgs(warning) in
+example {α} (n : Nat) (v : Wec α (Nat.succ n)) :
+    ∃ hd tl, v = Wec.cons Nat.succ hd tl := by
+  inversion +clear v with
+  | cons hd tl e => sorry -- don't actually know that f = succ
+
 example (H : Bool → Nat → False) (n : Nat) : False := by
   apply H at n; apply n; exact true
 
 lemma doubleNegation : ∀ P, P → ¬ ¬ P := by
   intro P p np; exact (np p)
+
+end Tests


### PR DESCRIPTION
This fixes failures to generalize indices of targets depended upon by the goal by also generalizing the target with a heterogeneous equality. By design, `inversion` may leave behind this HEq if it cannot be solved away, such as in the (fake but illustrative) proof for `Wec`.