### PR TITLE
Add initial version of automated grading

### DIFF
--- a/Autograder/Attributes.lean
+++ b/Autograder/Attributes.lean
@@ -1,0 +1,40 @@
+module
+
+public import Lean
+
+public section
+
+open Lean
+
+/-- The points parameter to `@[graded]` is a rational number -/
+abbrev PointAmount := Rat
+
+inductive Graded
+  /-- This marks an assignment with points -/
+  | assignment (points : PointAmount)
+  /-- This marks an ignored definition -/
+  | ignore
+  deriving Repr, Inhabited
+
+declare_syntax_cat graded_opts
+
+/-- The precise value of this definition is ignored by checks of subsequent graded items.
+In other words, this can be set to anything, as long as its type is exactly as in the original assignment. -/
+syntax "ignore" : graded_opts
+/-- The number of points awarded for a correct proof. -/
+syntax scientific : graded_opts
+
+/-- Configuration related to automatic grading. Modifications to these attributes are ignored and the original assignment is used as the source of truth. -/
+syntax (name := graded) "graded" (ppSpace graded_opts) : attr
+
+initialize gradedAttr : ParametricAttribute Graded ←
+  registerParametricAttribute {
+    name := `graded
+    descr := "This declaration is graded and awards the specified number of points"
+    getParam := fun _ => fun
+      | `(attr| graded $points:scientific) =>
+        let sci := points.getScientific
+        pure <| Graded.assignment <| Rat.ofScientific sci.1 sci.2.1 sci.2.2
+      | `(attr| graded ignore) => pure Graded.ignore
+      | _ => Elab.throwUnsupportedSyntax
+  }

--- a/Autograder/Basic.lean
+++ b/Autograder/Basic.lean
@@ -1,0 +1,225 @@
+module
+
+public import Lean
+public import Autograder.Attributes
+public import Autograder.Util
+
+public section
+
+open Lean DebugT VisitedT
+
+def getGradedAttribute? (name : Name) : CoreM (Option Graded) := do
+  return gradedAttr.getParam? (← getEnv) name
+
+def getGradedAttribute! (name : Name) : CoreM Graded := do
+  return (← getGradedAttribute? name).get!
+
+def getGradedPoints? (name : Name) : CoreM (Option PointAmount) := return match ← getGradedAttribute? name with
+  | some (.assignment points) => some points
+  | _ => none
+
+def isGradedIgnore? (name : Name) : CoreM Bool := return match ← getGradedAttribute? name with
+  | some .ignore => true
+  | _ => false
+
+def PointAmount.format (points : Option PointAmount) : String := match points with
+  | none => "none"
+  | some points => toString <| (Float.ofInt points.num) / (Float.ofInt points.den) -- TODO don't use floats
+
+/--
+Collect all declarations from the environment that are "assignments" i.e. have the `@[graded n]` attribute.
+-/
+def collectAssignments : CoreM (Array (Name × ConstantInfo)) := do
+  let mut results := #[]
+  for (name, constInfo) in (← getEnv).constants.toList do
+    if let some (.assignment _) ← getGradedAttribute? name then
+      results := results.push ⟨name, constInfo⟩
+  return results
+
+/--
+Compare binder names.
+
+For example in the `forallE` branch with `bnl=m._@.Assignment.2314059840._hygCtx._hyg.8 bnr=m._@.Submission.2314059840._hygCtx._hyg.8`, we need to erase the macro scopes to compare the names, otherwise they are considered ≠.
+
+NH: Is this correct?
+-/
+def compareBinderNames (l r : Name) := Id.run do
+  let l' := l.eraseMacroScopes
+  let r' := r.eraseMacroScopes
+  -- if l != r then
+    -- dbg_trace s!"erased macro scopes {l} => {l'}, {r} => {r'}"
+  l' == r'
+
+-- NH: is it correct to compare these?
+deriving instance BEq for QuotKind
+deriving instance BEq for QuotVal
+
+mutual
+
+/--
+Compare `expr_a` from the CoreM (assignment) with `expr_s` from the environment `env_s` (submission).
+-/
+partial def deepSynEq (env_s : Environment) (expr_a expr_s : Expr) : DebugT (VisitedT CoreM) Bool := call (m := VisitedT CoreM) do
+  dbg s!"deepSynEq: comparing {expr_a} with {expr_s}"
+  match expr_a, expr_s with
+  | .bvar i, .bvar j => return i == j
+  | .fvar _, .fvar _ => panic! "BUG: expressions should not contain free variables by the assumption that the module is well typed"
+  | .mvar _, .mvar _ => panic! "BUG: expressions should not contain metavariables by the assumption that the module is well sorted"
+  | .sort ua, .sort us => return ua == us
+  | .const na ua, .const ns us => return na == ns && (← deepSynEqName env_s na) && ua == us
+  | .app fa aa, .app fs as => return (← deepSynEq env_s fa fs) && (← deepSynEq env_s aa as)
+  | .lam bna bta ba bia, .lam bns bts bs bis => return compareBinderNames bna bns && (← deepSynEq env_s bta bts) && (← deepSynEq env_s ba bs) && bia == bis
+  | .forallE bna bta ba bia, .forallE bns bts bs bis => return compareBinderNames bna bns && (← deepSynEq env_s bta bts) && (← deepSynEq env_s ba bs) && bia == bis
+  | .letE na ta va ba nondepa, .letE ns ts vs bs nondeps => return compareBinderNames na ns && (← deepSynEq env_s ta ts) && (← deepSynEq env_s va vs) && (← deepSynEq env_s ba bs) && nondepa == nondeps
+  | .mdata _ a, .mdata _ s =>
+    dbg "deepSynEq: ignoring metadata" -- ignore metadata for now
+    deepSynEq env_s a s
+  | .proj na i a, .proj ns j s => return na == ns && (← deepSynEqName env_s na) && i == j && (← deepSynEq env_s a s)
+  | .lit a, .lit s => return a == s
+  | _, _ => return false
+
+/--
+Compare `name` from the CoreM (assignment) with the environment `env_s` (submission).
+The type of `name`, various metadata like reducibility attributes and its value are compared between the environments.
+
+NH: I see no reason to compare opaques like proof terms based on the assumption that even if they have changed, it should not have an observable effect
+-/
+partial def deepSynEqName (env_s : Environment) (name : Name) (compareOpaques := false) : DebugT (VisitedT CoreM) Bool := call (m := VisitedT CoreM) <|
+  defer (m := DebugT (VisitedT CoreM)) (fun b => do
+    if !b then
+      -- Marks the name false if the prediction was wrong
+      markFalse name (m := CoreM)
+  ) do
+  if let some eq := ← visited? name (m := CoreM) then
+    dbg s!"deepSynEqName: already visited {name} => {eq}"
+    return eq
+
+  -- We mark the name to avoid infinite recursion, and adjust if the function returns false
+  -- NH: There's probably a more elegant way to do this
+  markTrue name (m := CoreM)
+
+  dbg s!"deepSynEqName: comparing {name}"
+
+  let env_a ← getEnv
+  let some a_info := env_a.find? name | return false
+  let some s_info := env_s.find? name | return false
+
+  if let some Graded.ignore ← getGradedAttribute? name then
+    dbg s!"deepSynEqName: ignoring {name} (comparing only their types)"
+    return ← deepSynEq env_s a_info.type s_info.type
+
+  -- Check that the types of the constants are syntactically equal
+  if ! (← deepSynEq env_s a_info.type s_info.type) then return false
+  if a_info.type != s_info.type then
+    panic! "Types don't match"
+
+  -- Check that level params are equal
+  if ! a_info.levelParams == s_info.levelParams then return false
+
+  -- Check that reducibility attributes haven't been changed
+  if ! getReducibilityStatusCore env_a name == getReducibilityStatusCore env_s name then return false
+
+  match a_info, s_info with
+  | .axiomInfo a, .axiomInfo s => return a.isUnsafe == s.isUnsafe
+  | .defnInfo a, .defnInfo s => return a.safety == s.safety && (← deepSynEq env_s a.value s.value)
+  | .thmInfo a, .thmInfo s => return !compareOpaques || (← deepSynEq env_s a.value s.value)
+  | .opaqueInfo a, .opaqueInfo s => return a.isUnsafe == s.isUnsafe && (!compareOpaques || (← deepSynEq env_s a.value s.value))
+  | .quotInfo a, .quotInfo s => return a == s
+  | .inductInfo a, .inductInfo s => (a.ctors.zip s.ctors).allM fun ⟨ctor_a, ctor_s⟩ => return ctor_a == ctor_s && (← deepSynEqName env_s ctor_a)
+  | .ctorInfo a, .ctorInfo s => return a == s -- also compares their names which is unnecessary
+  | .recInfo a, .recInfo s => return a.isUnsafe == s.isUnsafe
+    && a.numParams == s.numParams
+    && a.numIndices == s.numIndices
+    && a.numMotives == s.numMotives
+    && a.numMinors == s.numMinors
+    && (← (a.rules.zip s.rules).allM fun ⟨rule_a, rule_s⟩ => do
+      return rule_a.nfields == rule_s.nfields && (← deepSynEq env_s rule_a.rhs rule_s.rhs))
+  | _, _ => return false
+
+end
+
+def allowedAxioms := #[`propext, `Quot.sound, `Classical.choice]
+
+def Lean.ConstantInfo.eqKind (c1 c2 : ConstantInfo) : Bool := (c1.isDefinition && c2.isDefinition) || (c1.isTheorem && c2.isTheorem)
+
+local instance : Inhabited Core.Context where
+  default := { fileName := "", fileMap := default }
+
+def Graded.points (self : Graded) : Option Rat := match self with
+  | assignment n => some n
+  | .ignore => none
+
+structure Report where
+  name : Name
+  points_awarded : Option Rat
+  points_maximum : Option Rat
+  errors : Array String
+  deriving Inhabited, Repr
+
+/--
+Check a single constant. Runs in the assignment's CoreM.
+-/
+def checkName (env_s : Environment) (name : Name) : DebugT (VisitedT CoreM) Report := do
+  let points_maximum := (← getGradedAttribute! name).points
+  let const_a := ((← getEnv).find? name).get!
+
+  let some const_s := env_s.find? name
+  | return {
+      name,
+      errors := #[s!"Could not find {name} in submission"]
+      points_maximum
+      points_awarded := none
+    }
+
+  if ! const_a.eqKind const_s then
+    let kindName := if const_a.isDefinition then "definition" else if const_a.isTheorem then "theorem" else panic! "BUG: assignment declaration is not a definition or a theorem"
+    return {
+      name,
+      errors := #[s!"Expected {name} to be a {kindName}"]
+      points_maximum
+      points_awarded := none
+    }
+
+  let mut errors := #[]
+  if const_a.isTheorem then
+    let typesEqual? ← deepSynEq env_s const_a.type const_s.type
+    if ! typesEqual? then
+      errors := errors.push s!"The type of {name} does not match the original type"
+
+    if let .error e := Lean.Kernel.check env_s {} (const_s.value! (allowOpaque := true)) then
+      panic! s!"BUG: submission failed kernel check even though it was built with lake!\n{← (e.toMessageData {}).format}"
+
+    let axioms ← Core.CoreM.toIO' (collectAxioms name) default { env := env_s }
+    if axioms.any (· ∉ allowedAxioms) then
+      errors := errors.push s!"{name} relies on an axiom which is not allowed: {axioms}"
+
+  if const_a.isDefinition then
+    if ! (← isGradedIgnore? const_a.name) then
+      panic! "Grading definitions is not supported, mark with @[graded ignore] instead"
+
+  let some points_maximum := points_maximum
+  | return { name, errors, points_maximum, points_awarded := none }
+
+  let points_awarded := some (if errors.isEmpty then points_maximum else 0)
+  return { name, errors, points_maximum, points_awarded }
+
+/--
+Check every declaration marked for grading in `env_assignment` against what is submitted in `env_submission`.
+-/
+def check (env_assignment env_submission : Environment) : DebugT (VisitedT IO) Unit := do
+  let assignments ← Core.CoreM.toIO' collectAssignments default { env := env_assignment }
+
+  let mut reports := #[]
+  for ⟨name, _const_a⟩ in assignments do
+    let new_reports ← (checkName env_submission name).toIO default { env := env_assignment }
+    reports := reports.push new_reports
+
+  let size ← VisitedT.size (m := IO)
+  dbg s!"Total number of names visited: {size}"
+
+  for report in reports do
+    IO.println s!"{report.name}: {PointAmount.format report.points_awarded} out of {PointAmount.format report.points_maximum}"
+    for error in report.errors do
+      IO.println s!"\t{error}"
+
+end

--- a/Autograder/Main.lean
+++ b/Autograder/Main.lean
@@ -1,0 +1,26 @@
+module
+
+public import Lean
+public import Autograder.Basic
+
+public def main (args : List String) : IO Unit := do
+  let some (assignment : String) := args[0]?
+    | throw <| .userError "Expected ASSIGNMENT"
+  let some (submission : String) := args[1]?
+    | throw <| .userError "Expected SUBMISSION"
+
+  let debug := (← IO.getEnv "AUTOGRADER_DEBUG") == some "1"
+
+  let sysroot ← Lean.findSysroot
+  IO.println s!"Using toolchain: {sysroot}"
+  Lean.initSearchPath sysroot
+
+  -- Note: this requires the modules to be built with lake first!
+  let env_assignment ← Lean.importModules #[
+    { module := Lean.Syntax.decodeNameLit ("`" ++ assignment) |>.get! }
+  ] {}
+  let env_submission ← Lean.importModules #[
+    { module := Lean.Syntax.decodeNameLit ("`" ++ submission) |>.get! }
+  ] {}
+
+  let _ ← ((check env_assignment env_submission).runWithDebug debug).run' ∅

--- a/Autograder/README.md
+++ b/Autograder/README.md
@@ -1,0 +1,121 @@
+# Autograder
+
+[A library](./Basic.lean) and [CLI tooling](./grade.sh) for validating lean-based homework submissions.
+
+The student-facing part of this library is [Attributes.lean](./Attributes.lean).
+It's distributed as part of the generated lean handouts.
+
+## Attributes
+
+Attributes, such as `@[graded 1.0]` tell the autograder how declarations should be graded.
+Grading happens in the context of an ASSIGNMENT module (e.g. `_out/lf/student/lean/LF/Basics.lean`).
+The student submits their solutions as SUBMISSION, and this is compared against ASSIGNMENT by .
+
+Supported attributes:
+- `@[graded <points>]` where `<points>` is a rational number in scientific notation.
+  Used to mark a declaration to be graded with the specified amount of points.
+- `@[graded ignore]`.
+  Used to mark a definition as "ignored" by the comparison algorithm.
+  Useful for "sorry" definitions that the student fills in -- otherwise the grader will error if the definition has been modified (which is counter-productive if the exercise is about coming up with a definition).
+  > These could be easily detected automatically by looking for declarations which are defined as sorry.
+
+Note: If it's more convenient, we can put grading attributes away from the declarations like this: `attribute [graded 2.0] Nat.add_zero`. This makes it easier to e.g. copy the code to the lean playground.
+
+## Grading script
+
+[`grade.sh`](./grade.sh) can be used to run the grading pipeline for a single file submission:
+
+```sh
+./grade.sh --assignment _out/lf/student/lean/ --submission _out/grading-test/LF/Basics.lean
+```
+
+- `--assignment` should point to the (unmodified) assignment project. The script uses the lake environment from this directory as the base for a temporary copy.
+- `--submission` should point to an individual submission from the student.
+
+> Note: `LF.Basics` is currently the only supported chapter.
+
+The script starts by copying the assignment project to a temporary directory, let's call it `$TMPDIR`.
+It also copies [`Main.lean`](./Main.lean) as `$TMPDIR/Main.lean`.
+It then copies the submission to `$TMPDIR/Submission.lean` and adds
+```toml
+[[lean_lib]]
+name = "Submission"
+```
+to `$TMPDIR/lakefile.toml`.
+
+The actual grading happens by running `lake build` and `lake build Submission` followed by `lake env $AUTOGRADER_EXE LF.Basics Submission` in `$TMPDIR`.
+
+> You can manually specify the path to `autograder` with the `AUTOGRADER_EXE` environment variable.
+> If unset, it defaults to this project's `.lake/build/bin/autograder` which can be built with `make autograder`.
+
+### Cleanup
+
+The temporary directory `$TMPDIR` is not removed automatically.
+The following command can be used to remove all temporary files used by the tool.
+
+```
+rm -vrf /tmp/autograder-**
+```
+
+## Debugging
+
+To get debug logs, set the `AUTOGRADER_DEBUG=1` environment variable, e.g. by prefixing running the script with it:
+```
+AUTOGRADER_DEBUG=1 ./Autograder/grade.sh ...
+```
+
+## Design
+
+The main problem the library solves is "when are two declarations from different environments considered equal" taking into account grading related details like when to ignore a definition (`@[graded ignore]`).
+
+The obvious question is "why is comparing the expressions not sufficient?" and the rough answer is that expressions can refer to other constants by `Name`s, which are not compared when comparing the expressions syntax-to-syntax.
+
+The approach taken is to traverse the "left" (assignment, unmodified) and "right" (submission) expression while recursively comparing any constants found in them.
+
+The high-level algorithm is as follows, given a name and the constant with that name from both environments:
+
+1. check if the constants are of the same kind (theorem/definition)
+2. if they are theorems:
+  1. check that their types are `deepSynEq`
+  2. check the axioms used by the submission
+3. if they are definitions:
+  1. check that the types of the definitions match (even though definitions don't award points, this is helpful to point out the root cause of a mismatch)
+  2. check the axioms used by the submission
+
+> In addition we mark visited names to efficiently walk the closure of names in the constants.
+
+The comparison `deepSynEq` is similar to syntactic equality, i.e. it will consider `n + 0 = id n` to be different from `n + 0 = n`.
+
+For example, consider the following definition
+```lean
+@[irreducible]
+def add (n : Nat) (m : Nat) : Nat :=
+  match m with
+  | succ m' => succ (add n m')
+  | zero => n
+```
+Making any of the following changes to the definition will be considered a change:
+- Changing any name even in an α-compatible way
+- Removing `@[irreducible]`
+- Reordering the match arms
+
+The following are for example not considered syntactic changes:
+- Combining the arguments into `(n m : Nat)`
+- Leaving out the explicit return type `: Nat`
+
+## Known issues/limitations
+
+- The `autograder` binary should check if it was built using the same toolchain as what is used by `PATH_TO_ASSIGNMENT_PROJECT`
+- The points only support scientific numbers, e.g. `0.25`, but not rationals like `1/3` are represented.
+- Autograder is not aware of our custom verso annotations like `GRADE_THEOREM`, `GRADE_MANUAL`
+- `LF.Basics` is hard-coded in `grade.sh`
+- The attributes are not supported on examples.
+- `deepSynEqName` does not check some modifiers like `noncomputable`.
+
+## Methodology & acknowledgements
+
+This library was developed with ideas borrowed from the following projects:
+- [lean4-autograder-main](https://github.com/robertylewis/lean4-autograder-main) is a more complete grading solution designed to integrate with [Gradeoscope](https://gradescope-autograders.readthedocs.io/en/latest/) and a heavy inspiration for this project.
+  For example, using `@[...]` attributes for marking declarations is inspired by lean4-autograder-main.
+  > NH: I did not manage to actually use the tool because I ran into an issue where the tool couldn't find something in `.lake/packages/autograder/`.
+- [comparator](https://github.com/leanprover/comparator) and [lean4-export](https://github.com/leanprover/lean4export/) provided useful reading into how to work with the Lean [Environment](https://leanprover-community.github.io/mathlib4_docs/Lean/Environment.html) and how to recursively traverse expressions.

--- a/Autograder/Util.lean
+++ b/Autograder/Util.lean
@@ -1,0 +1,77 @@
+module
+
+public import Lean
+
+public section
+
+open Lean
+
+/-- Add state tracking which names have been visited (and whether they are considered equal) to a monad -/
+@[reducible, expose] def VisitedT (m : Type → Type) (α : Type) := StateT (Std.HashMap Name Bool) m α
+
+namespace VisitedT
+
+def size [Monad m] : VisitedT m Nat := do
+  return (← get).size
+
+def visited? [Monad m] (name : Name) : VisitedT m (Option Bool) := do
+  let map ← get
+  return map.get? name
+
+def markTrue [Monad m] (name : Name) : VisitedT m Unit := do
+  modify (·.insert name true)
+
+def markFalse [Monad m] (name : Name) : VisitedT m Unit := do
+  modify (·.insert name false)
+
+def unmark [Monad m] (name : Name) : VisitedT m Unit := do
+  modify (·.erase name)
+
+end VisitedT
+
+
+structure DebugConfig where
+  silent : Bool
+  depth : Nat
+
+instance : Inhabited DebugConfig where
+  default := { silent := true, depth := 0 }
+
+/-- Provides utilities for debugging and tracing -/
+@[reducible, expose] def DebugT (m : Type → Type) (α : Type) := StateT DebugConfig m α
+
+namespace DebugT
+
+def modifyDepth [Monad m] (f : Nat → Nat) : DebugT m Unit := do
+  modify fun state => { state with depth := f state.depth }
+
+def getDepth [Monad m] : DebugT m Nat := do
+  return (← get).depth
+
+def getSilent [Monad m] : DebugT m Bool := do
+  return (← get).silent
+
+def call [Monad m] (f : DebugT m β) : DebugT m β := do
+  modifyDepth (· + 1)
+  let res ← f
+  modifyDepth (· - 1)
+  return res
+
+def dbg [Monad m] [MonadLiftT IO m] (msg : String) (level := "debug") : DebugT m Unit := do
+  let silent ← getSilent
+  if ! silent then
+    let depth ← getDepth
+    IO.println s!"[{level}:{depth}]: {msg}"
+
+def runWithDebug [Monad m] (debug : Bool) (self : DebugT m α) := self.run { silent := ! debug, depth := 0 }
+
+def toIO (self : DebugT (VisitedT CoreM) α) (ctx : Core.Context) (s : Core.State) : DebugT (VisitedT IO) α :=
+  fun cfg vis => (self cfg vis).toIO' ctx s
+
+end DebugT
+
+/-- Defers calling `f` after `x`, i.e. calls `f` with the value of `x` and returns the value of `x` -/
+def defer [Monad m] [Monad n] [MonadLiftT m n] (f : α → n Unit) (x : m α) : n α := do
+  let res := (← x)
+  f res
+  return res

--- a/Autograder/grade.sh
+++ b/Autograder/grade.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -o errexit -o noclobber -o nounset -o pipefail
+
+base=$(dirname "$0")
+base=$(realpath "$base")
+AUTOGRADER_EXE="${AUTOGRADER_EXE:-$base/../.lake/build/bin/autograder}"
+
+usage() {
+  printf "Usage: %s --assignment PATH_TO_ASSIGNMENT_PROJECT --submission PATH_TO_SUBMISSION_FILE\n\nSee README.md for instructions.\n" $0 >&2
+  exit 2
+}
+
+opts=$(getopt \
+  --longoptions assignment:,submission:,help \
+  --name grade.sh \
+  --options "" \
+  -- "$@"
+)
+if [ "$?" != "0" ]; then
+  usage
+fi
+
+eval set -- "$opts"
+
+assignment=
+submission=
+
+while :
+do
+  case "$1" in
+    --assignment)
+      assignment=$2
+      shift 2
+      ;;
+
+    --submission)
+      submission=$2
+      shift 2
+      ;;
+
+    --help)
+      usage
+      shift
+      ;;
+
+    # -- means the end of the arguments; drop this, and break out of the while loop
+    --) shift; break ;;
+
+    *)
+      echo "Unexpected option: $1 - this should not happen."
+      usage
+      ;;
+  esac
+done
+
+if [[ "$assignment" == "" || "$submission" == "" ]]; then
+  echo "missing --assignment or --submission" >&2
+  exit 2
+fi
+
+TMPDIR=$(mktemp -d -t autograder-XXXXXXXXXX)
+
+echo "Copying $assignment to $TMPDIR"
+cp -r "$assignment/." "$TMPDIR"
+
+echo "Copying $submission to $TMPDIR/Submission.lean"
+cp "$submission" "$TMPDIR/Submission.lean"
+
+echo "Appending $TMPDIR/lakefile.toml"
+cat <<'EOF' >> $TMPDIR/lakefile.toml
+
+
+[[lean_lib]]
+name = "Submission"
+EOF
+
+pushd "$TMPDIR"
+
+echo "Running 'lake build'"
+lake build
+
+echo "Running 'lake build Submission'"
+lake build Submission
+
+echo "Running 'lake env "$AUTOGRADER_EXE" LF.Basics Submission'"
+lake env "$AUTOGRADER_EXE" LF.Basics Submission

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ clean:
 	lake clean
 	rm -rf _out/
 
+autograder:
+	lake build autograder
+
 # ── Generating Verso chapters from bare Lean (temporary!) ─────────
 # Chapters that are not yet authored directly in Verso are generated from their
 # code-forward `.lean` source by scripts/to_verso.py:

--- a/SFLMeta/Save.lean
+++ b/SFLMeta/Save.lean
@@ -7,6 +7,7 @@ import SFLMeta.SlideBreak
 import SFLMeta.Details
 import Std.Data.HashMap
 import SubVerso.Highlighting
+import Autograder.Attributes -- This import is a workaround for a limitation with `include_str`: https://github.com/leanprover-community/mathlib4/pull/221#issuecomment-1063468937
 
 open Lean Elab
 open Verso.Genre Manual
@@ -193,7 +194,11 @@ private def lakefileTemplate (vol : String) : String :=
   "version = \"0.1.0\"\n" ++
   "defaultTargets = [\"" ++ vol ++ "\"]\n\n" ++
   "[[lean_lib]]\n" ++
-  "name = \"" ++ vol ++ "\"\n"
+  "name = \"" ++ vol ++ "\"\n" ++
+  r#"
+[[lean_lib]]
+name = "Autograder"
+globs = ["Autograder.+"]"# -- Includes contents of Autograder/ without having an explicit Autograder.lean at root
 
 /-! ## ExtraStep walker -/
 
@@ -689,7 +694,12 @@ def walkOuter (width : Nat) (vol : String) (text : Part Manual) (buf : SaveBuffe
     let chapterFile := chapterPath vol p
     -- BCP: Maybe this is not needed?
     -- buf := appendBoth buf chapterFile "import Lean\n\nopen Lean\n\n"
+    -- NH: This is probably not the most elegant place to inject the Autograder import
+    buf := appendBoth buf chapterFile "import Autograder.Attributes\n\n"
     buf := walkSection width 1 chapterFile p buf
+  -- Include Autograder in the buf
+  -- Lake doesn't detect changes to Attributes.lean through the include_str. A workaround import is in place at the top of the file.
+  buf := appendBoth buf "Autograder/Attributes.lean" (include_str "../Autograder/Attributes.lean")
   return buf
 
 /--

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -34,3 +34,11 @@ name = "TS"
 [[lean_exe]]
 name = "sfl"
 root = "Targets"
+
+[[lean_lib]]
+name = "Autograder"
+globs = ["Autograder.+"]
+
+[[lean_exe]]
+name = "autograder"
+root = "Autograder.Main"


### PR DESCRIPTION
Here's the initial design for automated grading.

I recommend for reviewers to start by reading [README.md](https://github.com/plclub/sf-in-lean/pull/43/changes#diff-1b78a53a40555c44f3ad24f149ded7f834bc87bc69e31a6ddf749b2ecfdcfa03).

To test the system out locally, I recommend creating a new temporary [git worktree](https://git-scm.com/docs/git-worktree) as follows, running the commands from a local clone of `sf-in-lean`:
```
git fetch
git worktree add ../sf-in-lean-autograder autograder-test
cd ../sf-in-lean-autograder
```
> The `autograder-test` branch also contains changes to Basics.lean, which I can create a PR for once I get the lock.

Then, build `lf-student` (and optionally `lf-solutions`) and prepare a submission project for testing modifications:
```
make lf-student
cp -r _out/lf/student/lean/. _out/grading-test/
```

Now, build and run the autograder to grade `grading-test`:
```
make autograder
./Autograder/grade.sh --assignment _out/lf/student/lean/ --submission _out/grading-test/LF/Basics.lean
```

The actual grading output is at the very end, with each assignment's points and errors displayed.

```
NatPlayground.Nat.ltb_test3: 0.000000 out of 1.000000
	NatPlayground.Nat.ltb_test3 relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.incr_test2: 0.000000 out of 0.500000
	NatPlayground.Nat.incr_test2 relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.andb_eq_orb: 0.000000 out of 3.000000
	NatPlayground.andb_eq_orb relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.zero_neb_add_one: 0.000000 out of 1.000000
	NatPlayground.Nat.zero_neb_add_one relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.incr_test1: 0.000000 out of 0.500000
	NatPlayground.Nat.incr_test1 relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.orb_false_true: 0.000000 out of 2.000000
	NatPlayground.Nat.orb_false_true relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.binToNat_test1: 0.000000 out of 0.500000
	NatPlayground.Nat.binToNat_test1 relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.binToNat_test2: 0.000000 out of 0.500000
	NatPlayground.Nat.binToNat_test2 relies on an axiom which is not allowed: #[sorryAx]
MyBool.nandb_test1: 0.000000 out of 1.000000
	MyBool.nandb_test1 relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.add_id_exercise: 0.000000 out of 1.000000
	NatPlayground.Nat.add_id_exercise relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.incr_test3: 0.000000 out of 0.500000
	NatPlayground.Nat.incr_test3 relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.identity_fn_applied_twice: 0.000000 out of 1.000000
	NatPlayground.identity_fn_applied_twice relies on an axiom which is not allowed: #[sorryAx]
NatPlayground.Nat.binToNat_test3: 0.000000 out of 0.500000
	NatPlayground.Nat.binToNat_test3 relies on an axiom which is not allowed: #[sorryAx]
MyBool.andb3_test1: 0.000000 out of 1.000000
	MyBool.andb3_test1 relies on an axiom which is not allowed: #[sorryAx]
```

To grade the generated solutions, run
```
./Autograder/grade.sh --assignment _out/lf/student/lean/ --submission _out/lf/solutions/lean/LF/Basics.lean
```

<details>
<summary>Output from the script on solutions</summary>

```
Copying _out/lf/student/lean/ to /tmp/autograder-EPkJYZz0uF
Copying _out/lf/solutions/lean/LF/Basics.lean to /tmp/autograder-EPkJYZz0uF/Submission.lean
Appending /tmp/autograder-EPkJYZz0uF/lakefile.toml
/tmp/autograder-EPkJYZz0uF /tmp/sf-in-lean-autograder
Running 'lake build'
⚠ [3/5] Replayed LF.Basics
info: LF/Basics.lean:125:0: Day.monday
info: LF/Basics.lean:127:0: Day.tuesday
warning: LF/Basics.lean:262:4: declaration uses `sorry`
warning: LF/Basics.lean:266:8: declaration uses `sorry`
warning: LF/Basics.lean:267:8: declaration uses `sorry`
warning: LF/Basics.lean:268:8: declaration uses `sorry`
warning: LF/Basics.lean:269:8: declaration uses `sorry`
warning: LF/Basics.lean:277:4: declaration uses `sorry`
warning: LF/Basics.lean:281:8: declaration uses `sorry`
warning: LF/Basics.lean:282:8: declaration uses `sorry`
warning: LF/Basics.lean:283:8: declaration uses `sorry`
warning: LF/Basics.lean:284:8: declaration uses `sorry`
info: LF/Basics.lean:298:0: Bool.true : Bool
info: LF/Basics.lean:304:0: true : Bool
info: LF/Basics.lean:305:0: !true : Bool
info: LF/Basics.lean:311:0: Bool.not : Bool → Bool
warning: LF/Basics.lean:375:13: Variable name `p` is not explicitly referenced.

The binding can be removed (if unused) or named `_` (if used implicitly).

Note: This linter can be disabled with `set_option linter.unusedVariables false`
info: LF/Basics.lean:439:0: myFoo : Bool
info: LF/Basics.lean:440:0: Playground.myFoo : RGB
info: LF/Basics.lean:459:0: RGB.myBlue : RGB
info: LF/Basics.lean:460:0: RGB.myOtherBlue : RGB
info: LF/Basics.lean:488:0: MyNamespace.myDef : Bool
info: LF/Basics.lean:507:0: Nibble.bits Bit.b1 Bit.b0 Bit.b1 Bit.b0 : Nibble
info: LF/Basics.lean:600:0: NatPlayground.Nat.succ (NatPlayground.Nat.succ (NatPlayground.Nat.zero))
info: LF/Basics.lean:606:0: NatPlayground.Nat.succ (n : Nat) : Nat
info: LF/Basics.lean:607:0: NatPlayground.Nat.Nat.pred (n : Nat) : Nat
info: LF/Basics.lean:608:0: NatPlayground.Nat.minustwo (n : Nat) : Nat
info: LF/Basics.lean:674:0: NatPlayground.Nat.add_zero (n : Nat) : n + zero = n
warning: LF/Basics.lean:719:8: declaration uses `sorry`
warning: LF/Basics.lean:872:8: declaration uses `sorry`
warning: LF/Basics.lean:878:8: declaration uses `sorry`
warning: LF/Basics.lean:914:8: declaration uses `sorry`
warning: LF/Basics.lean:984:4: declaration uses `sorry`
warning: LF/Basics.lean:988:8: declaration uses `sorry`
warning: LF/Basics.lean:989:8: declaration uses `sorry`
warning: LF/Basics.lean:991:8: declaration uses `sorry`
warning: LF/Basics.lean:1029:8: declaration uses `sorry`
info: LF/Basics.lean:1044:0: NatPlayground.Nat.mul_zero (n : Nat) : n * zero = zero
info: LF/Basics.lean:1045:0: NatPlayground.Nat.mul_succ (n m : Nat) : n * m.succ = n * m + n
warning: LF/Basics.lean:1062:0: declaration uses `sorry`
warning: LF/Basics.lean:1189:8: declaration uses `sorry`
warning: LF/Basics.lean:1196:8: declaration uses `sorry`
warning: LF/Basics.lean:1287:4: declaration uses `sorry`
warning: LF/Basics.lean:1291:4: declaration uses `sorry`
warning: LF/Basics.lean:1296:8: declaration uses `sorry`
warning: LF/Basics.lean:1298:8: declaration uses `sorry`
warning: LF/Basics.lean:1300:8: declaration uses `sorry`
warning: LF/Basics.lean:1302:8: declaration uses `sorry`
warning: LF/Basics.lean:1303:8: declaration uses `sorry`
warning: LF/Basics.lean:1304:8: declaration uses `sorry`
warning: LF/Basics.lean:1308:8: declaration uses `sorry`
warning: LF/Basics.lean:1309:8: declaration uses `sorry`
warning: LF/Basics.lean:1310:8: declaration uses `sorry`
warning: LF/Basics.lean:1315:8: declaration uses `sorry`
warning: LF/Basics.lean:1317:8: declaration uses `sorry`
warning: LF/Basics.lean:1319:8: declaration uses `sorry`
warning: LF/Basics.lean:1320:8: declaration uses `sorry`
warning: LF/Basics.lean:1335:8: declaration uses `sorry`
warning: LF/Basics.lean:1353:8: declaration uses `sorry`
Build completed successfully (5 jobs).
Running 'lake build Submission'
⚠ [3/4] Built Submission
info: Submission.lean:125:0: Day.monday
info: Submission.lean:127:0: Day.tuesday
info: Submission.lean:300:0: Bool.true : Bool
info: Submission.lean:306:0: true : Bool
info: Submission.lean:307:0: !true : Bool
info: Submission.lean:313:0: Bool.not : Bool → Bool
warning: Submission.lean:377:13: Variable name `p` is not explicitly referenced.

The binding can be removed (if unused) or named `_` (if used implicitly).

Note: This linter can be disabled with `set_option linter.unusedVariables false`
info: Submission.lean:441:0: myFoo : Bool
info: Submission.lean:442:0: Playground.myFoo : RGB
info: Submission.lean:461:0: RGB.myBlue : RGB
info: Submission.lean:462:0: RGB.myOtherBlue : RGB
info: Submission.lean:490:0: MyNamespace.myDef : Bool
info: Submission.lean:509:0: Nibble.bits Bit.b1 Bit.b0 Bit.b1 Bit.b0 : Nibble
info: Submission.lean:602:0: NatPlayground.Nat.succ (NatPlayground.Nat.succ (NatPlayground.Nat.zero))
info: Submission.lean:608:0: NatPlayground.Nat.succ (n : Nat) : Nat
info: Submission.lean:609:0: NatPlayground.Nat.Nat.pred (n : Nat) : Nat
info: Submission.lean:610:0: NatPlayground.Nat.minustwo (n : Nat) : Nat
info: Submission.lean:676:0: NatPlayground.Nat.add_zero (n : Nat) : n + zero = n
info: Submission.lean:1064:0: NatPlayground.Nat.mul_zero (n : Nat) : n * zero = zero
info: Submission.lean:1065:0: NatPlayground.Nat.mul_succ (n m : Nat) : n * m.succ = n * m + n
warning: Submission.lean:1082:0: declaration uses `sorry`
Build completed successfully (4 jobs).
Running 'lake env /tmp/sf-in-lean-autograder/Autograder/../.lake/build/bin/autograder LF.Basics Submission'
Using toolchain: /home/niklash/.elan/toolchains/leanprover--lean4---v4.31.0-rc2
NatPlayground.Nat.ltb_test3: 1.000000 out of 1.000000
NatPlayground.Nat.incr_test2: 0.500000 out of 0.500000
NatPlayground.andb_eq_orb: 3.000000 out of 3.000000
NatPlayground.Nat.zero_neb_add_one: 1.000000 out of 1.000000
NatPlayground.Nat.incr_test1: 0.500000 out of 0.500000
NatPlayground.Nat.orb_false_true: 2.000000 out of 2.000000
NatPlayground.Nat.binToNat_test1: 0.500000 out of 0.500000
NatPlayground.Nat.binToNat_test2: 0.500000 out of 0.500000
MyBool.nandb_test1: 1.000000 out of 1.000000
NatPlayground.Nat.add_id_exercise: 1.000000 out of 1.000000
NatPlayground.Nat.incr_test3: 0.500000 out of 0.500000
NatPlayground.identity_fn_applied_twice: 1.000000 out of 1.000000
NatPlayground.Nat.binToNat_test3: 0.500000 out of 0.500000
MyBool.andb3_test1: 1.000000 out of 1.000000
```

</details>

> After running grade.sh, you can clean up temporary files with `rm -vrf /tmp/autograder-**`

When making suggestions or giving feedback, please take into account I spent >40 hours on this :)

Resolves #27 

Updates:
- Force pushed to remove unused `--keep` option
- Fixed a few typos