### PR TITLE
Rework namespaces flow in Basics

### DIFF
--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -990,8 +990,8 @@ Names in the `Bool` `namespace` are available without qualification.
 
 ::::full
 Finally, Lean can often automatically figure out which namespace a qualified name lives in,
-saving us the need to explicitly specify it every time we use the name. In addition the
-to fully qualified style (e.g., `Day.monday`), we can opt for a partially qualified style,
+saving us the need to explicitly specify it every time we use the name. Instead of
+the fully qualified style (e.g., `Day.monday`), we can opt for a partially qualified style,
 writing just `.monday`.
 
 When we do this, Lean tries to resolve the `.monday` name by seeing what its expected type is,

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1011,7 +1011,8 @@ and inferring which namespace it must be from based on that type. If there is on
 namespace (i.e., if it is unambiguous which constructor we're referring to), then it will
 automatically resolve to the expected value.
 
-So, for example, we could also write `nextWorkingDay` like so:
+So, for example, we could also write `nextWorkingDay` like so, using the shorter
+style for both the value being matched upon and the value being returned:
 ::::
 
 ::::terse

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -634,19 +634,19 @@ matches the given type and signal an error if not.
 #check (Bool.not Bool.true : Bool)
 ```
 
-Functions like `Bool.not` are themselves data values, just like `Bool.true`
+Functions like {name}`Bool.not` are themselves ordinary values, just like {name}`Bool.true`
 and `Bool.false`.  Their types are called _function types_, and they are
 written with arrows.
 
 ```lean
-#check not
+#check Bool.not
 ```
 
 ::::full
 The type of `Bool.not`, written `Bool → Bool` and pronounced "`Bool`
 arrow `Bool`," can be read, "Given an input of type `Bool`, this
 function produces an output of type `Bool`." Similarly, the type of
-`and`, written `Bool → Bool → Bool`, can be read, "Given two inputs,
+{name}`Bool.and`, written `Bool → Bool → Bool`, can be read, "Given two inputs,
 each of type `Bool`, this function produces an output of type
 `Bool`."
 ::::

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -899,14 +899,14 @@ end Playground
 ```
 
 ::::full
-When creating a type, a `namespace` with the same name as that type is implicitly created as well;
+When a type is created, a `namespace` with the same name as that type is implicitly created as well;
 definitions on that type are available inside that `namespace` without a prefix. In the example
 below, we can use the `blue` constructor without qualification because
 we are inside the `RGB` `namespace`, which is the same as `blue`'s type.
 ::::
 
 ::::terse
-Types implicitly create namespaces.
+Type definitions implicitly create namespaces.
 ::::
 
 
@@ -939,8 +939,8 @@ def RGB.myOtherBlue : RGB := myBlue
 :::
 
 ::::full
-Similarly, we could write the definition of `nextWorkingDay`
-earlier inside the `Day` namespace like so:
+Similarly, we could rewrite the definition of `nextWorkingDay`
+from above inside the `Day` namespace like so:
 ::::
 
 ```lean
@@ -980,19 +980,20 @@ end MyOtherNamespace
 
 export MyOtherNamespace (myVisibleDef)
 
--- this is usable without qualification, but `myHiddenDef` would not be
+-- This makes `myvisibleDef` usable without qualification, but not `myHiddenDef`:
 #check myVisibleDef -- Bool
 ```
 
 ::::full
-In fact, this is what Lean does with the `Bool` type. Since it is such an important
+In fact, this is what exactly what Lean does with the standard `Bool` type by default.
+Since it is such an important
 part of many proofs and programs, Lean implicitly `export`s many of `Bool`s functions and
 constructors. Accordingly, we can use constructors like `true` and `false` and functions like `not`
 without qualifying them with `Bool.`.
 ::::
 
 ::::terse
-Names in the `Bool` `namespace` are available without qualification.
+Names from the `Bool` `namespace` are `export`ed and thus available without qualification.
 ::::
 
 ```lean
@@ -1003,15 +1004,15 @@ Names in the `Bool` `namespace` are available without qualification.
 ::::full
 Finally, Lean can often automatically figure out which namespace a qualified name lives in,
 saving us the need to explicitly specify it every time we use the name. Instead of
-the fully qualified style (e.g., `Day.monday`), we can opt for a partially qualified style,
+the fully qualified style (e.g., `Day.monday`), we can opt for an implicitly qualified style,
 writing just `.monday`.
 
-When we do this, Lean tries to resolve the `.monday` name by seeing what its expected type is,
+When we do this, Lean tries to resolve the `.monday` name by seeing what its expected type is
 and inferring which namespace it must be from based on that type. If there is only one such
 namespace (i.e., if it is unambiguous which constructor we're referring to), then it will
 automatically resolve to the expected value.
 
-So, for example, we could also write `nextWorkingDay` like so, using the shorter
+So, for example, we can also write `nextWorkingDay` as follows, using the shorter
 style for both the value being matched upon and the value being returned:
 ::::
 
@@ -1042,7 +1043,9 @@ In this case, it will raise an error:
 @dsainati1: see my comment later in the file about guard msgs
 
 ```lean
---- this doesn't work, Lean doesn't know which `true` we mean
+-- This doesn't work: Lean doesn't know which `true` we mean
+-- BCP: Why is this an inline comment?
+-- BCP: Is the `drop all` syntax explained?
 #guard_msgs(drop all) in
 #check .true --
 ```
@@ -1058,10 +1061,11 @@ Here, though, because `not` is a function that takes a `Bool` argument, Lean kno
 ```
 ::::
 
+-- BCP: This is not going to typeset well!
 ::::exercise(rating:=0) (name := "custom_namespace_checks")
-Predict the output of each of these statements below.
-Do you think their results will change depending on which `namespace`
-they are in? How?
+Predict the output of each of the statements below.
+Do you think their results would change depending on which namespace
+the statements appear in? How?
 
 #check .black -- Write your prediction here.
 #check Color.black -- Write your prediction here.
@@ -1988,6 +1992,8 @@ compiled to Lean. If we just naïvely strip out #guard msgs, the generated .lean
 errors since those commands were guarding actual errors rather than just warnings. So we would need
 a way to have .lean files with errors in them permitted by the make command, or we would need to
 leave in #guard msgs that are guarding actual errors.
+
+BCP: This is a tricky balancing act!!  Let's talk about it.
 
 ```lean
 /--

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1053,7 +1053,7 @@ Here, though, because `not` is a function that takes a `Bool` argument, Lean kno
 `.true` must here be a `Bool`:
 
 ```lean
-#check (not .true)
+#check (Bool.not .true)
 ```
 ::::
 

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -225,7 +225,7 @@ from the book's Lean sources, find the above example, and observe
 the result in the Lean InfoView panel.
 
 :::dev
-DHS: Where are we showing responses in comments? I don't see them.
+@dsainati1: Where are we showing responses in comments? I don't see them.
 RAB: Why did we remove the comments?
 Per GitHub discussion, MWH agrees - this is unresolved.
 BCP: Don't understand the state of play here...
@@ -298,7 +298,7 @@ chapters.
 RAB: Is Lean compiling to C its "killer app," or is it the fact that it is an
 executable programming language (unlike Gallina)? We should get a Lean pro's
 take on what to say here.
-DHS: Per GitHub discussion, we should either include a diagram in a later chapter,
+@dsainati1: Per GitHub discussion, we should either include a diagram in a later chapter,
 or potentially link to https://lean-lang.org/doc/reference/latest/Elaboration-and-Compilation/
 :::
 
@@ -543,7 +543,7 @@ it can change the meaning of the proof, usually causing the proof to break. If w
 instead written the following:
 
 :::dev
-DHS: Ideally would change this to a #guardmsgs(error) if we can
+@dsainati1: Ideally would change this to a #guardmsgs(error) if we can
 :::
 
 /- theorem trueandb : ∀ (b : MyBool), (MyBool.true && b) = b := by
@@ -916,7 +916,7 @@ def RGB.myOtherBlue : RGB := myBlue
 ```
 
 :::dev
-DHS: see my comment later in the file about guard msgs
+@dsainati1: see my comment later in the file about guard msgs
 
 ```lean
 --- this doesn't work; the identifier is unknown
@@ -1026,7 +1026,7 @@ which version of `.true` we mean, since it could either be `Bool.true` or `MyBoo
 In this case, it will raise an error:
 
 :::dev
-DHS: see my comment later in the file about guard msgs
+@dsainati1: see my comment later in the file about guard msgs
 
 ```lean
 --- this doesn't work, Lean doesn't know which `true` we mean
@@ -1964,7 +1964,7 @@ because it gets stripped out when verso files are translated to
 :::
 
 :::dev
-DHS: At the moment our convention for unfinished proofs is to end with sorry and
+@dsainati1: At the moment our convention for unfinished proofs is to end with sorry and
 guard the "proof uses sorry" warning. However after going through MRC's comments here
 I realized we don't need to do this: we can leave the proof unfinished and guard the error
 about goals being unsolved. IMO this is preferable because it illustrates more directly
@@ -2200,7 +2200,7 @@ GRADE_THEOREM 1: zero_nbeq_add_1
 ::::
 
 :::dev
-DHS: I move that we just cut this section entirely and come back to it when
+@dsainati1: I move that we just cut this section entirely and come back to it when
 we've presented enough of the requisite material that we can actually explain
 mwhicks1: I'm going to leave this here for now, but perhaps make a note to
 fix later on---when you've fixed it, come back and delete this, rather than

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -182,69 +182,16 @@ to say about pattern matching -- we'll introduce more of its features
 as the need arises.)
 
 You may notice that we qualified all the constructors before using them,
-writing `Day.monday` instead of just `monday`, for example. You may
-wonder if this is necessary.
-
+writing `Day.monday` instead of just `monday`, for example.
 Lean places all constructors into a "namespace" associated with their type,
 and requires uses of those constructors to be prefixed with their namespace.
-We will see in a little bit how to enter a namespace and avoid this requirement,
-but for now, if we wish to be a bit more concise, we can use just a `.`,
-like `.monday`, that signals that we're qualifying a name
-without having to type too much. A more concise (but equivalent) definition
-of `nextWorkingDay` is given below.
-
-:::dev
-BCP: I *still* find this quite tangled.  We say Lean requires all uses of constructors to be prefixed with their namespace, but then, right after, we suggest exactly not doing this!  (And I am still confused, myself, about identifiers like `true` and `false`, which seem not to need to be prefixed, even though they come from their own namespace.)
-DHS: I spent some time thinking about how to clean up this explanation, and what I realized
-is that I'm having trouble justifying Lean's convention here because I don't actually understand it
-either! To me, the difference betweeen `.CName` and `CName` seems minimal, so I don't really
-understand why Lean requires the former. I would be curious to know if there is a canonical
-explanation of why Lean works this way that we can lean on.
-DHS: Maybe the thing to do then is to defer the explanation of the .monday style until later, when there is actually a motivating example for why it's nice. So we only use the fully qualified Day.monday style until the section about namespaces, then we can explain opening namespaces to get just monday, and then even later when we have long names we can explain .monday.
-What to say: Lean usually resolves names by looking at the current namespace, and this is the single explanation for why whether I'm in namespace Day or the body of a function Day.nextWorkingDay, I don't need to write the full Day.monday. When you use the leading dot notation you are asking Lean to instead use the expected type's namespace, so that .monday used in a place expecting something of type Day will resolve to Day.monday.
-:::
-
-```lean
-def nextWorkingDay' (d : Day) : Day :=
-  match d with
-  | .monday    => .tuesday
-  | .tuesday   => .wednesday
-  | .wednesday => .thursday
-  | .thursday  => .friday
-  | .friday    => .monday
-  | .saturday  => .monday
-  | .sunday    => .monday
-```
-
-When full qualification is not necessary to disambiguate, we will
-prefer the shorter syntax with just the `.`.
+There are a few circumstances in which this requirement can be relaxed,
+which we shall see in a little bit. For now, however, we proceed by
+fully qualifying all constructor names.
 
 If you ever need to know the type of *any* pattern, object, or function,
 you can hover over it with your mouse in any editor that supports Lean,
 like VS Code or the web version we provide.
-
-:::dev
-RAB: I'm resolving the discussion for now. The `.pattern` syntax shows
-up in the Lean suggestions, in the documentation, and (less importantly)
-in our examples pervasively after this point, and we need to introduce it early.
-I think we should ask for feedback from people who aren't writing the book on
-this part and on others; I feel our curse of knowledge is leading to a lot of
-focus on something that may not be that important.
-
-BCP: I respectfully disagree that it's not important -- that is, the concept
-doesn't seem all that important, but not confusing readers is important, and right now I think we are doing that.  We need *some* consistent story.
-
-Old conversation, for reference:
-MWH - it seems that the full explanation comes later? I'm still not sure I get
-what's being said here. I think it's maybe worth being systematic, right here,
-if it seems to slow you down.
-DHS - I worry that explaining namespaces right here is too soon. This is essentially
-the very first thing we explain in the whole textbook, and going directly in to the
-details of how namespaces work immediately seems like a lot. Does it seem appropriate
-to say "names have to be qualified" here and then explain namespaces later?
-MWH - This is a key concept as the current comment explains. I'm a little inclined to
-put it all here. But I'm good with whatever for now. We can always change it later.
-:::
 ::::
 
 :::slidebreak
@@ -263,11 +210,11 @@ in comments.)
 ::::
 
 ```lean
-#eval nextWorkingDay .friday
+#eval nextWorkingDay Day.friday
 ```
 
 ```lean
-#eval nextWorkingDay (nextWorkingDay .saturday)
+#eval nextWorkingDay (nextWorkingDay Day.saturday)
 ```
 
 ::::full
@@ -319,7 +266,7 @@ Continuing with our simple type and function, we can record what we _expect_
 the result of calling a function to be in the form of a Lean `example`:
 
 ```lean
-example : nextWorkingDay (nextWorkingDay .saturday) = .tuesday := by
+example : nextWorkingDay (nextWorkingDay Day.saturday) = Day.tuesday := by
   rfl
 ```
 
@@ -333,8 +280,8 @@ the same term."
 `rfl` stands for "reflexivity," which is the principle that any value is
 equal to itself. After evaluation, both sides of the equality are the same
 value, so the assertion is true by reflexivity.  If we had made a different
-assertion, such as `example : nextWorkingDay (nextWorkingDay .saturday) =
-.monday`, then Lean would not be able to verify it and would instead signal an
+assertion, such as `example : nextWorkingDay (nextWorkingDay Day.saturday) =
+Day.monday`, then Lean would not be able to verify it and would instead signal an
 error. Try it out!
 
 We can also ask Lean to _compile_ our definitions to efficient
@@ -367,7 +314,7 @@ and `false`.
 Another familiar enumerated type:
 :::
 
-We define our own `MyBool` to teach the concept of building from
+We define our own `MyBool` to teach the concept of building booleans from
 scratch; later we'll switch to Lean's built-in `Bool`.
 We use a different name to make explicit that this is not the same
 type as Lean's built-in, but their definitions are equivalent.
@@ -378,14 +325,6 @@ inductive MyBool : Type where
   | false
 ```
 
-The next command opens a new namespace so that our definitions don't
-clash with ones from the standard library. We'll discuss it in more
-detail below.
-
-```lean
-namespace MyBool
-```
-
 ::::full
 Functions over booleans can be defined in the same way as above
 ::::
@@ -393,8 +332,8 @@ Functions over booleans can be defined in the same way as above
 ```lean
 def notb (b : MyBool) : MyBool :=
   match b with
-  | .true => .false
-  | .false => .true
+  | MyBool.true => MyBool.false
+  | MyBool.false => MyBool.true
 ```
 
 :::slidebreak
@@ -403,13 +342,13 @@ def notb (b : MyBool) : MyBool :=
 ```lean
 def andb (b1 : MyBool) (b2 : MyBool) : MyBool :=
   match b1 with
-  | .true => b2
-  | .false => .false
+  | MyBool.true => b2
+  | MyBool.false => MyBool.false
 
 def orb (b1 : MyBool) (b2 : MyBool) : MyBool :=
   match b1 with
-  | .true => .true
-  | .false => b2
+  | MyBool.true => MyBool.true
+  | MyBool.false => b2
 ```
 
 ::::full
@@ -425,10 +364,10 @@ Note the syntax for defining multi-argument functions (`andb` and `orb`).
 
 
 ```lean
-example : orb .true  .false = .true  := by rfl
-example : orb .false .false = .false := by rfl
-example : orb .false .true  = .true  := by rfl
-example : orb .true  .true  = .true  := by rfl
+example : orb MyBool.true  MyBool.false = MyBool.true  := by rfl
+example : orb MyBool.false MyBool.false = MyBool.false := by rfl
+example : orb MyBool.false MyBool.true  = MyBool.true  := by rfl
+example : orb MyBool.true  MyBool.true  = MyBool.true  := by rfl
 ```
 
 We can define new symbolic notations for existing definitions.
@@ -441,9 +380,9 @@ local infixl:30 (priority := high) " || " => orb
 ```
 
 ```lean
-example : (.false || .false || .true) = .true := by rfl
+example : (MyBool.false || MyBool.false || MyBool.true) = MyBool.true := by rfl
 
-example : (!.false) = .true := by rfl
+example : (!MyBool.false) = MyBool.true := by rfl
 ```
 
 :::slidebreak
@@ -456,20 +395,20 @@ leaving for you -- i.e., your job is to replace `sorry` with real
 definitions and proofs.
 
 Remove `sorry` below and complete the definition of the following
-function.  The function should return `.true` if either or both of
-its inputs are `.false`. Make sure that the `example` assertions
+function.  The function should return `MyBool.true` if either or both of
+its inputs are `MyBool.false`. Make sure that the `example` assertions
 below can be verified by Lean.
 
 ```lean
 def nandb (b1 : MyBool) (b2 : MyBool) : MyBool
   := solution!(match b1 with
-  | .true => notb b2
-  | .false => .true)
+  | MyBool.true => notb b2
+  | MyBool.false => MyBool.true)
 
-example : nandb .true  .false  = .true  := solution!(by rfl)
-example : nandb .false .false =  .true  := solution!(by rfl)
-example : nandb .false .true  =  .true  := solution!(by rfl)
-example : nandb .true  .true   = .false := solution!(by rfl)
+example : nandb MyBool.true  MyBool.false  = MyBool.true  := solution!(by rfl)
+example : nandb MyBool.false MyBool.false =  MyBool.true  := solution!(by rfl)
+example : nandb MyBool.false MyBool.true  =  MyBool.true  := solution!(by rfl)
+example : nandb MyBool.true  MyBool.true   = MyBool.false := solution!(by rfl)
 ```
 
 :::grade
@@ -488,10 +427,10 @@ otherwise.
 def andb3 (b1 : MyBool) (b2 : MyBool) (b3 : MyBool) : MyBool
   := solution!(andb b1 (andb b2 b3))
 
-example : andb3 .true .true .true  = .true  := solution!(by rfl)
-example : andb3 .false .true .true = .false := solution!(by rfl)
-example : andb3 .true .false .true = .false := solution!(by rfl)
-example : andb3 .true .true .false = .false := solution!(by rfl)
+example : andb3 MyBool.true  MyBool.true  MyBool.true  = MyBool.true  := solution!(by rfl)
+example : andb3 MyBool.false MyBool.true  MyBool.true  = MyBool.false := solution!(by rfl)
+example : andb3 MyBool.true  MyBool.false MyBool.true  = MyBool.false := solution!(by rfl)
+example : andb3 MyBool.true  MyBool.true  MyBool.false = MyBool.false := solution!(by rfl)
 ```
 
 :::grade
@@ -511,14 +450,14 @@ Now that we've defined some basic functions on booleans, let's see how to
 _prove_ some simple properties of those functions. Here is a simple rule
 about `&&`:
 
-- `.true && b = b`
+- `MyBool.true && b = b`
 
 This is an example of a _proposition_, a logical _claim_ that we can try to prove.
-It says that `.true && b` is equal to `b` for every `MyBool` `b`.
+It says that `MyBool.true && b` is equal to `b` for every `MyBool` `b`.
 
 How might we write this proposition in Lean?
 
-- `theorem true_and : ∀ (b : MyBool), (.true && b) = b`
+- `theorem true_and : ∀ (b : MyBool), (MyBool.true && b) = b`
 
 The keyword `theorem` indicates that we are stating (and eventually proving)
 a proposition; the text after the first `:` is the proposition we want to prove.
@@ -534,7 +473,7 @@ Now that we've stated the theorem we'd like to prove, let's set about proving it
 ::::
 
 ```lean
-theorem true_andb : ∀ (b : MyBool), (.true && b) = b := by
+theorem true_andb : ∀ (b : MyBool), (MyBool.true && b) = b := by
   intro b
   rfl
 ```
@@ -561,10 +500,10 @@ Let's walk through the example above with this terminology in mind.
 ::::
 
 ```lean
-theorem true_andb_explained : ∀ (b : MyBool), (.true && b) = b := by
+theorem true_andb_explained : ∀ (b : MyBool), (MyBool.true && b) = b := by
   /- Move your cursor (click) here to see the initial proof state in
       the InfoView. The context (before the ⊢) is empty.
-      The goal is `∀ (b : MyBool), (true && b) = b`. -/
+      The goal is `∀ (b : MyBool), (MyBool.true && b) = b`. -/
   intro b
   /- Now click here to see the new proof state that results from the
      tactic. Notice how `intro b` has changed the _context_: it now
@@ -585,12 +524,13 @@ theorem true_andb_explained : ∀ (b : MyBool), (.true && b) = b := by
     As in the `example`s above, we can use the `rfl` tactic,
     which closes goals about equality where both sides are equal to
     one another according to the principle of reflexivity. Now,
-    inspecting our goal will show that it is `(true && b) = b`, which
+    inspecting our goal will show that it is `(MyBool.true && b) = b`, which
     may not appear to be equal to itself. However, the tactic
     _evaluates_ both sides of the equality before comparing them. In
     this case, if we look at the definition of `andb`, we can see that,
-    when its first argument is `true`, the result is its second
-    argument. So the two terms `true && b` and `b` are in fact equal because one evaluates to the other.
+    when its first argument is `MyBool.true`, the result is its second
+    argument. So the two terms `MyBool.true && b` and `b` are in fact equal because one
+    evaluates to the other.
   -/
   rfl
   /- The proof is now done! The Lean InfoView tells us there are "No goals". -/
@@ -606,7 +546,7 @@ instead written the following:
 DHS: Ideally would change this to a #guardmsgs(error) if we can
 :::
 
-/- theorem trueandb : ∀ (b : MyBool), (.true && b) = b := by
+/- theorem trueandb : ∀ (b : MyBool), (MyBool.true && b) = b := by
   intro b
     rfl
 -/
@@ -617,7 +557,7 @@ In general, sequential tactics applied to the same goal must be on subsequent li
 level of indentation or separated on the same line by a `;` like so:
 
 ```lean
-theorem true_andb' : ∀ (b : MyBool), (.true && b) = b := by
+theorem true_andb' : ∀ (b : MyBool), (MyBool.true && b) = b := by
   intro b; rfl
 ```
 ::::
@@ -627,7 +567,7 @@ Here's a simple proof for you to try.
 Remove `sorry` and fill in the proof.
 
 ```lean
-theorem false_orb : ∀ (b : MyBool), (.false || b) = b := by
+theorem false_orb : ∀ (b : MyBool), (MyBool.false || b) = b := by
   solution!
     intro b
     rfl
@@ -651,7 +591,7 @@ checked world!
 ::::
 
 ```lean -keep
-theorem really_bad : MyBool.true = .false := by sorry
+theorem really_bad : MyBool.true = MyBool.false := by sorry
 ```
 
 ::::full
@@ -662,18 +602,7 @@ introduce new tactics and proof techniques gradually, enriching the propositions
 Now that we've seen how to define our own booleans and prove some basic
 properties about them, let's switch to Lean's built-in `Bool` type, which has the same structure
 but comes with a lot of useful functions and lemmas.
-
-Because `Bool` is such an important type in Lean, its `true` and `false` constructors can be written
-without a `.` to qualify them.
-:::dev
-BCP: Do we need to be so vague?  It sounds like it's saying that `true` and `false` are built in / treated specially by the language,
-which is not what we mean.
-:::
 ::::
-
-```lean
-end MyBool
-```
 
 ## Types
 
@@ -681,7 +610,7 @@ Every expression in Lean has a type describing what sort of value it computes.
 The `#check` command asks Lean to print the type of an expression.
 
 ```lean
-#check true
+#check Bool.true
 ```
 
 If the expression after `#check` is followed by a colon and a type,
@@ -689,12 +618,12 @@ Lean will verify that the type of the expression
 matches the given type and signal an error if not.
 
 ```lean
-#check (true : Bool)
-#check (not true : Bool)
+#check (Bool.true : Bool)
+#check (Bool.not Bool.true : Bool)
 ```
 
-Functions like `not` are themselves data values, just like `true`
-and `false`.  Their types are called _function types_, and they are
+Functions like `Bool.not` are themselves data values, just like `Bool.true`
+and `Bool.false`.  Their types are called _function types_, and they are
 written with arrows.
 
 ```lean
@@ -702,7 +631,7 @@ written with arrows.
 ```
 
 ::::full
-The type of `not`, written `Bool → Bool` and pronounced "`Bool`
+The type of `Bool.not`, written `Bool → Bool` and pronounced "`Bool`
 arrow `Bool`," can be read, "Given an input of type `Bool`, this
 function produces an output of type `Bool`." Similarly, the type of
 `and`, written `Bool → Bool → Bool`, can be read, "Given two inputs,
@@ -752,7 +681,7 @@ inductive Color : Type where
 An `inductive` definition does two things:
 
 - It introduces a set of new _constructors_. E.g., {name}`RGB.red`,
-  {name}`Color.primary`, {name}`true`, {name}`false`, {name}`Day.monday`,
+  {name}`Color.primary`, {name}`Bool.true`, {name}`Bool.false`, {name}`Day.monday`,
   etc. are constructors.
 
 - It groups them into a new named type, like `Bool`, `RGB`, or
@@ -764,22 +693,14 @@ obeying the declared number and types of the constructor arguments.
 E.g., these are valid constructor expressions...
 
 - {name}`RGB.red`
-- {name}`true`
+- {name}`Bool.true`
 - {name}`Color.primary` {name}`RGB.red`
 
 ...but these are not:
 
 - `RGB.red Color.primary`
-- `true RGB.red`
-- `Color.primary (.primary .red)`
-
-Note that we don't need to qualify `true` as `Bool.true`.
-Lean recognizes `Bool` as a type whose constructors
-are usable without qualification by default.
-
-:::dev
-BCP: "One of the types..." is mysterious.  What are these types?  Have we been told about them already?
-:::
+- `Bool.true RGB.red`
+- `Color.primary (Color.primary RGB.red)`
 
 :::slidebreak
 :::
@@ -790,41 +711,41 @@ we did for `Day` and `Bool`.
 ```lean
 def monochrome (c : Color) : Bool :=
   match c with
-  | .black => true
-  | .white => true
-  | .primary p => false
+  | Color.black => Bool.true
+  | Color.white => Bool.true
+  | Color.primary p => Bool.false
 ```
 
 Since the `primary` constructor takes an argument, a pattern
 that matches `.primary` should include either a variable, a constant
 of appropriate type, or `_`. Lean's convention is to use a `_` (called a
 _wildcard_) when the argument to a constructor doesn't matter. In
-the definition of `monochrome`, we don't use the argument to `.primary`, so
+the definition of `monochrome`, we don't use the argument to `Color.primary`, so
 a more idiomatic definition would be:
 
 ```lean
 def monochrome' (c : Color) : Bool :=
   match c with
-  | .black => true
-  | .white => true
-  | .primary _ => false
+  | Color.black => Bool.true
+  | Color.white => Bool.true
+  | Color.primary _ => Bool.false
 ```
 
-We can use a constant argument to `.primary` to match a specific primary color:
+We can use a constant argument to `Color.primary` to match a specific primary color:
 
 ```lean
 def isRed (c : Color) : Bool :=
   match c with
-  | .black => false
-  | .white => false
-  | .primary .red => true
-  | .primary _ => false
+  | Color.black => Bool.false
+  | Color.white => Bool.false
+  | Color.primary RGB.red => Bool.true
+  | Color.primary _ => Bool.false
 ```
 
-The pattern `.primary .red` will match only when `c` is
-`.primary` with the argument `.red`. The pattern `.primary _` matches
-every `.primary` color, but because patterns are checked in
-order, the `.primary _` case will never be reached if the color is `.red`.
+The pattern `Color.primary RGB.red` will match only when `c` is
+`Color.primary` with the argument `RGB.red`. The pattern `Color.primary _` matches
+every `Color.primary` color, but because patterns are checked in
+order, the `Color.primary _` case will never be reached if the color is `RGB.red`.
 
 An alternative way to write the same function would be to explicitly
 nest match statements:
@@ -832,17 +753,17 @@ nest match statements:
 ```lean
 def isRed' (c : Color) : Bool :=
   match c with
-  | .black => false
-  | .white => false
-  | .primary r =>
+  | Color.black => Bool.false
+  | Color.white => Bool.false
+  | Color.primary r =>
     match r with
-    | .red => true
-    | _ => false
+    | RGB.red => Bool.true
+    | _ => Bool.false
 ```
 
 This function produces the same result as the old
 `isRed` but illustrates the use of a pattern matching variable: the
-`.primary r` pattern stores the `RGB` argument into variable `r`,
+`Color.primary r` pattern stores the `RGB` argument into variable `r`,
 and then pattern matches on that argument to produce the final
 result.
 
@@ -861,14 +782,14 @@ or you could try to come up with a shorter solution...
 def is_weekend (d : Day) : Bool
   := solution!
     (match d with
-    | .saturday => true
-    | .sunday => true
+    | Day.saturday => true
+    | Day.sunday => true
     | _ => false
     )
 
 unseal is_weekend
-example : is_weekend .sunday = true := solution!(by rfl)
-example : is_weekend .friday = false := solution!(by rfl)
+example : is_weekend Day.sunday = true := solution!(by rfl)
+example : is_weekend Day.friday = false := solution!(by rfl)
 seal is_weekend
 ```
 :::dev
@@ -896,18 +817,20 @@ Green is not an inversion of anything.
 def is_inversion (c1 c2 : Color) : Bool
   := solution!
     (match c1, c2 with
-    | .black, .white => true
-    | .white, .black => true
-    | .primary .red, .primary .blue => true
-    | .primary .blue, .primary .red => true
+    | Color.black, Color.white => Bool.true
+    | Color.white, Color.black => Bool.true
+    | Color.primary RGB.red, Color.primary RGB.blue => Bool.true
+    | Color.primary RGB.blue, Color.primary RGB.red => Bool.true
     | _, _ => false
     )
 
 unseal is_inversion
-example : is_inversion .black .white = true := solution!(by rfl)
-example : is_inversion .white .black = true := solution!(by rfl)
-example : is_inversion (.primary .red) (.primary .blue) = true := solution!(by rfl)
-example : is_inversion (.primary .green) (.primary .red) = false := solution!(by rfl)
+example : is_inversion Color.black Color.white = true := solution!(by rfl)
+example : is_inversion Color.white Color.black = Bool.true := solution!(by rfl)
+example : is_inversion (Color.primary RGB.red) (Color.primary RGB.blue) = Bool.true :=
+  solution!(by rfl)
+example : is_inversion (Color.primary RGB.green) (Color.primary RGB.red) = Bool.false :=
+  solution!(by rfl)
 seal is_inversion
 ```
 :::dev
@@ -950,29 +873,9 @@ end Playground
 #check Playground.myFoo  -- RGB
 ```
 
-::::exercise(rating:=0) (name := "custom_namespace_checks")
-Predict the output of each of these statements below.
-Do you think their results will change depending on which `namespace`
-they are in? How?
-
-#check .black -- Write your prediction here.
-#check Color.black -- Write your prediction here.
-#check RGB -- Write your prediction here.
-#check NatPlayground.myFoo -- Write your prediction here.
-
-Once you have written your predictions, copy the lines from the comment into
-an active section of the book to evaluate them.
-::::
-
-:::dev
-RAB: This seems like a reasonable exercise; I'm not quite sure if/how we should grade it?
-BCP: Not all exercises need to be graded.  (In Rocq we had a notation for manually graded exercises. An optional and manually graded exercise would serve for this.)
-:::
-
-::::full
 Namespaces can be opened and closed as often as you like to add new definitions and access old ones.
-When inside a `namespace`, definitions from the same namespace can be referenced without prefixes.
-::::
+When inside a `namespace`, definitions from the that namespace can be referenced
+without prefixes.
 
 ```lean
 namespace Playground
@@ -984,11 +887,16 @@ end Playground
 ```
 
 ::::full
-When a `namespace` shares the same name as a type, definitions on that type are
-available inside the `namespace` without a prefix. In the example
-below, we can use the `blue` constructor without a `.` because
+When creating a type, a `namespace` with the same name as that type is implicitly created as well;
+definitions on that type are available inside that `namespace` without a prefix. In the example
+below, we can use the `blue` constructor without qualification because
 we are inside the `RGB` `namespace`, which is the same as `blue`'s type.
 ::::
+
+::::terse
+Types implicitly create namespaces.
+::::
+
 
 ```lean
 namespace RGB
@@ -996,11 +904,8 @@ def myBlue : RGB := blue
 end RGB
 ```
 
-::::full
-Top-level definitions can also be prefixed by a namespace to put
-them in the namespace "from the outside," without having to open and
-close it.
-::::
+Top-level definitions can also be prefixed by a namespace,
+which opens the namespace temporarily for the body of the definition.
 
 ```lean
 --- this works, because the definition is qualified by `RGB.`
@@ -1022,13 +927,12 @@ DHS: see my comment later in the file about guard msgs
 :::
 
 ::::full
-When we do this, definitions inside that namespace are available without
-qualification. So, for example, we could write the definition of `nextWorkingDay''`
+Similarly, we could write the definition of `nextWorkingDay`
 earlier inside the `Day` namespace like so:
 ::::
 
 ```lean
-def Day.nextWorkingDay'' (d : Day) : Day :=
+def Day.nextWorkingDay' (d : Day) : Day :=
   match d with
   | monday    => tuesday
   | tuesday   => wednesday
@@ -1039,21 +943,126 @@ def Day.nextWorkingDay'' (d : Day) : Day :=
   | sunday    => monday
 ```
 
-::::full
 We can also use `open` to bring the definitions of a namespace into
 the current scope; after that, we can refer to any of the namespace's
 definitions without a prefix.
-::::
 
 ```lean
 namespace MyNamespace
-def myDef : Bool := true
+def myDef : Bool := Bool.true
 end MyNamespace
 
 open MyNamespace
 
 #check myDef -- Bool
 ```
+
+If we only want to bring _some_, rather than all, of the definitions
+of a namespace into the current scope, we can use the `export` command:
+
+```lean
+namespace MyOtherNamespace
+def myHiddenDef : Bool := Bool.true
+def myVisibleDef : Bool := Bool.false
+end MyOtherNamespace
+
+export MyOtherNamespace (myVisibleDef)
+
+-- this is usable without qualification, but `myHiddenDef` would not be
+#check myVisibleDef -- Bool
+```
+
+::::full
+In fact, this is what Lean does with the `Bool` type. Since it is such an important
+part of many proofs and programs, Lean implicitly `export`s many of `Bool`s functions and
+constructors. Accordingly, we can use constructors like `true` and `false` and functions like `not`
+without qualifying them with `Bool.`.
+::::
+
+::::terse
+Names in the `Bool` `namespace` are available without qualification.
+::::
+
+```lean
+#check Bool.true -- Bool
+#check true -- Bool
+```
+
+::::full
+Finally, Lean can often automatically figure out which namespace a qualified name lives in,
+saving us the need to explicitly specify it every time we use the name. In addition the
+to fully qualified style (e.g., `Day.monday`), we can opt for a partially qualified style,
+writing just `.monday`.
+
+When we do this, Lean tries to resolve the `.monday` name by seeing what its expected type is,
+and inferring which namespace it must be from based on that type. If there is only one such
+namespace (i.e., if it is unambiguous which constructor we're referring to), then it will
+automatically resolve to the expected value.
+
+So, for example, we could also write `nextWorkingDay` like so:
+::::
+
+::::terse
+Lean can often guess which qualified name we mean if we don't supply it explicitly:
+::::
+
+```lean
+def nextWorkingDay' (d : Day) : Day :=
+  match d with
+  | .monday    => .tuesday
+  | .tuesday   => .wednesday
+  | .wednesday => .thursday
+  | .thursday  => .friday
+  | .friday    => .monday
+  | .saturday  => .monday
+  | .sunday    => .monday
+```
+
+::::full
+In the function above, both the type of `d` and the return type of the function are declared
+to be `Day`s. When we use the `.monday` style in the function body, Lean can figure
+out that we must mean `Day.monday`. However, in the example below, Lean can't figure out
+which version of `.true` we mean, since it could either be `Bool.true` or `MyBool.true`.
+In this case, it will raise an error:
+
+:::dev
+DHS: see my comment later in the file about guard msgs
+
+```lean
+--- this doesn't work, Lean doesn't know which `true` we mean
+#guard_msgs(drop all) in
+#check .true --
+```
+:::
+::::
+
+::::full
+Here, though, because `not` is a function that takes a `Bool` argument, Lean knows that
+`.true` must here be a `Bool`:
+
+```lean
+#check (not .true)
+```
+::::
+
+::::exercise(rating:=0) (name := "custom_namespace_checks")
+Predict the output of each of these statements below.
+Do you think their results will change depending on which `namespace`
+they are in? How?
+
+#check .black -- Write your prediction here.
+#check Color.black -- Write your prediction here.
+#check RGB -- Write your prediction here.
+#check Playground.myFoo -- Write your prediction here.
+
+Once you have written your predictions, copy the lines from the comment into
+an active section of the book to evaluate them.
+::::
+
+:::dev
+RAB: This seems like a reasonable exercise; I'm not quite sure if/how we should grade it?
+BCP: Not all exercises need to be graded.  (In Rocq we had a notation for manually graded exercises. An optional and manually graded exercise would serve for this.)
+:::
 
 ## Constructors with Multiple Parameters
 

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -325,6 +325,14 @@ inductive MyBool : Type where
   | false
 ```
 
+The next command opens a new namespace so that our definitions don't
+clash with ones from the standard library. We'll discuss it in more
+detail below.
+
+```lean
+namespace MyBool
+```
+
 ::::full
 Functions over booleans can be defined in the same way as above
 ::::
@@ -592,6 +600,10 @@ checked world!
 
 ```lean -keep
 theorem really_bad : MyBool.true = MyBool.false := by sorry
+```
+
+```lean
+end MyBool
 ```
 
 ::::full

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -969,6 +969,11 @@ open MyNamespace
 #check myDef -- Bool
 ```
 
+:::dev
+@dsainati1: We should come to a concrete decision about whether or not we are
+putting types in comments for #check and #eval commands.
+:::
+
 If we only want to bring _some_, rather than all, of the definitions
 of a namespace into the current scope, we can use the `export` command:
 


### PR DESCRIPTION
This reworks the presentation of namespaces in Basics. The new flow is:
- Start out with everything being fully qualified, including `Day`, `MyBool`, `Color` and `RGB`. This is consistent with what the Lean InfoView will show students and what VSCode will show them on hover, so it is verbose but minimally confusing.
- In the section about namespaces, explain that inside namespaces you don't have to qualify names in that namespace.
- Explain that you can open or export namespaces so you can use them unqualified outside of the namespace. Explain that this is what Lean does with `Bool`.
- Explain how partially qualified names work using type inference. 

After the namespaces section of the file everything is the same. 