### PR TITLE
Permanent conversion of HL/Imp.lean to verso

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,28 +64,30 @@ source:
 
 In general, there should be at most one blank line at a time in .lean files.  
 
-## Avoid inner ``` fences inside noop author blocks
+## Author notes are `:::` directives (not code blocks)
 
-Author/developer notes are emitted by `to_verso` as **code blocks**
-(` ```dev ` and ` ```instructors `), NOT as `:::dev` / `:::instructors`
-directives. Reason: a Verso *directive* always parses its body as markdown, so
-arbitrary author prose (`:::`, `*`, `#`, `[…]`, backticks) could derail the
-parser and used to require an ugly inner verbatim ` ``` ` fence. A Verso **code
-block** (`@[code_block]`, `CodeBlockExpanderOf`) instead receives its body as a
-raw string that is never parsed — so a single tagged fence suffices and no inner
-fence is needed. See `SFLMeta/Comment.lean` (` ```dev `), `SFLMeta/Instructors.lean`
-(` ```instructors `), and the models `SFLMeta/Bnf.lean` / `SFLMeta/Save.lean`.
-The code block is registered under the directive's name via `@[code_block dev]`
-(explicit ident) so the fence reads ` ```dev ` even though a same-named
-`@[directive] def dev` still exists (directives and code blocks live in separate
-expander tables). In `to_verso`, `_emit_noop_directive` uses `_code_block(tag,
-text)`. Do NOT reintroduce the inner-fence pattern for these.
+Author/developer notes are emitted by `to_verso` as **directives** — `:::dev`
+and `:::instructors` — the same as `:::hide` / `:::answer` / `:::grade` /
+`:::solution`, NOT as ` ```dev ` / ` ```instructors ` code blocks. This is the
+preferred authoring convention (see CONTRIBUTING.md, "Author-only annotations").
 
-Still verbatim-fenced (`_verbatim_block`), intentionally: `:::hide`,
-`:::solution`, `:::grade`. Unlike dev/instructors, `solution` and `grade` bodies
-are meant to be *consumed* later (solutions build / grading), so converting them
-to raw-body code blocks needs separate design. If you do convert one, follow the
-` ```dev ` pattern above.
+A directive parses its body as markdown, so `to_verso` wraps the body in a
+**verbatim ` ``` ` fence** (`_verbatim_block`) — arbitrary author prose (`:::`,
+`*`, `#`, `[…]`, backticks) then can't derail the parser. `_emit_noop_directive`
+emits `:::<tag>` + `_verbatim_block(text)` + `:::`, and `_fuse_noop_blocks` fuses
+adjacent same-tag runs. The `dev`/`instructors` directives live in
+`SFLMeta/Comment.lean` / `SFLMeta/Instructors.lean`; a same-named
+`@[code_block dev]` still exists for back-compat but `to_verso` no longer emits
+it. (Earlier guidance preferred the ` ```dev ` code-block form to avoid the inner
+fence — that was reversed 2026-07-11 in favor of the directive form.)
+
+When editing a **versified** chapter by hand, prefer inlining the note body as
+plain markdown (backtick code identifiers, escape markdown-special text just as
+in `::::full` prose); reach for an inner ` ``` ` fence only when the body is
+code-dense or embeds a ` ```lean ` snippet that must not elaborate. All of
+`dev`/`instructors`/`hide`/`answer`/`grade`/`solution` are noops (bodies dropped
+from every build); the tag name reserves each for a future build that treats it
+differently.
 
 ## Rough-draft conversion straight from a .v chapter
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,6 +368,12 @@ guidelines.
   fine to unfold and simplify through definitions; *using* that code,
   do not "peek through the interface."
 
+* **Name namespaces for what they are, not after a type they contain.**
+  A warm-up / redefinition section that shadows later top-level names goes in a
+  clearly-named namespace — e.g. `namespace Warmup`, not `namespace AExp` (too
+  easily misread as the `Aexp` type, so `AExp.Bexp` reads like a field of
+  `Aexp`).  (Rocq's `Module AExp` warm-up in `Imp` became `namespace Warmup`.)
+
 ### Notation and simplification
 
 When notation is implemented via typeclass instances, `dsimp [add]` /
@@ -410,11 +416,13 @@ for nesting.  Use **three colons** (`:::`) for a directive whose body
 contains only prose and code blocks.  Use **four colons** (`::::`)
 whenever the body itself contains three-colon directives.
 
-In practice: `::::full`, `::::terse`, `::::exercise`, and `::::solution`
-almost always use four colons because they commonly nest `:::grade`,
-`:::instructors`, or similar leaf blocks inside them.  Author-annotation
-directives (`:::dev`, `:::instructors`, `:::hide`, `:::grade`) are always
-leaves and always use three colons.
+In practice the widths follow the nesting: leaf directives (`:::dev`,
+`:::instructors`, `:::hide`, `:::answer`, `:::grade`, `:::solution`, `:::terse`,
+`:::slidebreak`) are always three colons; a `::::full` / `::::hide` / `::::quiz`
+that nests a leaf uses four; an `:::::exercise` that nests those uses five.
+`to_verso` computes the minimal correct width automatically; when hand-authoring,
+just make each container strictly wider than everything directly nested inside
+it.
 
 ### Build variants and prose directives
 
@@ -490,6 +498,23 @@ GRADE_THEOREM 1: nandb_test4
 a noop in all rendered outputs (body discarded at elaboration); the
 spec survives verbatim in the Verso source for tooling.
 
+### Quizzes
+
+**`::::quiz … ::::`** — A multiple-choice review question: the body holds the
+question prose and the options, and the answer goes in a nested **`:::answer`**.
+
+* A *provable* answer is a plain (verbatim) ` ``` ` fence holding the Lean
+  theorem — shown for reference, not re-elaborated (so it is not type-checked;
+  keep it in sync with live definitions by hand).
+* A deliberately *false* / unprovable claim is kept as an illustration: state it
+  and leave the proof stuck with an explanatory comment (the SFL analogue of
+  Rocq's `Abort`) — do **not** `sorry` it, and do **not** make it a live
+  ` ```lean ` block.
+
+`:::answer` — like the other author-only tags — is a noop today (dropped from
+every build), reserved for a future answer-revealing build.  Use `:::answer`
+(not `:::hide`) for a quiz's answer, so that future build can find it.
+
 ### Solution mechanisms inside `lean` blocks
 
 Both mechanisms are elaborated by Lean at compile time (errors in the
@@ -530,13 +555,38 @@ inductive Bin : Type where
 -- END SOLUTION
 ```
 
-**Convention:** prefer `solution!(…)` for single-term / single-tactic
-answers; use `-- SOLUTION` blocks for multi-line answers.
+**Convention:** prefer `solution!(…)` for a single term or tactic sequence.
+Use `-- SOLUTION … -- END SOLUTION` only where the elided region stays *valid as
+a comment* — the constructors of an `inductive`, or a whole top-level
+declaration (the student sees `-- FILL IN HERE` in its place).
+
+**Do not use `-- SOLUTION` for a `def` body or a proof body.**  Eliding those to
+`-- FILL IN HERE` leaves an incomplete `def … :=` or an empty `by` block, which
+fails to compile — and a stubbed `def` must keep its *name* defined so later code
+still elaborates.  Wrap those in `solution!(…)` instead, so the student variant
+becomes `:= sorry` / `by sorry`.  (Use `-- END SOLUTION` as the closer, not
+`-- /SOLUTION`; `to_verso` rewrites the code-forward `-- /SOLUTION` to it, but
+hand-authored Verso must use `-- END SOLUTION`.)
 
 ### Author-only annotations
 
 These directives are invisible in all rendered outputs (HTML, TeX, and
 generated `.lean` files).  They exist only in the Verso source.
+
+Write author-facing notes as `:::` **directives** — not ` ```dev ` /
+` ```instructors ` code blocks.  A directive's body is parsed as markdown, so
+backtick code identifiers (`foo_bar`, `[x]`) and escape markdown-special text
+just as you would in `::::full` prose; reach for an inner ` ``` ` fence only when
+the body is code-dense or embeds a ` ```lean ` snippet that must not elaborate.
+(`to_verso` generates these directives with the body verbatim-fenced, which is
+always safe; a hand pass can un-fence and inline the markdown.)
+
+Pick the tag by intent — `:::instructors` (instructor notes), `:::dev` (author
+TODOs / review threads), `:::answer` (a quiz's answer — see **Quizzes**),
+`:::hide` (genuinely hidden content).  All are noops today (dropped from every
+build), so the choice is *semantic*: the name reserves each for a future build
+that could treat it differently (reveal `:::answer`, show `:::instructors` to
+instructors).
 
 **`:::instructors … :::`** — Notes for instructors: pacing advice,
 classroom caveats, which sections to skip for a short course, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -693,6 +693,37 @@ diagram (e.g., SVG), and a plain code block containing the ASCII art.
 HTML renders only the diagram child; the saver emits only the ASCII
 fallback wrapped in a `/-! … -/` module-doc comment.
 
+### Verso markup for nicer HTML
+
+Beyond the structural directives above, the Manual genre offers **inline roles**
+that enrich expository prose in the HTML.  Use them where they add value (and
+don't over-link — link the first substantive mention in a passage, not every
+occurrence):
+
+* `` {name}`Foo.bar` `` — a clickable identifier that hovers to show its
+  type/signature and links to its definition.  Use for references to real
+  declarations (defs, theorems, constructors, types) in prose.  **Caveat:** the
+  name must resolve *in scope at that point in the document* — defined earlier
+  and reachable (mind namespaces and forward references), or the build fails.  So
+  this is a targeted, build-verified pass, not a global `` `x` ``→`` {name}`x` ``
+  replace; and it applies only in visible prose (not inside `lean` blocks, quiz
+  options, or dropped author notes).
+* `` {lean}`expr` `` — an inline *elaborated expression* (any term or type, with
+  hover types).  Use when a whole expression — not just a single name — belongs
+  in prose, e.g. `` {lean}`Aexp → Nat` `` or `` {lean}`Coe Ident Aexp` ``.
+* `{ref "tag"}[link text]` — a cross-reference link to a section.  Tag the target
+  by putting a `%%% tag := "the-tag" %%%` block right under its heading, then
+  reference it with `{ref "the-tag"}[…]`.  Use for "see the X section
+  above/below" phrasings.
+* `` {tactic}`simp` `` — links a tactic name to its documentation; good for prose
+  that mentions tactics.
+* `` {deftech}`term` `` / `` {tech}`term` `` — define a technical term (glossary
+  entry + anchor) and link its later uses.  Good for a chapter's recurring
+  defined terms.
+* Also available: `{option}` (Lean options), `` {module}`Foo` `` (module links),
+  `{margin}[…]` (sidebar notes), `{index}` / `{see}` / `{seeAlso}` (book index),
+  `{citep}` / `{citet}` (bibliography).
+
 ## Porting chapters from Rocq
 
 The `to_verso` script automates the mechanical parts of translating from Rocq to 

--- a/HL.lean
+++ b/HL.lean
@@ -3,6 +3,7 @@ import SFLMeta.Ignore
 import SFLMeta.Save
 
 import HL.Intro
+import HL.Imp
 
 import VersoManual
 
@@ -10,3 +11,4 @@ open Verso Genre Manual
 
 #doc (Manual) "Hoare Logic" =>
 {include HL.Intro}
+{include HL.Imp}

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -28,7 +28,7 @@ htmlSplit := .never
 file := some "Imp"
 %%%
 
-```instructors
+:::instructors
 This chapter plus `Maps` takes a little more than one
    80-minute lecture.  It could be streamlined a bit further without
    losing much, by removing (for example) the inference rules and BNF
@@ -37,9 +37,9 @@ This chapter plus `Maps` takes a little more than one
    (BCP 21: ... Actually, I tried removing inference rules from the
    TERSE version; eventually decided that it makes some of the
    definitions harder to talk about.)
-```
+:::
 
-```dev
+:::dev
 SOONER: Needs some WORKINCLASSes and some quizzes
 
 LATER: Another nice challenge exercise at some point would be to add
@@ -48,9 +48,9 @@ LATER: Another nice challenge exercise at some point would be to add
    aliasing / etc.).
 
 SOONER: BCP 25: Maybe we should write /\ instead of && in assertions,
-   to save a mismatch in the dec_minimum exercise in Hoare2?
+   to save a mismatch in the `dec_minimum` exercise in Hoare2?
 
-HIDE: At some point we could consider moving material from the old
+   At some point we could consider moving material from the old
    HoareLists to this chapter (and into later files, as
    appropriate).  We haven't done it yet because it's a shame to
    complicate the nice simple presentation here when it's used as the
@@ -66,7 +66,7 @@ below is a recap.  For linear arithmetic we use `lia`;
 NOTE that LF currently
 introduces `omega`, not `lia`, so this needs to be reconciled volume-wide
 (either introduce `lia` in LF, or keep `omega`).
-```
+:::
 
 ::::full
 In this chapter, we take a more serious look at how to use Lean as a
@@ -92,12 +92,12 @@ _Hoare Logic_, a popular logic for reasoning about imperative programs.
 
 # Arithmetic and Boolean Expressions
 
-```dev
+:::dev
 SOONER: At this point, I usually take some of the lecture time to
    give a high-level picture of the structure of an interpreter, the
    processes of lexing and parsing, the notion of ASTs, etc.  Might be
    nice to work some of those ideas into the notes. - BCP
-```
+:::
 
 ::::full
 We'll present Imp in three parts: first a core language of _arithmetic
@@ -109,7 +109,7 @@ sequencing, and loops.
 ## Syntax
 
 ```lean
-namespace AExp
+namespace Warmup
 ```
 
 ::::full
@@ -138,19 +138,15 @@ inductive Bexp where
   | and (b1 b2 : Bexp)
 ```
 
-```dev
-MWH: Will we develop `ImpParser`? Mentioned below as an optional chapter
-```
+:::dev
+  SOONER: mwhicks1: Will we develop `ImpParser`? Mentioned below as an optional chapter
+:::
 
 ::::full
 In this chapter, we'll mostly elide the translation from the concrete
 syntax that a programmer would actually write to these abstract syntax
 trees -- the process that, for example, would translate the string
-`"1 + 2 * 3"` to the AST
-
-```
-.plus (.num 1) (.mult (.num 2) (.num 3))
-```
+`"1 + 2 * 3"` to the AST `.plus (.num 1) (.mult (.num 2) (.num 3))`.
 
 The optional chapter `ImpParser` develops a simple lexical analyzer and
 parser that can perform this translation.  You do not need to understand
@@ -209,12 +205,12 @@ implementations and proofs.
 
 _Evaluating_ an arithmetic expression produces a number.
 
-```dev
+:::dev
 chenson2018: TODO: seal evaluators with `@[irreducible]` and prove
    *characterizing lemmas* (one
    `rfl` equation per constructor) that proofs rewrite with instead of
    unfolding the definition; tag lemmas `@[simp]`.
-```
+:::
 
 ```lean
 def Aexp.eval (a : Aexp) : Nat :=
@@ -414,11 +410,9 @@ inductive Aexp.evalR : Aexp → Nat → Prop where
       Aexp.evalR (.mult a1 a2) (n1 * n2)
 ```
 
-```dev
-chenson2018: There is still some naming weirdness in the relation forms of evaluation that should be addressed later.
-
-mwhicks1: I think this comment is about wanting to call `evalR` something like `Rel`, but it's not clear to me that I want to do that, e.g., since there are multiple evaluation relations (such as big-step and small-step) there won't be just one name
-```
+:::dev
+chenson2018: There is still some naming weirdness in the relation forms of evaluation that should be addressed later. The inductive should be in upper camel case (you can disambiguate which evaluation with its name) and the constructors should not have these `E_A` prefixes.
+:::
 
 ::::full
 A small notational aside. We could instead have presented this relation
@@ -523,20 +517,19 @@ them:
 ```
 ::::
 
-::::hide
-```
-/- INSTRUCTORS: It might be useful to write the inference rules on the
-   chalkboard, walking through the translation from the inductive
-   definition, and then use these quizzes to check comprehension.
-   BCP 21: Too heavy. -/
-/- LATER: The first two quizzes here seem kind of boring. -/
-```
-::::
+:::instructors
+It might be useful to write the inference rules on the
+chalkboard, walking through the translation from the inductive
+definition, and then use these quizzes to check comprehension.
+BCP 21: Too heavy.
 
-```dev
+LATER: The first two quizzes here seem kind of boring.
+:::
+
+:::dev
 mwhicks1: both of the next two quizzes were hidden in the source
 material; the first quiz here is shown, the second is kept under `HIDE`.
-```
+:::
 
 ::::quiz
 Which rules are needed to prove the following?
@@ -572,10 +565,10 @@ Which rules are needed to prove the following?
 ````
 ::::
 
-```dev
+:::dev
 mwhicks1: Not sure if we need ⇓b, or whether we can define
 ⇓ overloaded. Don't understand Lean notation yet!
-```
+:::
 
 :::::exercise (rating := 1) (name := "beval_rules")
 Here, again, is the definition of the `Bexp.eval` function:
@@ -647,9 +640,9 @@ GRADE_MANUAL 1: beval_rules
 It is straightforward to prove that the relational and functional
 definitions of evaluation agree.
 
-```dev
+:::dev
 SOONER: BCP 23: Why can't we do induction on H in the ← direction??
-```
+:::
 
 ```lean
 theorem aevalR_iff_aeval (a : Aexp) (n : Nat) :
@@ -673,9 +666,9 @@ theorem aevalR_iff_aeval (a : Aexp) (n : Nat) :
 Again, we can make the proof quite a bit shorter using the combinators
 from the previous section.
 
-```dev
+:::dev
 mwhicks1: the `-- WORKINCLASS` marker leaves this shorter proof as a live in-class exercise.
-```
+:::
 
 ```lean
 theorem aevalR_iff_aeval' (a : Aexp) (n : Nat) :
@@ -711,9 +704,9 @@ inductive Bexp.evalR : Bexp → Bool → Prop where
 scoped notation:55 e:56 " ⇓b " b:56 => Bexp.evalR e b
 ```
 
-```dev
+:::dev
 mwhicks1: There is no keyboard shortcut for a subscript b, nor is there one for c (to use used with cevalR below). There are numbers, x, y, z, l, m, n, etc.
-```
+:::
 
 ```lean
 theorem bevalR_iff_beval (b : Bexp) (bv : Bool) :
@@ -753,7 +746,7 @@ GRADE_THEOREM 3: bevalR_iff_beval
 :::::
 
 ```lean
-end AExp
+end Warmup
 ```
 
 ## Computational vs. Relational Definitions
@@ -857,7 +850,7 @@ inductive Aexp.evalR : Aexp → Nat → Prop where
 end AevalRExtended
 ```
 
-```dev
+:::dev
 mwhicks1: The following text seems not quite right to me. First, you can
 use options for partial functions, and that's very natural to do in Lean
 as a monad. Second, and related, monadic functions need not even be
@@ -865,7 +858,7 @@ terminating if the implement the `CCPO` typeclass and are labeled as
 a `partial_fixpoint`. Maybe we don't want to get into the second thing here,
 but failing to mention options (which I think were introduced in LF) seems
 a bit surprising.
-```
+:::
 
 ::::full
 At this point you may be wondering: which of these styles should I use
@@ -900,15 +893,15 @@ only hold numbers.
 
 ## States
 
-```dev
+:::dev
 LATER: Maybe this section needs a little preface talking about "what is
    the meaning of an expression with variables?"...
 
-LATER: (Note copied from Equiv right before the assign_aequiv
+LATER: (Note copied from Equiv right before the `assign_aequiv`
    exercise): Some or all of this discussion should really happen when
    states are introduced in Imp.v, and the whole idea of treating states as
    an ADT should be raised there.
-```
+:::
 
 Since we'll want to look variables up to find out their current values,
 we'll use total maps from the `Maps` chapter. A _machine state_ (or
@@ -935,7 +928,7 @@ abbrev State := TotalMap Ident Nat
 
 We can add variables to the arithmetic expressions we had before simply
 by including one more constructor.  (This is a fresh `Aexp`, replacing
-the variable-free one from the `AExp` namespace above.)
+the variable-free one from the `Warmup` namespace above.)
 
 ```lean
 inductive Aexp where
@@ -946,7 +939,7 @@ inductive Aexp where
   | mult (a1 a2 : Aexp)
 ```
 
-````dev
+:::dev
 chenson2018: Rather than define identifiers as Ident, a more general approach is
 to use a *type variable* with `DecidableEq` (as the
 `Maps` chapter does), threaded through `Aexp`/`Bexp`/`Com`/`State`.  Stashed
@@ -963,7 +956,7 @@ inductive Aexp (V : Type) where
 -- TotalMap V Nat`, and `[DecidableEq V]` wherever a lookup/update is
 -- performed.
 ```
-````
+:::
 
 The `Bexp` definition is unchanged, except that it now refers to the new `Aexp`.
 
@@ -981,12 +974,12 @@ inductive Bexp where
 Defining a few variable names as shorthands will make examples easier
    to read.
 
-```instructors
+:::instructors
 We usually don't use x as a "bare identifier" in examples
    -- it is normally wrapped in an id constructor.  If this were _always_
-   the case, then it would make more sense to define the notation [x] to
-   mean [id (Id 0)].  But there quite a few counterexamples. Maybe we
-   could define [xx] to mean [id (Id 0)], or some such? But it's still
+   the case, then it would make more sense to define the notation `[x]` to
+   mean `[id (Id 0)]`.  But there quite a few counterexamples. Maybe we
+   could define `[xx]` to mean `[id (Id 0)]`, or some such? But it's still
    awkward.
    BCP/AAA 2/16: Should we use a coercion for this?  It means introducing a
    new concept -- a somewhat magical one -- but it will make examples look
@@ -998,7 +991,7 @@ We usually don't use x as a "bare identifier" in examples
    the global variables W, X, Y, Z for readability)
    BCP 7/20: This still needs another look to see if there's a way to make
    it globally better.
-```
+:::
 
 ```lean
 def W : Ident := "W"
@@ -1055,16 +1048,14 @@ syntax:max "~" term:max : imp_aexp
 syntax:min "aexp " "{" imp_aexp "}" : term
 ```
 
-::::hide
-```
-/- INSTRUCTORS: A variable reference elaborates to `Aexp.id $x` with the identifier spliced
-   as a *term*, not as a string literal. So `aexp { X }` is `Aexp.id X`, using
-   the declared constant `X : Ident`, exactly matching hand-written terms like
-   `.asgn X …` and the shape the state/`ceval` proofs expect. (Rocq's `<{ }>`
-   does the same via its `constr` fallback, yielding `AId X`.) A consequence is
-   that a variable name must be a declared `Ident` constant — as W/X/Y/Z are. -/
-```
-::::
+:::instructors
+A variable reference elaborates to `Aexp.id $x` with the identifier spliced
+as a *term*, not as a string literal. So `aexp { X }` is `Aexp.id X`, using
+the declared constant `X : Ident`, exactly matching hand-written terms like
+`.asgn X …` and the shape the state/`ceval` proofs expect. (Rocq's `<{ }>`
+does the same via its `constr` fallback, yielding `AId X`.) A consequence is
+that a variable name must be a declared `Ident` constant — as W/X/Y/Z are.
+:::
 
 ```lean
 open Lean in
@@ -1078,16 +1069,14 @@ macro_rules
   | `(aexp { ($a) }) => `(aexp {$a})
 ```
 
-::::hide
-```
-/- INSTRUCTORS: The literals `true`/`false` are accepted through the bare-identifier form
-   (`syntax:max ident : imp_bexp`) and turned into `Bexp.bool` by the macro
-   below, which rejects any other identifier. We take this route rather than
-   declaring `true`/`false` as symbols: as reserved keywords they would break
-   ordinary Lean uses of `true`/`false`, and as non-reserved symbols they would
-   clash with the bare-identifier form of `imp_aexp`. -/
-```
-::::
+:::instructors
+The literals `true`/`false` are accepted through the bare-identifier form
+(`syntax:max ident : imp_bexp`) and turned into `Bexp.bool` by the macro
+below, which rejects any other identifier. We take this route rather than
+declaring `true`/`false` as symbols: as reserved keywords they would break
+ordinary Lean uses of `true`/`false`, and as non-reserved symbols they would
+clash with the bare-identifier form of `imp_aexp`.
+:::
 
 ```lean
 /-- Boolean expressions of Imp -/
@@ -1115,14 +1104,12 @@ syntax:max "~" term:max : imp_bexp
 syntax:min "bexp " "{" imp_bexp "}" : term
 ```
 
-::::hide
-```
-/- INSTRUCTORS: The antiquotations are annotated with their category (`$a:imp_aexp`,
-   `$b:imp_bexp`) because an `imp_bexp` can begin with an `imp_aexp` (a
-   comparison); without the annotation the parser would descend into `imp_aexp`
-   and then insist on a comparison operator. -/
-```
-::::
+:::instructors
+The antiquotations are annotated with their category (`$a:imp_aexp`,
+`$b:imp_bexp`) because an `imp_bexp` can begin with an `imp_aexp` (a
+comparison); without the annotation the parser would descend into `imp_aexp`
+and then insist on a comparison operator.
+:::
 
 ```lean
 open Lean in
@@ -1243,7 +1230,7 @@ partial def delabAexpInner : DelabM (TSyntax `imp_aexp) := do
       | some v => pure ⟨Syntax.mkNumLit (toString v) |>.raw⟩
       | none   => `(imp_aexp| ~$(← withAppArg delab))
     | Aexp.id _ =>
-      -- INSTRUCTORS: a variable reference like aexp { X } elaborates to Aexp.id X where X is the declared Ident constant, so the delaborators print the constant's name as a bare identifier (and also handle the .id "X" string-literal form).
+      -- A variable reference like aexp { X } elaborates to Aexp.id X where X is the declared Ident constant, so the delaborators print the constant's name as a bare identifier (and also handle the .id "X" string-literal form).
       match ← withAppArg getExpr with
       | .const nm _      => `(imp_aexp| $(mkIdent nm):ident)
       | .lit (.strVal s) => `(imp_aexp| $(mkIdent (.mkSimple s)):ident)
@@ -1397,7 +1384,9 @@ example : aexp { Z + (X * Y) }.eval (X →ₜ 5 ; Y →ₜ 4 ; ∅) = 20 := by r
 example : bexp { true && !(X <= 4) }.eval (X →ₜ 5 ; ∅) = true := by rfl
 ```
 
+:::dev
 dsainati: Bikeshedding: I'm not sure how I feel about this arrow subscript for maps. Easy to change later but just flagging to discuss. mwhicks1: This comes from the Maps chapter, which chenson2018 is working on. There is a keyboard shortcut for ↦ we could use (\mapsto).
+:::
 
 # Commands
 
@@ -1581,7 +1570,7 @@ imp {
 ::::full
 The `imp { … }` notation, together with the delaborators, is purely a
 convenience for reading and writing programs. Occasionally, such as when debugging
-a definition or a stuck proof, the concrete syntax hides the underlying structure
+a definition or a stuck proof, the concrete syntax `hide`s the underlying structure
 we want to see. For those moments we can switch the Imp notation off in Lean's
 output with `set_option pp.notation false`, which our delaborators honor.
 
@@ -1684,13 +1673,13 @@ evaluation function tricky.
 Here's an attempt at defining an evaluation function for commands (with
 a bogus `while` case).
 
-```dev
+:::dev
 LATER: In SmallStep we need to package the state and command into a pair,
    so that we can talk about normal forms and such. Probably we should do it
    here too, for consistency. (Won't change much except the type
    declarations, but we'll need to add a comment why we wrote them this
    way.)
-```
+:::
 
 ```lean
 def Com.ceval_fun_no_while (st : State) (c : Com) : State :=
@@ -1736,11 +1725,11 @@ cannot be written in Lean -- at least not without additional tricks and
 workarounds.
 ::::
 
-```dev
-HIDE: Perhaps that discussion should be moved to -- or previewed in --
+:::dev
+   Perhaps that discussion should be moved to -- or previewed in --
    Logic.v?  MRC'20: It's already in ProofObjects (which not everyone
    sees).
-```
+:::
 
 :::terse
 A nonterminating `def loop_false (n) : False := loop_false n` would make `False` provable, so Lean rejects it.
@@ -1760,10 +1749,10 @@ definition of evaluation to be nondeterministic -- i.e., not only will it
 not be total, it will not even be a function!
 ::::
 
-```dev
+:::dev
 mwhicks1: I kind of hate this notation. Is there something more standard
 in Lean? CSLib precedent maybe?
-```
+:::
 
 We'll use the notation `st =[ c ]=> st'` for the `ceval` relation:
 `st =[ c ]=> st'` means that executing program `c` in a starting state
@@ -1775,10 +1764,10 @@ state `st` to `st'`".
 
 Operational Semantics
 
-```dev
-SOONER: BCP 21: I wonder if E_Seq would be easier to work with if st' and
+:::dev
+SOONER: BCP 21: I wonder if `E_Seq` would be easier to work with if st' and
    st'' were swapped...
-```
+:::
 
 Here is an informal definition of evaluation, presented as inference rules
 for readability:
@@ -1891,13 +1880,13 @@ example :
 What sorts of things might we want to prove using these definitions?  Here are some simple examples...
 :::
 
-```dev
-HIDE: PR: I phrased these quizzes with the following alternatives:
+:::dev
+  PR: I phrased these quizzes with the following alternatives:
    (A) Not true
    (B) True and easily provable
    (C) True and takes more work to prove
    (D) True and cannot be proved without additional axioms
-```
+:::
 
 ::::quiz
 Is the following proposition provable?
@@ -1934,9 +1923,9 @@ Is the following proposition provable?
 
 (A) Yes    (B) No    (C) Not sure
 
-```instructors
+:::instructors
 Answer is given later (`quiz2_answer`) as it depends on `ceval_deterministic`.
-```
+:::
 ::::
 
 ::::quiz
@@ -2009,27 +1998,26 @@ Is the following proposition provable?
 
 (A) Yes    (B) No    (C) Not sure
 
-````dev
-HIDE: This claim is *false*, so it cannot be proved -- the proof gets
-   stuck immediately:
+:::answer
+This claim is *false*, so it cannot be proved -- the proof gets
+stuck immediately:
 
-   ```
-   Lemma quiz5_answer: forall (b : bexp) (c : com) (st : state),
-     ~(exists st', st =[ while b do c end ]=> st') ->
-     forall st'', beval st'' b = true.
-   Proof.
-     intros b c st H st''.
-   Abort. (* Can't make any progress - claim is false! *)
-   ```
-````
+```
+theorem quiz5_answer (b : Bexp) (c : Com) (st : State)
+    (H : ¬ ∃ st', st =[ imp { while (~b) { ~c } } ]=> st') :
+    ∀ st'', Bexp.eval st'' b = true := by
+  intro st''
+  -- Can't make any progress -- the claim is false!
+```
+:::
 ::::
 
 ## Determinism of Evaluation
 
-```dev
+:::dev
 LATER: Maybe this should go at the end of the file in a section marked
    optional? Not everybody will want to spend time on it.
-```
+:::
 
 ::::full
 Changing from a computational to a relational definition of evaluation
@@ -2044,10 +2032,10 @@ In fact this cannot happen: `ceval` _is_ a partial function.
 Finally, we should pause to check that our evaluation relation really is a (partial) function...
 :::
 
-```dev
+:::dev
 LATER: Informal proof needed! (And one can surely be found in some past
    CIS500 exam solutions!)
-```
+:::
 
 ```lean
 theorem ceval_deterministic (c : Com) (st st1 st2 : State)
@@ -2117,10 +2105,10 @@ def pup_to_n : Com := solution!(
   })
 ```
 
-```dev
-HIDE: Result is the same as `(X →ₜ 0 ; Y →ₜ 3 ; ∅)` if one admits
+:::hide
+   Result is the same as `(X →ₜ 0 ; Y →ₜ 3 ; ∅)` if one admits
    functional extensionality.
-```
+:::
 
 ```lean
 theorem pup_to_2_ceval :
@@ -2143,17 +2131,17 @@ theorem pup_to_2_ceval :
 ```
 :::::
 
-```dev
+:::dev
 LATER: Comment from reader: Another good place to mention lack of
    functional extensionality.  The 6 `→ₜ`/`t_update`s in the above theorem
    are not redundant, nor would `pup_to_2_ceval` be provable if the
    algorithm were defined differently (e.g., if it used `Z` as a "buffer"
    variable instead of decrementing `X`).
-```
+:::
 
 # Reasoning About Imp Programs
 
-```dev
+:::dev
 LATER: This section doesn't seem very useful -- to anybody! It takes too
    much time to go through it in class, and even for advanced students it's
    too low-level and grubby to be a very convincing motivation for what
@@ -2164,7 +2152,7 @@ LATER: This section doesn't seem very useful -- to anybody! It takes too
    (BCP 10/18: However, this removes quite a few exercises. Is the homework
    assignment still meaty enough? I'm going to leave it as-is for now, but
    we should reconsider this later.)
-```
+:::
 
 ::::full
 We'll get into more systematic and powerful techniques for reasoning
@@ -2187,9 +2175,9 @@ theorem plus2_spec (st : State) (n : Nat) (st' : State)
       lia
 ```
 
-```dev
+:::dev
 LATER: This used to be recommended.  Should it be reinstated?
-```
+:::
 
 :::::exercise (rating := 3) (name := "XtimesYinZ_spec")
 State and prove a specification of `XtimesYinZ`.
@@ -2256,7 +2244,7 @@ theorem loop_never_stops (st st' : State) : ¬ (st =[ loop ]=> st') := by
 ```
 :::::
 
-```dev
+:::dev
 LATER: Marc Bezem 2022:
    There are trade-offs between using tactics and additional lemmas. Here is
    a case where a lemma would make things clearer. For `loop_never_stops`,
@@ -2264,8 +2252,10 @@ LATER: Marc Bezem 2022:
    `remember` is hard to understand. The following formulation explains the
    induction better:
 
+```
      Theorem loop_never_stops' : forall st st' c,
        st =[ c ]=> st' -> c = loop -> False.
+```
 
    The equivalence of the two formulations is an easy lemma.  (Note: the Lean
    proof above already takes exactly this generalized-`key` shape.)
@@ -2273,7 +2263,7 @@ LATER: Marc Bezem 2022:
    statements are negations, and the `remember` in the proof is avoided in
    the new one by introducing an equality in the theorem statement that IMO
    is not very pretty...
-```
+:::
 
 :::::exercise (rating := 3) (name := "no_whiles_eqv")
 The following function yields `true` just on programs with no while
@@ -2376,7 +2366,8 @@ theorem no_whiles_terminating' (c : Com) (st1 : State)
 ```
 :::::
 
-```dev
+:::dev
+```
 mwhicks1: NOT PORTED YET — remaining sections of sfdev/lf/Imp.v to port:
   - Case Study (Optional), Imp.v:2774
       * subtract_slowly_spec (EX4?, Imp.v:2919): loop-invariant style proof
@@ -2400,3 +2391,4 @@ mwhicks1: NOT PORTED YET — remaining sections of sfdev/lf/Imp.v to port:
       * add_for_loop (EX4?, Imp.v:3728): add a C-style `for` loop to Com,
         its notation, and extend ceval.
 ```
+:::

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -324,7 +324,7 @@ theorem optimize_0plus_sound (a : Aexp) :
 # Optimizing Booleans
 
 :::::exercise (rating := 3) (name := "optimize_0plus_b_sound")
-Since the `Aexp.optimize_0plus` transformation doesn't change the value of an
+Since the {name}`Aexp.optimize_0plus` transformation doesn't change the value of an
 `Aexp`, we should be able to apply it to all the `Aexp`s that appear in a
 `Bexp` without changing the `Bexp`'s value.  Write a function that
 performs this transformation on `Bexp`s and prove it sound.  Use the
@@ -387,7 +387,7 @@ GRADE_THEOREM 2: optimize_0plus_b_sound
 # Evaluation as a Relation
 
 ::::full
-We have presented `Aexp.eval` and `Bexp.eval` as functions defined by
+We have presented {name}`Aexp.eval` and {name}`Bexp.eval` as functions defined by
 recursion. Another way to think about evaluation -- one that is often
 more flexible -- is as a _relation_ between expressions and their
 values. This perspective leads to inductive definitions like the
@@ -442,7 +442,7 @@ names chosen during proofs involving the relation, at the cost of making
 the definition a little more verbose. We adopt the named style.
 ::::
 
-It will be convenient to have an infix notation for `Aexp.evalR`.  We'll
+It will be convenient to have an infix notation for {name}`Aexp.evalR`.  We'll
 write `e ⇓ n` to mean that arithmetic expression `e` evaluates to
 value `n`.  (We scope the notation to this namespace so it doesn't
 collide with other evaluation relations later.)  In Lean the notation is
@@ -456,7 +456,7 @@ scoped notation:55 e:56 " ⇓ " n:56 => Aexp.evalR e n
 
 ::::full
 In informal discussions, it is convenient to write the rules for
-`Aexp.evalR` and similar relations in the more readable graphical form of
+{name}`Aexp.evalR` and similar relations in the more readable graphical form of
 _inference rules_, where the premises above the line justify the
 conclusion below the line.  For example, the constructor `E_APlus`
 
@@ -571,7 +571,7 @@ mwhicks1: Not sure if we need ⇓b, or whether we can define
 :::
 
 :::::exercise (rating := 1) (name := "beval_rules")
-Here, again, is the definition of the `Bexp.eval` function:
+Here, again, is the definition of the {name}`Bexp.eval` function:
 
 ```
 def Bexp.eval (b : Bexp) : Bool :=
@@ -680,8 +680,8 @@ theorem aevalR_iff_aeval' (a : Aexp) (n : Nat) :
 ```
 
 :::::exercise (rating := 3) (name := "bevalR")
-Write a relation `Bexp.evalR` in the same style as `Aexp.evalR`, and prove that
-it is equivalent to `Bexp.eval`.
+Write a relation `Bexp.evalR` in the same style as {name}`Aexp.evalR`, and prove that
+it is equivalent to {name}`Bexp.eval`.
 
 ```lean
 inductive Bexp.evalR : Bexp → Bool → Prop where
@@ -1008,6 +1008,9 @@ overloading should not cause confusion.)
 ::::
 
 ## Notations
+%%%
+tag := "imp-notations"
+%%%
 
 ::::full
 To make Imp programs easier to read and write, we introduce some notations and implicit
@@ -1071,7 +1074,7 @@ macro_rules
 
 :::instructors
 The literals `true`/`false` are accepted through the bare-identifier form
-(`syntax:max ident : imp_bexp`) and turned into `Bexp.bool` by the macro
+(`syntax:max ident : imp_bexp`) and turned into {name}`Bexp.bool` by the macro
 below, which rejects any other identifier. We take this route rather than
 declaring `true`/`false` as symbols: as reserved keywords they would break
 ordinary Lean uses of `true`/`false`, and as non-reserved symbols they would
@@ -1157,7 +1160,7 @@ instance : Coe Bool Bexp where
 With these coercions we can write `.plus 3 (.mult X 2)` instead of the fully
    explicit `.plus (.num 3) (.mult (.id "X") (.num 2))`, and `.and true (.not …)`
    instead of `.and (.bool true) (.not …)`. More readably still, the concrete
-   syntax from the Notations section lets us write these examples directly:
+   syntax from the {ref "imp-notations"}[Notations section] lets us write these examples directly:
 ::::
 
 ```lean
@@ -1166,6 +1169,9 @@ def example_bexp : Bexp := bexp { true && !(X <= 4) }
 ```
 
 ## Delaborators
+%%%
+tag := "imp-delaborators"
+%%%
 
 ::::full
 The notations above are _input_ only: they teach Lean how to *read* `aexp
@@ -1429,7 +1435,7 @@ declare_syntax_cat imp_com
 `skip` is *not* a reserved keyword: it is accepted through a bare
    identifier-terminated command (`syntax ident ";" : imp_com`) and recognised
    in the macro below, which rejects any other identifier. This keeps `skip`
-   usable as the bare constructor name `Com.skip` in `match`/`induction`
+   usable as the bare constructor name {name}`Com.skip` in `match`/`induction`
    elsewhere in the file, and avoids reserving `skip` globally.
 
 ```lean
@@ -1468,8 +1474,9 @@ macro_rules
 
 ::::full
 Just as we did for expressions, we add a delaborator so that Lean prints
-commands back in the `imp { … }` concrete syntax (see the Delaborators
-section above). It reuses the expression delaborators for the condition of an
+commands back in the `imp { … }` concrete syntax (see the
+{ref "imp-delaborators"}[Delaborators section] above). It reuses the expression
+delaborators for the condition of an
 `if`/`while` and for the right-hand side of an assignment, and prints an
 unrecognized subcommand with the `~` escape.
 ::::
@@ -1577,7 +1584,7 @@ output with `set_option pp.notation false`, which our delaborators honor.
 Note that unlike a `def`, `imp { … }` is a `macro` which is expanded during elaboration,
 *before* the resulting term is type-checked. So `fact_in_lean` is not a
 program hidden behind a layer of notation that a proof must first peel back;
-it simply *is* the underlying tree of `Com`, `Aexp`, and `Bexp` constructors.
+it simply *is* the underlying tree of {name}`Com`, {name}`Aexp`, and {name}`Bexp` constructors.
 Consequently, when a proof goal mentions an Imp program, tactics such as
 `cases`, `injection`, and `simp` already act on those constructors directly
 -- there is nothing to "unfold". The delaborators affect only how that tree
@@ -2314,7 +2321,7 @@ theorem no_whiles_eqv (c : Com) : Com.no_whiles c = true ↔ NoWhilesR c := by
 :::::exercise (rating := 4) (name := "no_whiles_terminating")
 Imp programs that don't involve while loops always terminate.  State and
 prove a theorem `no_whiles_terminating` that says this.  Use either
-`Com.no_whiles` or `NoWhilesR`, as you prefer.
+{name}`Com.no_whiles` or {name}`NoWhilesR`, as you prefer.
 
 ```lean
 theorem no_whiles_terminating (c : Com) (st : State) (h : NoWhilesR c) :
@@ -2338,7 +2345,7 @@ theorem no_whiles_terminating (c : Com) (st : State) (h : NoWhilesR c) :
 ```
 
 And here is an alternative solution by induction on `c` (using
-   `Com.no_whiles` instead of `NoWhilesR`):
+   {name}`Com.no_whiles` instead of {name}`NoWhilesR`):
 
 ```lean
 -- SOLUTION
@@ -2390,5 +2397,29 @@ mwhicks1: NOT PORTED YET — remaining sections of sfdev/lf/Imp.v to port:
       * exn_imp (EX4A?, Imp.v:3524): exceptions variant. Large.
       * add_for_loop (EX4?, Imp.v:3728): add a C-style `for` loop to Com,
         its notation, and extend ceval.
+```
+:::
+
+:::dev
+```
+HTML polish — deferred Verso-markup opportunities for a later pass (see
+CONTRIBUTING.md, "Verso markup for nicer HTML"):
+* {name} was applied to resolvable declaration references in visible prose.
+  More could be added, but bare type names were linked only selectively (avoid
+  over-linking; mind forward references and the `Warmup` namespace — a name must
+  already be defined and in scope at that point in the document, or {name} fails
+  to build).
+* {ref "tag"} cross-references link "see the X section" phrasings; add a
+  `%%% tag := "…" %%%` block under a heading to make it a target. Done for the
+  Notations and Delaborators sections; more internal "above/below" phrasings
+  could get the same treatment.
+* {tactic}`simp` — link tactic names in the automation/tactics prose (`try`,
+  `repeat`, `<;>`, `simp`, `lia`, `cases`, `induction`).
+* {deftech}/{tech} — a small glossary: define Imp's core terms once with
+  {deftech} (abstract syntax, state, big-step, relation, partial function, …)
+  and link later uses with {tech}.
+* {lean}`expr` — inline elaborated expressions/types where a whole expression,
+  not just a single name, reads better with hover types (e.g. the
+  `Coe Ident Aexp` / `OfNat Aexp n` bullets in the Notations section).
 ```
 :::

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -1,102 +1,127 @@
-/- Imp: Simple Imperative Programs -/
+import VersoManual
+import VersoManual.InlineLean
+import Illuminate
+import SFLMeta.Bnf
+import SFLMeta.Ignore
+import SFLMeta.Save
+import SFLMeta.Comment
+import SFLMeta.Exercise
+import SFLMeta.Grade
+import SFLMeta.Hide
+import SFLMeta.Instructors
+import SFLMeta.Quiz
+import SFLMeta.SlideBreak
+import SFLMeta.Solution
+import SFLMeta.Terse
+import LF.Maps
+import Lean.PrettyPrinter.Delaborator
+import Lean.PrettyPrinter.Parenthesizer
+open Verso.Genre Manual
+open SFLMeta
 
-/- INSTRUCTORS: This chapter plus `Maps` takes a little more than one
+open InlineLean hiding lean
+
+#doc (Manual) "Imp: Simple Imperative Programs" =>
+%%%
+tag := "Imp"
+htmlSplit := .never
+file := some "Imp"
+%%%
+
+```instructors
+This chapter plus `Maps` takes a little more than one
    80-minute lecture.  It could be streamlined a bit further without
    losing much, by removing (for example) the inference rules and BNF
    notations from the terse version.
 
    (BCP 21: ... Actually, I tried removing inference rules from the
    TERSE version; eventually decided that it makes some of the
-   definitions harder to talk about.) -/
-/- SOONER: Needs some WORKINCLASSes and some quizzes -/
-/- LATER: Another nice challenge exercise at some point would be to add
+   definitions harder to talk about.)
+```
+
+```dev
+SOONER: Needs some WORKINCLASSes and some quizzes
+
+LATER: Another nice challenge exercise at some point would be to add
    C-style arrays (i.e., indirect read/write).  This sets up some
    really nice challenge problems in Hoare (reasoning about arrays /
-   aliasing / etc.). -/
-/- SOONER: BCP 25: Maybe we should write /\ instead of && in assertions,
-   to save a mismatch in the dec_minimum exercise in Hoare2? -/
-/- HIDE: At some point we could consider moving material from the old
+   aliasing / etc.).
+
+SOONER: BCP 25: Maybe we should write /\ instead of && in assertions,
+   to save a mismatch in the dec_minimum exercise in Hoare2?
+
+HIDE: At some point we could consider moving material from the old
    HoareLists to this chapter (and into later files, as
    appropriate).  We haven't done it yet because it's a shame to
    complicate the nice simple presentation here when it's used as the
    basis for applications like Xavier's static analysis lectures.
-   Also, we now have a whole volume on real separation logic... -/
+   Also, we now have a whole volume on real separation logic...
 
--- MWH (port note): The Rocq chapter's "Rocq Automation" tour has been
--- retooled here for Lean.  The tactic combinators `try` and `repeat` (and the
--- custom-tactic `macro`) are introduced in this chapter; `<;>` and `simp` were
--- already introduced in Logical Foundations (`<;>` in `Induction`)
--- so we use them freely and the `<;>` section
--- below is a recap.  For linear arithmetic we use `lia`;
--- NOTE that LF currently
--- introduces `omega`, not `lia`, so this needs to be reconciled volume-wide
--- (either introduce `lia` in LF, or keep `omega`).
+MWH (port note): The Rocq chapter's "Rocq Automation" tour has been
+retooled here for Lean.  The tactic combinators `try` and `repeat` (and the
+custom-tactic `macro`) are introduced in this chapter; `<;>` and `simp` were
+already introduced in Logical Foundations (`<;>` in `Induction`)
+so we use them freely and the `<;>` section
+below is a recap.  For linear arithmetic we use `lia`;
+NOTE that LF currently
+introduces `omega`, not `lia`, so this needs to be reconciled volume-wide
+(either introduce `lia` in LF, or keep `omega`).
+```
 
-import LF.Maps
-import Lean.PrettyPrinter.Delaborator
-import Lean.PrettyPrinter.Parenthesizer
+::::full
+In this chapter, we take a more serious look at how to use Lean as a
+tool to study other things.  Our case study is a _simple imperative
+programming language_ called Imp, embodying a tiny core fragment of
+conventional mainstream languages such as C and Java.
 
--- FULL
-/-
-  In this chapter, we take a more serious look at how to use Lean as a
-  tool to study other things.  Our case study is a _simple imperative
-  programming language_ called Imp, embodying a tiny core fragment of
-  conventional mainstream languages such as C and Java.
+Here is a familiar mathematical function written in Imp.
 
-  Here is a familiar mathematical function written in Imp.
+```
+Z := X;
+Y := 1;
+while Z <> 0 do
+  Y := Y * Z;
+  Z := Z - 1
+end
+```
+::::
 
-  ```
-  Z := X;
-  Y := 1;
-  while Z <> 0 do
-    Y := Y * Z;
-    Z := Z - 1
-  end
-  ```
--/
--- /FULL
--- HIDEFROMADVANCED
-/-
-  We concentrate here on defining the _syntax_ and _semantics_ of Imp;
-  later in this volume we develop a theory of _program equivalence_ and introduce
-  _Hoare Logic_, a popular logic for reasoning about imperative programs.
--/
--- /HIDEFROMADVANCED
+We concentrate here on defining the _syntax_ and _semantics_ of Imp;
+later in this volume we develop a theory of _program equivalence_ and introduce
+_Hoare Logic_, a popular logic for reasoning about imperative programs.
 
-/-
-  ######################################################################
-  # Arithmetic and Boolean Expressions
--/
+# Arithmetic and Boolean Expressions
 
-/- SOONER: At this point, I usually take some of the lecture time to
+```dev
+SOONER: At this point, I usually take some of the lecture time to
    give a high-level picture of the structure of an interpreter, the
    processes of lexing and parsing, the notion of ASTs, etc.  Might be
-   nice to work some of those ideas into the notes. - BCP -/
+   nice to work some of those ideas into the notes. - BCP
+```
 
--- FULL
-/-
-  We'll present Imp in three parts: first a core language of _arithmetic
-  and boolean expressions_, then an extension of these with _variables_,
-  and finally a language of _commands_ including assignment, conditionals,
-  sequencing, and loops.
--/
--- /FULL
+::::full
+We'll present Imp in three parts: first a core language of _arithmetic
+and boolean expressions_, then an extension of these with _variables_,
+and finally a language of _commands_ including assignment, conditionals,
+sequencing, and loops.
+::::
 
-/-
-  ######################################################################
-  ## Syntax
--/
+## Syntax
 
+```lean
 namespace AExp
+```
 
--- FULL
-/-
-  These two definitions specify the _abstract syntax_ of arithmetic and
-  boolean expressions.
--/
--- /FULL
--- TERSE: /- Abstract syntax trees for arithmetic and boolean expressions: -/
+::::full
+These two definitions specify the _abstract syntax_ of arithmetic and
+boolean expressions.
+::::
 
+:::terse
+Abstract syntax trees for arithmetic and boolean expressions:
+:::
+
+```lean
 inductive Aexp where
   | num (n : Nat)
   | plus (a1 a2 : Aexp)
@@ -111,88 +136,87 @@ inductive Bexp where
   | gt (a1 a2 : Aexp)
   | not (b : Bexp)
   | and (b1 b2 : Bexp)
+```
 
--- MWH: Will we develop `ImpParser`? Mentioned below as an optional chapter
--- FULL
-/-
-  In this chapter, we'll mostly elide the translation from the concrete
-  syntax that a programmer would actually write to these abstract syntax
-  trees -- the process that, for example, would translate the string
-  `"1 + 2 * 3"` to the AST
+```dev
+MWH: Will we develop `ImpParser`? Mentioned below as an optional chapter
+```
 
-  ```
-  .plus (.num 1) (.mult (.num 2) (.num 3))
-  ```
+::::full
+In this chapter, we'll mostly elide the translation from the concrete
+syntax that a programmer would actually write to these abstract syntax
+trees -- the process that, for example, would translate the string
+`"1 + 2 * 3"` to the AST
 
-  The optional chapter `ImpParser` develops a simple lexical analyzer and
-  parser that can perform this translation.  You do not need to understand
-  that chapter to understand this one, but if you haven't already taken a
-  course where these techniques are covered (e.g., a course on compilers)
-  you may want to skim it.
+```
+.plus (.num 1) (.mult (.num 2) (.num 3))
+```
 
-  For comparison, here's a conventional BNF (Backus-Naur Form) grammar
-  defining the same abstract syntax:
+The optional chapter `ImpParser` develops a simple lexical analyzer and
+parser that can perform this translation.  You do not need to understand
+that chapter to understand this one, but if you haven't already taken a
+course where these techniques are covered (e.g., a course on compilers)
+you may want to skim it.
 
-  ```
-  a := nat
-      | a + a
-      | a - a
-      | a * a
+For comparison, here's a conventional BNF (Backus-Naur Form) grammar
+defining the same abstract syntax:
 
-  b := bool
-      | a = a
-      | a <> a
-      | a <= a
-      | a > a
-      | ~ b
-      | b && b
-  ```
+```
+a := nat
+    | a + a
+    | a - a
+    | a * a
 
-  Compared to the Lean version above...
+b := bool
+    | a = a
+    | a <> a
+    | a <= a
+    | a > a
+    | ~ b
+    | b && b
+```
 
-    - The BNF is more informal -- for example, it gives some suggestions
-      about the surface syntax of expressions (like the fact that the
-      addition operation is written with an infix `+`) while leaving other
-      aspects of lexical analysis and parsing (like the relative precedence
-      of `+`, `-`, and `*`, the use of parens to group subexpressions, etc.)
-      unspecified.  Some additional information -- and human intelligence --
-      would be required to turn this description into a formal definition,
-      e.g., for implementing a compiler.
+Compared to the Lean version above...
 
-      The Lean version consistently omits all this information and
-      concentrates on the abstract syntax only.
+  - The BNF is more informal -- for example, it gives some suggestions
+    about the surface syntax of expressions (like the fact that the
+    addition operation is written with an infix `+`) while leaving other
+    aspects of lexical analysis and parsing (like the relative precedence
+    of `+`, `-`, and `*`, the use of parens to group subexpressions, etc.)
+    unspecified.  Some additional information -- and human intelligence --
+    would be required to turn this description into a formal definition,
+    e.g., for implementing a compiler.
 
-    - Conversely, the BNF version is lighter and easier to read.  Its
-      informality makes it flexible, a big advantage in situations like
-      discussions at the blackboard, where conveying general ideas is more
-      important than nailing down every detail precisely.
+    The Lean version consistently omits all this information and
+    concentrates on the abstract syntax only.
 
-      Indeed, there are dozens of BNF-like notations and people switch
-      freely among them -- usually without bothering to say which kind of
-      BNF they're using, because there is no need to: a rough-and-ready
-      informal understanding is all that's important.
+  - Conversely, the BNF version is lighter and easier to read.  Its
+    informality makes it flexible, a big advantage in situations like
+    discussions at the blackboard, where conveying general ideas is more
+    important than nailing down every detail precisely.
 
-  It's good to be comfortable with both sorts of notations: informal ones
-  for communicating between humans and formal ones for carrying out
-  implementations and proofs.
--/
--- /FULL
+    Indeed, there are dozens of BNF-like notations and people switch
+    freely among them -- usually without bothering to say which kind of
+    BNF they're using, because there is no need to: a rough-and-ready
+    informal understanding is all that's important.
 
+It's good to be comfortable with both sorts of notations: informal ones
+for communicating between humans and formal ones for carrying out
+implementations and proofs.
+::::
 
+## Evaluation
 
-/-
-  ######################################################################
-  ## Evaluation
--/
+_Evaluating_ an arithmetic expression produces a number.
 
-/- _Evaluating_ an arithmetic expression produces a number. -/
-
-/- chenson2018: TODO: seal evaluators with `@[irreducible]` and prove
+```dev
+chenson2018: TODO: seal evaluators with `@[irreducible]` and prove
    *characterizing lemmas* (one
    `rfl` equation per constructor) that proofs rewrite with instead of
    unfolding the definition; tag lemmas `@[simp]`.
- -/
+```
 
+```lean
 def Aexp.eval (a : Aexp) : Nat :=
   match a with
   | num   n     =>  n
@@ -201,9 +225,11 @@ def Aexp.eval (a : Aexp) : Nat :=
   | mult  a1 a2 =>  eval a1 * eval a2
 
 example : Aexp.eval (.plus (.num 2) (.num 2)) = 4 := by rfl
+```
 
-/- Similarly, evaluating a boolean expression yields a boolean. -/
+Similarly, evaluating a boolean expression yields a boolean.
 
+```lean
 def Bexp.eval (b : Bexp) : Bool :=
   match b with
   | bool b     =>  b
@@ -213,33 +239,28 @@ def Bexp.eval (b : Bexp) : Bool :=
   | gt   a1 a2 =>  a1.eval > a2.eval
   | not  b1    =>  !eval b1
   | and  b1 b2 =>  eval b1 && eval b2
+```
 
--- QUIZ
-/-
-  What does the following expression evaluate to?
+::::quiz
+What does the following expression evaluate to?
 
-  ```
-  Aexp.eval (.plus (.num 3) (.minus (.num 4) (.num 1)))
-  ```
+```
+Aexp.eval (.plus (.num 3) (.minus (.num 4) (.num 1)))
+```
 
-  (A) true    (B) false    (C) 0    (D) 3    (E) 6
--/
--- /QUIZ
+(A) true    (B) false    (C) 0    (D) 3    (E) 6
+::::
 
-/-
-  ######################################################################
-  ## Optimization
--/
+## Optimization
 
--- FULL
-/-
-  We haven't defined very much yet, but we can already get some mileage
-  out of the definitions. Suppose we define a function that takes an
-  arithmetic expression and slightly simplifies it, changing every
-  occurrence of `0 + e` (i.e., `.plus (.num 0) e`) into just `e`.
--/
--- /FULL
+::::full
+We haven't defined very much yet, but we can already get some mileage
+out of the definitions. Suppose we define a function that takes an
+arithmetic expression and slightly simplifies it, changing every
+occurrence of `0 + e` (i.e., `.plus (.num 0) e`) into just `e`.
+::::
 
+```lean
 def Aexp.optimize_0plus (a : Aexp) : Aexp :=
   match a with
   | num   n          => num n
@@ -247,33 +268,32 @@ def Aexp.optimize_0plus (a : Aexp) : Aexp :=
   | plus  e1      e2 => plus  (optimize_0plus e1) (optimize_0plus e2)
   | minus e1      e2 => minus (optimize_0plus e1) (optimize_0plus e2)
   | mult  e1      e2 => mult  (optimize_0plus e1) (optimize_0plus e2)
+```
 
--- FULL
-/-
-  To gain confidence that our optimization is doing the right thing we
-  can test it on some examples and see if the output looks OK.
--/
--- /FULL
+::::full
+To gain confidence that our optimization is doing the right thing we
+can test it on some examples and see if the output looks OK.
+::::
 
-/- test_optimize_0plus -/
+```lean
 example :
     Aexp.optimize_0plus (.plus (.num 2)
                                (.plus (.num 0)
                                       (.plus (.num 0) (.num 1))))
       = .plus (.num 2) (.num 1) := by rfl
+```
 
--- FULL
-/-
-  But if we want to be certain the optimization is correct -- that
-  evaluating an optimized expression _always_ gives the same result as
-  the original -- we should prove it!
+::::full
+But if we want to be certain the optimization is correct -- that
+evaluating an optimized expression _always_ gives the same result as
+the original -- we should prove it!
 
-  Here is a first, deliberately explicit proof. It works, but notice how
-  much of it is repetitive: several cases are discharged by exactly the
-  same three-step incantation.
--/
--- /FULL
+Here is a first, deliberately explicit proof. It works, but notice how
+much of it is repetitive: several cases are discharged by exactly the
+same three-step incantation.
+::::
 
+```lean
 theorem optimize_0plus_sound (a : Aexp) :
     a.optimize_0plus.eval = a.eval := by
   induction a with
@@ -303,24 +323,20 @@ theorem optimize_0plus_sound (a : Aexp) :
   | mult a1 a2 ih1 ih2 =>
     simp only [Aexp.optimize_0plus, Aexp.eval]
     rw [ih1, ih2]
+```
 
-/-
-  ######################################################################
-  # Optimizing Booleans
--/
+# Optimizing Booleans
 
--- EX3 (optimize_0plus_b_sound)
-/-
-  Since the `Aexp.optimize_0plus` transformation doesn't change the value of an
-  `Aexp`, we should be able to apply it to all the `Aexp`s that appear in a
-  `Bexp` without changing the `Bexp`'s value.  Write a function that
-  performs this transformation on `Bexp`s and prove it sound.  Use the
-  combinators we've just seen to make the proof as short and elegant as
-  possible.
--/
+:::::exercise (rating := 3) (name := "optimize_0plus_b_sound")
+Since the `Aexp.optimize_0plus` transformation doesn't change the value of an
+`Aexp`, we should be able to apply it to all the `Aexp`s that appear in a
+`Bexp` without changing the `Bexp`'s value.  Write a function that
+performs this transformation on `Bexp`s and prove it sound.  Use the
+combinators we've just seen to make the proof as short and elegant as
+possible.
 
-def Bexp.optimize_0plus_b (b : Bexp) : Bexp :=
-  -- ADMITDEF
+```lean
+def Bexp.optimize_0plus_b (b : Bexp) : Bexp := solution!(
   match b with
   | bool b    =>  bool b
   | eq a1 a2  =>  eq a1.optimize_0plus a2.optimize_0plus
@@ -328,50 +344,62 @@ def Bexp.optimize_0plus_b (b : Bexp) : Bexp :=
   | le a1 a2  =>  le a1.optimize_0plus a2.optimize_0plus
   | gt a1 a2  =>  gt a1.optimize_0plus a2.optimize_0plus
   | not b1    =>  not (optimize_0plus_b b1)
-  | and b1 b2 =>  and (optimize_0plus_b b1) (optimize_0plus_b b2)
-  -- /ADMITDEF
+  | and b1 b2 =>  and (optimize_0plus_b b1) (optimize_0plus_b b2))
 
-/- optimize_0plus_b_test1 -/
 example :
     Bexp.optimize_0plus_b
         (.not (.gt (.plus (.num 0) (.num 4)) (.num 8)))
-      = (.not (.gt (.num 4) (.num 8))) := by rfl -- ADMITTED
--- GRADE_THEOREM 0.5: optimize_0plus_b_test1
+      = (.not (.gt (.num 4) (.num 8))) := solution!(by rfl)
+```
 
-/- optimize_0plus_b_test2 -/
+:::grade
+```
+GRADE_THEOREM 0.5: optimize_0plus_b_test1
+```
+:::
+
+```lean
 example :
     Bexp.optimize_0plus_b
         (.and (.le (.plus (.num 0) (.num 4)) (.num 5)) (.bool true))
-      = (.and (.le (.num 4) (.num 5)) (.bool true)) := by rfl -- ADMITTED
--- GRADE_THEOREM 0.5: optimize_0plus_b_test2
+      = (.and (.le (.num 4) (.num 5)) (.bool true)) := solution!(by rfl)
+```
 
+:::grade
+```
+GRADE_THEOREM 0.5: optimize_0plus_b_test2
+```
+:::
+
+```lean
 theorem optimize_0plus_b_sound (b : Bexp) :
     b.optimize_0plus_b.eval = b.eval := by
-  -- ADMITTED
-  induction b with
-  | not b1 ih => simp only [Bexp.optimize_0plus_b, Bexp.eval]; rw [ih]
-  | and b1 b2 ih1 ih2 => simp only [Bexp.optimize_0plus_b, Bexp.eval]; rw [ih1, ih2]
-  | _ => simp only [Bexp.optimize_0plus_b, Bexp.eval, optimize_0plus_sound]
-  -- /ADMITTED
--- GRADE_THEOREM 2: optimize_0plus_b_sound
--- []
+  solution!
+    induction b with
+    | not b1 ih => simp only [Bexp.optimize_0plus_b, Bexp.eval]; rw [ih]
+    | and b1 b2 ih1 ih2 => simp only [Bexp.optimize_0plus_b, Bexp.eval]; rw [ih1, ih2]
+    | _ => simp only [Bexp.optimize_0plus_b, Bexp.eval, optimize_0plus_sound]
+```
 
-/-
-  ######################################################################
-  # Evaluation as a Relation
--/
+:::grade
+```
+GRADE_THEOREM 2: optimize_0plus_b_sound
+```
+:::
+:::::
 
--- FULL
-/-
-  We have presented `Aexp.eval` and `Bexp.eval` as functions defined by
-  recursion. Another way to think about evaluation -- one that is often
-  more flexible -- is as a _relation_ between expressions and their
-  values. This perspective leads to inductive definitions like the
-  following. We name the hypotheses in each case (`h1`, `h2`); this
-  gives us readable names to refer to during proofs.
--/
--- /FULL
+# Evaluation as a Relation
 
+::::full
+We have presented `Aexp.eval` and `Bexp.eval` as functions defined by
+recursion. Another way to think about evaluation -- one that is often
+more flexible -- is as a _relation_ between expressions and their
+values. This perspective leads to inductive definitions like the
+following. We name the hypotheses in each case (`h1`, `h2`); this
+gives us readable names to refer to during proofs.
+::::
+
+```lean
 inductive Aexp.evalR : Aexp → Nat → Prop where
   | E_ANum (n : Nat) :
       Aexp.evalR (.num n) n
@@ -384,149 +412,148 @@ inductive Aexp.evalR : Aexp → Nat → Prop where
   | E_AMult (a1 a2 : Aexp) (n1 n2 : Nat)
       (h1 : Aexp.evalR a1 n1) (h2 : Aexp.evalR a2 n2) :
       Aexp.evalR (.mult a1 a2) (n1 * n2)
+```
 
--- chenson2018: There is still some naming weirdness in the relation forms of evaluation that should be addressed later.
--- mwhicks1: I think this comment is about wanting to call `evalR` something like `Rel`, but it's not clear to me that I want to do that, e.g., since there are multiple evaluation relations (such as big-step and small-step) there won't be just one name
+```dev
+chenson2018: There is still some naming weirdness in the relation forms of evaluation that should be addressed later.
 
--- FULL
-/-
-  A small notational aside. We could instead have presented this relation
-  with *positional* hypotheses -- no names for the premises:
+mwhicks1: I think this comment is about wanting to call `evalR` something like `Rel`, but it's not clear to me that I want to do that, e.g., since there are multiple evaluation relations (such as big-step and small-step) there won't be just one name
+```
 
-  ```
-  inductive Aexp.evalR : Aexp → Nat → Prop where
-    | E_ANum (n : Nat) :
-        Aexp.evalR (.num n) n
-    | E_APlus (e1 e2 : Aexp) (n1 n2 : Nat) :
-        Aexp.evalR e1 n1 →
-        Aexp.evalR e2 n2 →
-        Aexp.evalR (.plus e1 e2) (n1 + n2)
-    | E_AMinus (e1 e2 : Aexp) (n1 n2 : Nat) :
-        Aexp.evalR e1 n1 →
-        Aexp.evalR e2 n2 →
-        Aexp.evalR (.minus e1 e2) (n1 - n2)
-    | E_AMult (e1 e2 : Aexp) (n1 n2 : Nat) :
-        Aexp.evalR e1 n1 →
-        Aexp.evalR e2 n2 →
-        Aexp.evalR (.mult e1 e2) (n1 * n2)
-  ```
+::::full
+A small notational aside. We could instead have presented this relation
+with *positional* hypotheses -- no names for the premises:
 
-  The version above instead gives explicit names to the hypotheses in each
-  case (the `h1`/`h2`). Naming the hypotheses gives us more control over the
-  names chosen during proofs involving the relation, at the cost of making
-  the definition a little more verbose. We adopt the named style.
--/
--- /FULL
+```
+inductive Aexp.evalR : Aexp → Nat → Prop where
+  | E_ANum (n : Nat) :
+      Aexp.evalR (.num n) n
+  | E_APlus (e1 e2 : Aexp) (n1 n2 : Nat) :
+      Aexp.evalR e1 n1 →
+      Aexp.evalR e2 n2 →
+      Aexp.evalR (.plus e1 e2) (n1 + n2)
+  | E_AMinus (e1 e2 : Aexp) (n1 n2 : Nat) :
+      Aexp.evalR e1 n1 →
+      Aexp.evalR e2 n2 →
+      Aexp.evalR (.minus e1 e2) (n1 - n2)
+  | E_AMult (e1 e2 : Aexp) (n1 n2 : Nat) :
+      Aexp.evalR e1 n1 →
+      Aexp.evalR e2 n2 →
+      Aexp.evalR (.mult e1 e2) (n1 * n2)
+```
 
-/-
-  It will be convenient to have an infix notation for `Aexp.evalR`.  We'll
-  write `e ⇓ n` to mean that arithmetic expression `e` evaluates to
-  value `n`.  (We scope the notation to this namespace so it doesn't
-  collide with other evaluation relations later.)  In Lean the notation is
-  declared right after the inductive.
--/
+The version above instead gives explicit names to the hypotheses in each
+case (the `h1`/`h2`). Naming the hypotheses gives us more control over the
+names chosen during proofs involving the relation, at the cost of making
+the definition a little more verbose. We adopt the named style.
+::::
 
+It will be convenient to have an infix notation for `Aexp.evalR`.  We'll
+write `e ⇓ n` to mean that arithmetic expression `e` evaluates to
+value `n`.  (We scope the notation to this namespace so it doesn't
+collide with other evaluation relations later.)  In Lean the notation is
+declared right after the inductive.
+
+```lean
 scoped notation:55 e:56 " ⇓ " n:56 => Aexp.evalR e n
+```
 
-/-
-  ######################################################################
-  ## Inference Rule Notation
--/
+## Inference Rule Notation
 
--- FULL
-/-
-  In informal discussions, it is convenient to write the rules for
-  `Aexp.evalR` and similar relations in the more readable graphical form of
-  _inference rules_, where the premises above the line justify the
-  conclusion below the line.  For example, the constructor `E_APlus`
+::::full
+In informal discussions, it is convenient to write the rules for
+`Aexp.evalR` and similar relations in the more readable graphical form of
+_inference rules_, where the premises above the line justify the
+conclusion below the line.  For example, the constructor `E_APlus`
 
-  ```
-      | E_APlus (a1 a2 : Aexp) (n1 n2 : Nat) :
-          Aexp.evalR a1 n1 →
-          Aexp.evalR a2 n2 →
-          Aexp.evalR (.plus a1 a2) (n1 + n2)
-  ```
+```
+    | E_APlus (a1 a2 : Aexp) (n1 n2 : Nat) :
+        Aexp.evalR a1 n1 →
+        Aexp.evalR a2 n2 →
+        Aexp.evalR (.plus a1 a2) (n1 + n2)
+```
 
-  can be written like this as an inference rule:
+can be written like this as an inference rule:
 
-  ```
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                      --------------------          (E_APlus)
-                      plus e1 e2 ⇓ n1+n2
-  ```
+```
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                    --------------------          (E_APlus)
+                    plus e1 e2 ⇓ n1+n2
+```
 
-  Formally, there is nothing deep about inference rules: they are just
-  implications. You can read the rule name on the right as the name of the
-  constructor and read each of the linebreaks between the premises above the
-  line (as well as the line itself) as `→`.  All the variables mentioned in
-  the rule (`e1`, `n1`, etc.) are implicitly bound by universal quantifiers
-  at the beginning. (Such variables are often called _metavariables_ to
-  distinguish them from the variables of the language we are defining. At
-  the moment, our arithmetic expressions don't include variables, but we'll
-  soon be adding them.) The whole collection of rules is understood as being
-  wrapped in an inductive declaration. In informal prose, this is sometimes
-  indicated by saying something like "Let `aevalR` be the smallest relation
-  closed under the following rules...".
+Formally, there is nothing deep about inference rules: they are just
+implications. You can read the rule name on the right as the name of the
+constructor and read each of the linebreaks between the premises above the
+line (as well as the line itself) as `→`.  All the variables mentioned in
+the rule (`e1`, `n1`, etc.) are implicitly bound by universal quantifiers
+at the beginning. (Such variables are often called _metavariables_ to
+distinguish them from the variables of the language we are defining. At
+the moment, our arithmetic expressions don't include variables, but we'll
+soon be adding them.) The whole collection of rules is understood as being
+wrapped in an inductive declaration. In informal prose, this is sometimes
+indicated by saying something like "Let `aevalR` be the smallest relation
+closed under the following rules...".
 
-  To summarize: a group of inference rules corresponds to a single inductive
-  definition; each rule's name corresponds to a constructor name; above the
-  line are the premises, below the line the conclusion; and metavariables
-  like `e1` and `n1` are implicitly universally quantified. The whole
-  collection of rules defines `⇓` as the smallest relation closed under
-  them:
+To summarize: a group of inference rules corresponds to a single inductive
+definition; each rule's name corresponds to a constructor name; above the
+line are the premises, below the line the conclusion; and metavariables
+like `e1` and `n1` are implicitly universally quantified. The whole
+collection of rules defines `⇓` as the smallest relation closed under
+them:
 
-  ```
-                          -----------                (E_ANum)
-                          num n ⇓ n
+```
+                        -----------                (E_ANum)
+                        num n ⇓ n
 
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                      --------------------           (E_APlus)
-                      plus e1 e2 ⇓ n1+n2
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                    --------------------           (E_APlus)
+                    plus e1 e2 ⇓ n1+n2
 
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                     ---------------------           (E_AMinus)
-                     minus e1 e2 ⇓ n1-n2
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                   ---------------------           (E_AMinus)
+                   minus e1 e2 ⇓ n1-n2
 
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                      --------------------           (E_AMult)
-                      mult e1 e2 ⇓ n1*n2
-  ```
--/
--- /FULL
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                    --------------------           (E_AMult)
+                    mult e1 e2 ⇓ n1*n2
+```
+::::
 
--- HIDE
+::::hide
+```
 /- INSTRUCTORS: It might be useful to write the inference rules on the
    chalkboard, walking through the translation from the inductive
    definition, and then use these quizzes to check comprehension.
    BCP 21: Too heavy. -/
 /- LATER: The first two quizzes here seem kind of boring. -/
--- /HIDE
+```
+::::
 
-/-
-  mwhicks1: both of the next two quizzes were hidden in the source
-  material; the first quiz here is shown, the second is kept under `HIDE`.
--/
--- QUIZ
-/-
-  Which rules are needed to prove the following?
+```dev
+mwhicks1: both of the next two quizzes were hidden in the source
+material; the first quiz here is shown, the second is kept under `HIDE`.
+```
 
-  ```
-  .mult (.plus (.num 3) (.num 1)) (.num 0) ⇓ 0
-  ```
+::::quiz
+Which rules are needed to prove the following?
 
-  (A) `E_ANum` and `E_APlus`
-  (B) `E_ANum` only
-  (C) `E_ANum` and `E_AMult`
-  (D) `E_AMult` and `E_APlus`
-  (E) `E_ANum`, `E_AMult`, and `E_APlus`
--/
--- /QUIZ
+```
+.mult (.plus (.num 3) (.num 1)) (.num 0) ⇓ 0
+```
 
--- HIDE
+(A) `E_ANum` and `E_APlus`
+(B) `E_ANum` only
+(C) `E_ANum` and `E_AMult`
+(D) `E_AMult` and `E_APlus`
+(E) `E_ANum`, `E_AMult`, and `E_APlus`
+::::
+
+::::hide
+````
 -- QUIZ
 /-
   Which rules are needed to prove the following?
@@ -542,90 +569,89 @@ scoped notation:55 e:56 " ⇓ " n:56 => Aexp.evalR e n
   (E) `E_ANum`, `E_AMinus`, and `E_APlus`
 -/
 -- /QUIZ
--- /HIDE
+````
+::::
 
-/-
-  mwhicks1: Not sure if we need ⇓b, or whether we can define
-  ⇓ overloaded. Don't understand Lean notation yet!
--/
+```dev
+mwhicks1: Not sure if we need ⇓b, or whether we can define
+⇓ overloaded. Don't understand Lean notation yet!
+```
 
--- FULL
--- EX1? (beval_rules)
-/-
-  Here, again, is the definition of the `Bexp.eval` function:
+:::::exercise (rating := 1) (name := "beval_rules")
+Here, again, is the definition of the `Bexp.eval` function:
 
-  ```
-  def Bexp.eval (b : Bexp) : Bool :=
-    match b with
-    | bool b     => b
-    | eq   a1 a2 => a1.eval == a2.eval
-    | neq  a1 a2 => a1.eval != a2.eval
-    | le   a1 a2 => a1.eval ≤ a2.eval
-    | gt   a1 a2 => a1.eval > a2.eval
-    | not  b1    => !eval b1
-    | and  b1 b2 => eval b1 && eval b2
-  ```
+```
+def Bexp.eval (b : Bexp) : Bool :=
+  match b with
+  | bool b     => b
+  | eq   a1 a2 => a1.eval == a2.eval
+  | neq  a1 a2 => a1.eval != a2.eval
+  | le   a1 a2 => a1.eval ≤ a2.eval
+  | gt   a1 a2 => a1.eval > a2.eval
+  | not  b1    => !eval b1
+  | and  b1 b2 => eval b1 && eval b2
+```
 
-  Write out a corresponding definition of boolean evaluation as a relation
-  (in inference rule notation).
--/
--- SOLUTION
-/-
-  Answer (`⇓b` is defined below):
+Write out a corresponding definition of boolean evaluation as a relation
+(in inference rule notation).
 
-  ```
-                          -------------              (E_bool)
-                          bool b ⇓b b
+:::solution
+````
+Answer (`⇓b` is defined below):
 
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                     -------------------------        (E_BEq)
-                     eq e1 e2 ⇓b (n1 =? n2)
+```
+                        -------------              (E_bool)
+                        bool b ⇓b b
 
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                   -------------------------------    (E_BNeq)
-                   neq e1 e2 ⇓b negb (n1 =? n2)
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                   -------------------------        (E_BEq)
+                   eq e1 e2 ⇓b (n1 =? n2)
 
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                     --------------------------       (E_BLe)
-                     le e1 e2 ⇓b (n1 <=? n2)
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                 -------------------------------    (E_BNeq)
+                 neq e1 e2 ⇓b negb (n1 =? n2)
 
-                            e1 ⇓ n1
-                            e2 ⇓ n2
-                  -------------------------------     (E_BGt)
-                  gt e1 e2 ⇓b negb (n1 <=? n2)
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                   --------------------------       (E_BLe)
+                   le e1 e2 ⇓b (n1 <=? n2)
 
-                             e ⇓b b
-                        ------------------            (E_BNot)
-                        not e ⇓b negb b
+                          e1 ⇓ n1
+                          e2 ⇓ n2
+                -------------------------------     (E_BGt)
+                gt e1 e2 ⇓b negb (n1 <=? n2)
 
-                            e1 ⇓b b1
-                            e2 ⇓b b2
-                    --------------------------        (E_BAnd)
-                    and e1 e2 ⇓b andb b1 b2
-  ```
--/
--- /SOLUTION
--- GRADE_MANUAL 1: beval_rules
--- []
--- /FULL
+                           e ⇓b b
+                      ------------------            (E_BNot)
+                      not e ⇓b negb b
 
-/-
-  ######################################################################
-  ## Equivalence of the Definitions
--/
+                          e1 ⇓b b1
+                          e2 ⇓b b2
+                  --------------------------        (E_BAnd)
+                  and e1 e2 ⇓b andb b1 b2
+```
+````
+:::
 
--- HIDEFROMADVANCED
-/-
-  It is straightforward to prove that the relational and functional
-  definitions of evaluation agree.
--/
--- /HIDEFROMADVANCED
+:::grade
+```
+GRADE_MANUAL 1: beval_rules
+```
+:::
+:::::
 
-/- SOONER: BCP 23: Why can't we do induction on H in the ← direction?? -/
+## Equivalence of the Definitions
 
+It is straightforward to prove that the relational and functional
+definitions of evaluation agree.
+
+```dev
+SOONER: BCP 23: Why can't we do induction on H in the ← direction??
+```
+
+```lean
 theorem aevalR_iff_aeval (a : Aexp) (n : Nat) :
     a ⇓ n ↔ a.eval = n := by
   constructor
@@ -642,29 +668,29 @@ theorem aevalR_iff_aeval (a : Aexp) (n : Nat) :
     | plus a1 a2 ih1 ih2 => exact .E_APlus a1 a2 _ _ ih1 ih2
     | minus a1 a2 ih1 ih2 => exact .E_AMinus a1 a2 _ _ ih1 ih2
     | mult a1 a2 ih1 ih2 => exact .E_AMult a1 a2 _ _ ih1 ih2
+```
 
--- HIDEFROMADVANCED
-/-
-  Again, we can make the proof quite a bit shorter using the combinators
-  from the previous section.
--/
--- mwhicks1: the `-- WORKINCLASS` marker leaves this shorter proof as a live in-class exercise.
+Again, we can make the proof quite a bit shorter using the combinators
+from the previous section.
 
+```dev
+mwhicks1: the `-- WORKINCLASS` marker leaves this shorter proof as a live in-class exercise.
+```
+
+```lean
 theorem aevalR_iff_aeval' (a : Aexp) (n : Nat) :
     a ⇓ n ↔ Aexp.eval a = n := by
-  -- WORKINCLASS
-  constructor
-  · intro h; induction h <;> simp_all [Aexp.eval]
-  · intro h; subst h; induction a <;> constructor <;> assumption
-  -- /WORKINCLASS
--- /HIDEFROMADVANCED
+  workinclass!
+    constructor
+    · intro h; induction h <;> simp_all [Aexp.eval]
+    · intro h; subst h; induction a <;> constructor <;> assumption
+```
 
--- EX3 (bevalR)
-/-
-  Write a relation `Bexp.evalR` in the same style as `Aexp.evalR`, and prove that
-  it is equivalent to `Bexp.eval`.
--/
+:::::exercise (rating := 3) (name := "bevalR")
+Write a relation `Bexp.evalR` in the same style as `Aexp.evalR`, and prove that
+it is equivalent to `Bexp.eval`.
 
+```lean
 inductive Bexp.evalR : Bexp → Bool → Prop where
   -- SOLUTION
   | E_bool (b : Bool) : Bexp.evalR (.bool b) b
@@ -680,82 +706,95 @@ inductive Bexp.evalR : Bexp → Bool → Prop where
       Bexp.evalR (.not b) (!bv)
   | E_BAnd (b1 b2 : Bexp) (tv1 tv2 : Bool) (h1 : Bexp.evalR b1 tv1) (h2 : Bexp.evalR b2 tv2) :
       Bexp.evalR (.and b1 b2) (tv1 && tv2)
-  -- /SOLUTION
+  -- END SOLUTION
 
 scoped notation:55 e:56 " ⇓b " b:56 => Bexp.evalR e b
+```
 
--- mwhicks1: There is no keyboard shortcut for a subscript b, nor is there one for c (to use used with cevalR below). There are numbers, x, y, z, l, m, n, etc.
+```dev
+mwhicks1: There is no keyboard shortcut for a subscript b, nor is there one for c (to use used with cevalR below). There are numbers, x, y, z, l, m, n, etc.
+```
 
+```lean
 theorem bevalR_iff_beval (b : Bexp) (bv : Bool) :
     b ⇓b bv ↔ Bexp.eval b = bv := by
-  -- ADMITTED
-  constructor
-  · intro h
-    induction h with
-    | E_bool b => rfl
-    | E_BEq a1 a2 n1 n2 h1 h2 =>
-        simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
-    | E_BNeq a1 a2 n1 n2 h1 h2 =>
-        simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
-    | E_BLe a1 a2 n1 n2 h1 h2 =>
-        simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
-    | E_BGt a1 a2 n1 n2 h1 h2 =>
-        simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
-    | E_BNot b bv h ih => simp only [Bexp.eval]; rw [ih]
-    | E_BAnd b1 b2 tv1 tv2 h1 h2 ih1 ih2 => simp only [Bexp.eval]; rw [ih1, ih2]
-  · intro h
-    subst h
-    induction b with
-    | bool b => exact .E_bool b
-    | eq a1 a2  => exact .E_BEq a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
-    | neq a1 a2 => exact .E_BNeq a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
-    | le a1 a2  => exact .E_BLe a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
-    | gt a1 a2  => exact .E_BGt a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
-    | not b ih => exact .E_BNot b _ ih
-    | and b1 b2 ih1 ih2 => exact .E_BAnd b1 b2 _ _ ih1 ih2
-  -- /ADMITTED
--- GRADE_THEOREM 3: bevalR_iff_beval
--- []
+  solution!
+    constructor
+    · intro h
+      induction h with
+      | E_bool b => rfl
+      | E_BEq a1 a2 n1 n2 h1 h2 =>
+          simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
+      | E_BNeq a1 a2 n1 n2 h1 h2 =>
+          simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
+      | E_BLe a1 a2 n1 n2 h1 h2 =>
+          simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
+      | E_BGt a1 a2 n1 n2 h1 h2 =>
+          simp only [Bexp.eval]; rw [(aevalR_iff_aeval a1 n1).mp h1, (aevalR_iff_aeval a2 n2).mp h2]
+      | E_BNot b bv h ih => simp only [Bexp.eval]; rw [ih]
+      | E_BAnd b1 b2 tv1 tv2 h1 h2 ih1 ih2 => simp only [Bexp.eval]; rw [ih1, ih2]
+    · intro h
+      subst h
+      induction b with
+      | bool b => exact .E_bool b
+      | eq a1 a2  => exact .E_BEq a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
+      | neq a1 a2 => exact .E_BNeq a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
+      | le a1 a2  => exact .E_BLe a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
+      | gt a1 a2  => exact .E_BGt a1 a2 _ _ ((aevalR_iff_aeval a1 _).mpr rfl) ((aevalR_iff_aeval a2 _).mpr rfl)
+      | not b ih => exact .E_BNot b _ ih
+      | and b1 b2 ih1 ih2 => exact .E_BAnd b1 b2 _ _ ih1 ih2
+```
 
+:::grade
+```
+GRADE_THEOREM 3: bevalR_iff_beval
+```
+:::
+:::::
+
+```lean
 end AExp
+```
 
-/-
-  ######################################################################
-  ## Computational vs. Relational Definitions
--/
+## Computational vs. Relational Definitions
 
--- FULL
-/-
-  For the definitions of evaluation for arithmetic and boolean
-  expressions, the choice of whether to use functional or relational
-  definitions is mainly a matter of taste. However, there are many
-  situations where relational definitions work much better than
-  functional ones.
--/
--- /FULL
--- TERSE: /- Sometimes relational definitions are the only reasonable option... -/
+::::full
+For the definitions of evaluation for arithmetic and boolean
+expressions, the choice of whether to use functional or relational
+definitions is mainly a matter of taste. However, there are many
+situations where relational definitions work much better than
+functional ones.
+::::
 
+:::terse
+Sometimes relational definitions are the only reasonable option...
+:::
+
+```lean
 namespace AevalRDivision
+```
 
-/-
-  For example, suppose that we wanted to extend the arithmetic operations
-  with division:
--/
+For example, suppose that we wanted to extend the arithmetic operations
+with division:
 
+```lean
 inductive Aexp where
   | num (n : Nat)
   | plus (a1 a2 : Aexp)
   | minus (a1 a2 : Aexp)
   | mult (a1 a2 : Aexp)
   | div (a1 a2 : Aexp)             -- NEW
+```
 
-/-
-  Extending the definition of `Aexp.eval` to handle this new operation would
-  not be straightforward (what should we return as the result of
-  `.div (.num 5) (.num 0)`?). But extending the relation is easy.
--/
--- TERSE: /- What should `Aexp.eval` return for `.div (.num 1) (.num 0)`?? -/
+Extending the definition of `Aexp.eval` to handle this new operation would
+not be straightforward (what should we return as the result of
+`.div (.num 5) (.num 0)`?). But extending the relation is easy.
 
+:::terse
+What should `Aexp.eval` return for `.div (.num 1) (.num 0)`??
+:::
+
+```lean
 inductive Aexp.evalR : Aexp → Nat → Prop where
   | E_ANum (n : Nat) : Aexp.evalR (.num n) n
   | E_APlus (a1 a2 : Aexp) (n1 n2 : Nat) (h1 : Aexp.evalR a1 n1) (h2 : Aexp.evalR a2 n2) :
@@ -767,38 +806,44 @@ inductive Aexp.evalR : Aexp → Nat → Prop where
   | E_ADiv (a1 a2 : Aexp) (n1 n2 n3 : Nat)             -- NEW
       (h1 : Aexp.evalR a1 n1) (h2 : Aexp.evalR a2 n2) (hpos : n2 > 0) (hdiv : n2 * n3 = n1) :
       Aexp.evalR (.div a1 a2) n3
+```
 
-/-
-  Notice that this evaluation relation corresponds to a _partial_
-  function: there are some inputs for which it does not specify an output.
--/
+Notice that this evaluation relation corresponds to a _partial_
+function: there are some inputs for which it does not specify an output.
 
+```lean
 end AevalRDivision
 
 namespace AevalRExtended
+```
 
--- TERSE: /- Another example: a _nondeterministic_ number generator: -/
-/-
-  Or suppose that we want to extend the arithmetic operations by a
-  nondeterministic number generator `any` that, when evaluated, may
-  yield any number.  (This is not the same as making a _probabilistic_
-  choice among all numbers -- we only say which results are _possible_.)
--/
+:::terse
+Another example: a _nondeterministic_ number generator:
+:::
 
+Or suppose that we want to extend the arithmetic operations by a
+nondeterministic number generator `any` that, when evaluated, may
+yield any number.  (This is not the same as making a _probabilistic_
+choice among all numbers -- we only say which results are _possible_.)
+
+```lean
 inductive Aexp where
   | any                            -- NEW
   | num (n : Nat)
   | plus (a1 a2 : Aexp)
   | minus (a1 a2 : Aexp)
   | mult (a1 a2 : Aexp)
+```
 
-/-
-  Again, extending `Aexp.eval` would be tricky, since evaluation is now _not_
-  a deterministic function from expressions to numbers; but extending the
-  relation is no problem.
--/
--- TERSE: /- What should `Aexp.eval` do with nondeterminism?? -/
+Again, extending `Aexp.eval` would be tricky, since evaluation is now _not_
+a deterministic function from expressions to numbers; but extending the
+relation is no problem.
 
+:::terse
+What should `Aexp.eval` do with nondeterminism??
+:::
+
+```lean
 inductive Aexp.evalR : Aexp → Nat → Prop where
   | E_Any (n : Nat) : Aexp.evalR .any n                   -- NEW
   | E_ANum (n : Nat) : Aexp.evalR (.num n) n
@@ -810,125 +855,119 @@ inductive Aexp.evalR : Aexp → Nat → Prop where
       Aexp.evalR (.mult a1 a2) (n1 * n2)
 
 end AevalRExtended
+```
 
-/-
-  mwhicks1: The following text seems not quite right to me. First, you can
-  use options for partial functions, and that's very natural to do in Lean
-  as a monad. Second, and related, monadic functions need not even be
-  terminating if the implement the `CCPO` typeclass and are labeled as
-  a `partial_fixpoint`. Maybe we don't want to get into the second thing here,
-  but failing to mention options (which I think were introduced in LF) seems
-  a bit surprising.
--/
+```dev
+mwhicks1: The following text seems not quite right to me. First, you can
+use options for partial functions, and that's very natural to do in Lean
+as a monad. Second, and related, monadic functions need not even be
+terminating if the implement the `CCPO` typeclass and are labeled as
+a `partial_fixpoint`. Maybe we don't want to get into the second thing here,
+but failing to mention options (which I think were introduced in LF) seems
+a bit surprising.
+```
 
--- FULL
-/-
-  At this point you may be wondering: which of these styles should I use
-  by default?
+::::full
+At this point you may be wondering: which of these styles should I use
+by default?
 
-  Where the thing being defined is not easy to express as a function --
-  or is genuinely _not_ a function -- there is no real choice. When both
-  styles are workable, relational definitions can be more elegant and
-  easier to understand, and Lean generates useful inversion and induction
-  principles from them. On the other hand, functional definitions are
-  automatically deterministic and total (for a relation we must _prove_
-  these if we need them), and we can use Lean's computation mechanism to
-  simplify them during proofs.
+Where the thing being defined is not easy to express as a function --
+or is genuinely _not_ a function -- there is no real choice. When both
+styles are workable, relational definitions can be more elegant and
+easier to understand, and Lean generates useful inversion and induction
+principles from them. On the other hand, functional definitions are
+automatically deterministic and total (for a relation we must _prove_
+these if we need them), and we can use Lean's computation mechanism to
+simplify them during proofs.
 
-  In large developments it is common to give a definition in _both_
-  styles plus a lemma that the two coincide, allowing later proofs to
-  switch between points of view at will -- exactly what we did above.
--/
--- /FULL
--- TERSE: /- Functional: computation. Relational: expressive. Best: both, proved equivalent. -/
+In large developments it is common to give a definition in _both_
+styles plus a lemma that the two coincide, allowing later proofs to
+switch between points of view at will -- exactly what we did above.
+::::
 
-/-
-  ######################################################################
-  # Expressions With Variables
--/
+:::terse
+Functional: computation. Relational: expressive. Best: both, proved equivalent.
+:::
 
--- FULL
-/-
-  Let's return to defining Imp. The next thing we need to do is to
-  enrich our arithmetic and boolean expressions with variables. To keep
-  things simple, we'll assume that all variables are global and that they
-  only hold numbers.
--/
--- /FULL
+# Expressions With Variables
 
-/-
-  ######################################################################
-  ## States
--/
+::::full
+Let's return to defining Imp. The next thing we need to do is to
+enrich our arithmetic and boolean expressions with variables. To keep
+things simple, we'll assume that all variables are global and that they
+only hold numbers.
+::::
 
-/- LATER: Maybe this section needs a little preface talking about "what is
-   the meaning of an expression with variables?"... -/
-/- LATER: (Note copied from Equiv right before the assign_aequiv
+## States
+
+```dev
+LATER: Maybe this section needs a little preface talking about "what is
+   the meaning of an expression with variables?"...
+
+LATER: (Note copied from Equiv right before the assign_aequiv
    exercise): Some or all of this discussion should really happen when
    states are introduced in Imp.v, and the whole idea of treating states as
-   an ADT should be raised there. -/
+   an ADT should be raised there.
+```
 
-/-
-  Since we'll want to look variables up to find out their current values,
-  we'll use total maps from the `Maps` chapter. A _machine state_ (or
-  just _state_) represents the current values of all variables at some
-  point in the execution of a program.
--/
--- FULL
-/-
-  For simplicity, we assume that the state is defined for _all_ variables,
-  even though any given program is only able to mention a finite number of
-  them. Because each variable stores a natural number, we represent the
-  state as a total map from strings (variable names) to `Nat`, and will use
-  `0` as the default value in the store.
--/
--- /FULL
+Since we'll want to look variables up to find out their current values,
+we'll use total maps from the `Maps` chapter. A _machine state_ (or
+just _state_) represents the current values of all variables at some
+point in the execution of a program.
 
-/- We give the type of variable identifiers a name, `Ident`. For now it is just
+::::full
+For simplicity, we assume that the state is defined for _all_ variables,
+even though any given program is only able to mention a finite number of
+them. Because each variable stores a natural number, we represent the
+state as a total map from strings (variable names) to `Nat`, and will use
+`0` as the default value in the store.
+::::
+
+We give the type of variable identifiers a name, `Ident`. For now it is just
    `String`; naming it makes the intent clearer.
--/
+
+```lean
 abbrev Ident := String
 abbrev State := TotalMap Ident Nat
+```
 
-/-
-  ######################################################################
-  ## Syntax
--/
+## Syntax
 
-/-
-  We can add variables to the arithmetic expressions we had before simply
-  by including one more constructor.  (This is a fresh `Aexp`, replacing
-  the variable-free one from the `AExp` namespace above.)
--/
+We can add variables to the arithmetic expressions we had before simply
+by including one more constructor.  (This is a fresh `Aexp`, replacing
+the variable-free one from the `AExp` namespace above.)
 
+```lean
 inductive Aexp where
   | num (n : Nat)
   | id (x : Ident)                -- NEW
   | plus (a1 a2 : Aexp)
   | minus (a1 a2 : Aexp)
   | mult (a1 a2 : Aexp)
+```
 
-/-
-  chenson2018: Rather than define identifiers as Ident, a more general approach is
-  to use a *type variable* with `DecidableEq` (as the
-  `Maps` chapter does), threaded through `Aexp`/`Bexp`/`Com`/`State`.  Stashed
-  for a future decision; the parameterized version would look like:
+````dev
+chenson2018: Rather than define identifiers as Ident, a more general approach is
+to use a *type variable* with `DecidableEq` (as the
+`Maps` chapter does), threaded through `Aexp`/`Bexp`/`Com`/`State`.  Stashed
+for a future decision; the parameterized version would look like:
 
-  ```
-  inductive Aexp (V : Type) where
-    | num (n : Nat)
-    | id (x : V)
-    | plus (a1 a2 : Aexp V)
-    | minus (a1 a2 : Aexp V)
-    | mult (a1 a2 : Aexp V)
-  -- … then `Bexp V`, `Com V`, `abbrev State (V) [DecidableEq V] :=
-  -- TotalMap V Nat`, and `[DecidableEq V]` wherever a lookup/update is
-  -- performed.
-  ```
--/
+```
+inductive Aexp (V : Type) where
+  | num (n : Nat)
+  | id (x : V)
+  | plus (a1 a2 : Aexp V)
+  | minus (a1 a2 : Aexp V)
+  | mult (a1 a2 : Aexp V)
+-- … then `Bexp V`, `Com V`, `abbrev State (V) [DecidableEq V] :=
+-- TotalMap V Nat`, and `[DecidableEq V]` wherever a lookup/update is
+-- performed.
+```
+````
 
-/- The `Bexp` definition is unchanged, except that it now refers to the new `Aexp`. -/
+The `Bexp` definition is unchanged, except that it now refers to the new `Aexp`.
 
+```lean
 inductive Bexp where
   | bool (b : Bool)
   | eq (a1 a2 : Aexp)
@@ -937,10 +976,13 @@ inductive Bexp where
   | gt (a1 a2 : Aexp)
   | not (b : Bexp)
   | and (b1 b2 : Bexp)
+```
 
-/- Defining a few variable names as shorthands will make examples easier
-   to read. -/
-/- INSTRUCTORS: We usually don't use x as a "bare identifier" in examples
+Defining a few variable names as shorthands will make examples easier
+   to read.
+
+```instructors
+We usually don't use x as a "bare identifier" in examples
    -- it is normally wrapped in an id constructor.  If this were _always_
    the case, then it would make more sense to define the notation [x] to
    mean [id (Id 0)].  But there quite a few counterexamples. Maybe we
@@ -955,46 +997,43 @@ inductive Bexp where
    ET 10/17: coercions and notations are done, see below.  (still keeping
    the global variables W, X, Y, Z for readability)
    BCP 7/20: This still needs another look to see if there's a way to make
-   it globally better. -/
+   it globally better.
+```
 
+```lean
 def W : Ident := "W"
 def X : Ident := "X"
 def Y : Ident := "Y"
 def Z : Ident := "Z"
+```
 
--- FULL
-/-
-  (This convention for naming program variables (`X`, `Y`, `Z`) clashes a
-  bit with our earlier use of uppercase letters for types. Since we're not
-  using polymorphism heavily in the chapters developed to Imp, this
-  overloading should not cause confusion.)
--/
--- /FULL
+::::full
+(This convention for naming program variables (`X`, `Y`, `Z`) clashes a
+bit with our earlier use of uppercase letters for types. Since we're not
+using polymorphism heavily in the chapters developed to Imp, this
+overloading should not cause confusion.)
+::::
 
-/-
-  ######################################################################
-  ## Notations
--/
+## Notations
 
--- FULL
-/-
-  To make Imp programs easier to read and write, we introduce some notations and implicit
-  coercions.
+::::full
+To make Imp programs easier to read and write, we introduce some notations and implicit
+coercions.
 
-  You do not need to understand exactly what these declarations do. Briefly, though:
+You do not need to understand exactly what these declarations do. Briefly, though:
 
-  - The `declare_syntax_cat` directive adds a new non-terminal to Lean's grammar, called
-    `imp_aexp`. We'll add additional non-terminals further below.
-  - Each `syntax` directive defines a grammar production, of which there are eight in
-    total. The first two define literals, `num` and `ident`, as `imp_aexp`s. The next
-    deveral directives define productions for building larger expressions, with
-    some annotations to define precedence, etc.
-  - Finally, `macro_rules` is used to translate each production of the `imp_aexp` nonterminal
-    into a Lean expression.
-  - The same basic pattern is followed for `bexp`s too.
--/
--- /FULL
+- The `declare_syntax_cat` directive adds a new non-terminal to Lean's grammar, called
+  `imp_aexp`. We'll add additional non-terminals further below.
+- Each `syntax` directive defines a grammar production, of which there are eight in
+  total. The first two define literals, `num` and `ident`, as `imp_aexp`s. The next
+  deveral directives define productions for building larger expressions, with
+  some annotations to define precedence, etc.
+- Finally, `macro_rules` is used to translate each production of the `imp_aexp` nonterminal
+  into a Lean expression.
+- The same basic pattern is followed for `bexp`s too.
+::::
 
+```lean
 /-- Arithmetic expressions of Imp -/
 declare_syntax_cat imp_aexp
 /-- Numeric literal -/
@@ -1014,15 +1053,20 @@ syntax:max "~" term:max : imp_aexp
 
 /-- Embed an Imp arithmetic expression into a Lean term -/
 syntax:min "aexp " "{" imp_aexp "}" : term
+```
 
--- HIDE
+::::hide
+```
 /- INSTRUCTORS: A variable reference elaborates to `Aexp.id $x` with the identifier spliced
    as a *term*, not as a string literal. So `aexp { X }` is `Aexp.id X`, using
    the declared constant `X : Ident`, exactly matching hand-written terms like
    `.asgn X …` and the shape the state/`ceval` proofs expect. (Rocq's `<{ }>`
    does the same via its `constr` fallback, yielding `AId X`.) A consequence is
    that a variable name must be a declared `Ident` constant — as W/X/Y/Z are. -/
--- /HIDE
+```
+::::
+
+```lean
 open Lean in
 macro_rules
   | `(aexp { $n:num }) => `(Aexp.num $(quote n.getNat))
@@ -1032,16 +1076,20 @@ macro_rules
   | `(aexp { $a - $b }) => `(Aexp.minus (aexp {$a}) (aexp {$b}))
   | `(aexp { $a * $b }) => `(Aexp.mult (aexp {$a}) (aexp {$b}))
   | `(aexp { ($a) }) => `(aexp {$a})
+```
 
--- HIDE
+::::hide
+```
 /- INSTRUCTORS: The literals `true`/`false` are accepted through the bare-identifier form
    (`syntax:max ident : imp_bexp`) and turned into `Bexp.bool` by the macro
    below, which rejects any other identifier. We take this route rather than
    declaring `true`/`false` as symbols: as reserved keywords they would break
    ordinary Lean uses of `true`/`false`, and as non-reserved symbols they would
    clash with the bare-identifier form of `imp_aexp`. -/
--- /HIDE
+```
+::::
 
+```lean
 /-- Boolean expressions of Imp -/
 declare_syntax_cat imp_bexp
 /-- Boolean literal (`true` or `false`) -/
@@ -1065,13 +1113,18 @@ syntax:max "~" term:max : imp_bexp
 
 /-- Embed an Imp boolean expression into a Lean term -/
 syntax:min "bexp " "{" imp_bexp "}" : term
+```
 
--- HIDE
+::::hide
+```
 /- INSTRUCTORS: The antiquotations are annotated with their category (`$a:imp_aexp`,
    `$b:imp_bexp`) because an `imp_bexp` can begin with an `imp_aexp` (a
    comparison); without the annotation the parser would descend into `imp_aexp`
    and then insist on a comparison operator. -/
--- /HIDE
+```
+::::
+
+```lean
 open Lean in
 macro_rules
   | `(bexp { $x:ident }) =>
@@ -1087,23 +1140,22 @@ macro_rules
   | `(bexp { ! $b:imp_bexp }) => `(Bexp.not (bexp {$b}))
   | `(bexp { $b1:imp_bexp && $b2:imp_bexp }) => `(Bexp.and (bexp {$b1}) (bexp {$b2}))
   | `(bexp { ($b:imp_bexp) }) => `(bexp {$b})
+```
 
+::::full
+We make it a little easier to write Imp programs using normal constructors (i.e.,
+without notation), by using _implicit coercions_.
+In Lean, a `Coe` instance tells the elaborator how to turn a
+value of one type into another automatically:
+ - `Coe Ident Aexp` lets us write a bare variable (an `Ident`) where an
+   `Aexp` is expected; the identifier is implicitly wrapped with `id`.
+ - `OfNat Aexp n` lets us write a numeric literal where an `Aexp` is
+   expected; it is implicitly wrapped with `num`.
+ - `Coe Bool Bexp` lets us write a boolean literal (`true`/`false`) where a
+   `Bexp` is expected; it is implicitly wrapped with `bool`.
+::::
 
--- FULL
-/-
-  We make it a little easier to write Imp programs using normal constructors (i.e.,
-  without notation), by using _implicit coercions_.
-  In Lean, a `Coe` instance tells the elaborator how to turn a
-  value of one type into another automatically:
-   - `Coe Ident Aexp` lets us write a bare variable (an `Ident`) where an
-     `Aexp` is expected; the identifier is implicitly wrapped with `id`.
-   - `OfNat Aexp n` lets us write a numeric literal where an `Aexp` is
-     expected; it is implicitly wrapped with `num`.
-   - `Coe Bool Bexp` lets us write a boolean literal (`true`/`false`) where a
-     `Bexp` is expected; it is implicitly wrapped with `bool`.
--/
--- /FULL
-
+```lean
 instance : Coe Ident Aexp where
   coe := .id
 
@@ -1112,49 +1164,48 @@ instance (n : Nat) : OfNat Aexp n where
 
 instance : Coe Bool Bexp where
   coe := .bool
+```
 
--- FULL
-/- With these coercions we can write `.plus 3 (.mult X 2)` instead of the fully
+::::full
+With these coercions we can write `.plus 3 (.mult X 2)` instead of the fully
    explicit `.plus (.num 3) (.mult (.id "X") (.num 2))`, and `.and true (.not …)`
    instead of `.and (.bool true) (.not …)`. More readably still, the concrete
-   syntax from the Notations section lets us write these examples directly: -/
--- /FULL
+   syntax from the Notations section lets us write these examples directly:
+::::
 
+```lean
 def example_aexp : Aexp := aexp { 3 + (X * 2) }
 def example_bexp : Bexp := bexp { true && !(X <= 4) }
+```
 
-/-
-  ######################################################################
-  ## Delaborators
--/
+## Delaborators
 
--- FULL
-/-
-  The notations above are _input_ only: they teach Lean how to *read* `aexp
-  { … }` and `bexp { … }`, but Lean still *prints* an expression using its raw
-  constructors -- `example_aexp` shows up as `Aexp.plus (Aexp.num 3) …` rather
-  than `aexp { 3 + X * 2 }`. A _delaborator_ closes the loop. Where a `macro`
-  turns surface syntax into a term (_elaboration_), a delaborator does the
-  reverse: it turns an elaborated term back into surface syntax so that Lean's
-  own output uses our concrete Imp notation.
+::::full
+The notations above are _input_ only: they teach Lean how to *read* `aexp
+{ … }` and `bexp { … }`, but Lean still *prints* an expression using its raw
+constructors -- `example_aexp` shows up as `Aexp.plus (Aexp.num 3) …` rather
+than `aexp { 3 + X * 2 }`. A _delaborator_ closes the loop. Where a `macro`
+turns surface syntax into a term (_elaboration_), a delaborator does the
+reverse: it turns an elaborated term back into surface syntax so that Lean's
+own output uses our concrete Imp notation.
 
-  Each delaborator below walks a term of the given type and rebuilds the
-  matching piece of `imp_aexp`/`imp_bexp` syntax; a subterm Lean doesn't
-  recognize is printed with the `~` escape. The `@[delab …]` attribute
-  registers the top-level function to fire whenever Lean is about to display a
-  term headed by one of those constructors -- unless notation printing has been
-  switched off with `set_option pp.notation false`, which lets us fall back to
-  the raw constructors when debugging (see _Desugaring Notations_ below). The
-  companion _category parenthesizer_ re-inserts the parentheses the grammar's
-  precedences demand, so that, e.g., `(1 + 2) * 3` prints with its parentheses
-  intact.
+Each delaborator below walks a term of the given type and rebuilds the
+matching piece of `imp_aexp`/`imp_bexp` syntax; a subterm Lean doesn't
+recognize is printed with the `~` escape. The `@[delab …]` attribute
+registers the top-level function to fire whenever Lean is about to display a
+term headed by one of those constructors -- unless notation printing has been
+switched off with `set_option pp.notation false`, which lets us fall back to
+the raw constructors when debugging (see _Desugaring Notations_ below). The
+companion _category parenthesizer_ re-inserts the parentheses the grammar's
+precedences demand, so that, e.g., `(1 + 2) * 3` prints with its parentheses
+intact.
 
-  You do not need to understand the details. The result is that a `#check`, an
-  `#eval`, or a proof goal mentioning an Imp expression is displayed in
-  readable Imp syntax rather than as a pile of constructors.
--/
--- /FULL
+You do not need to understand the details. The result is that a `#check`, an
+`#eval`, or a proof goal mentioning an Imp expression is displayed in
+readable Imp syntax rather than as a pile of constructors.
+::::
 
+```lean
 namespace Imp.Delab
 open Lean PrettyPrinter Delaborator SubExpr Parenthesizer
 
@@ -1247,10 +1298,13 @@ partial def delabBexpInner : DelabM (TSyntax `imp_bexp) := do
       `(imp_bexp| $s1 && $s2)
     | _ => `(imp_bexp| ~$(← delab))
   annAsTerm stx
+```
 
--- The `whenPPOption getPPNotation` wrapper lets `set_option pp.notation false`
--- switch this delaborator off, revealing the raw constructors (see the
--- "Desugaring Notations" discussion, after the commands are introduced).
+The `whenPPOption getPPNotation` wrapper lets `set_option pp.notation false`
+switch this delaborator off, revealing the raw constructors (see the
+"Desugaring Notations" discussion, after the commands are introduced).
+
+```lean
 @[delab app.Aexp.num, delab app.Aexp.id, delab app.Aexp.plus,
   delab app.Aexp.minus, delab app.Aexp.mult]
 partial def delabAexp : Delab := whenPPOption getPPNotation do
@@ -1283,14 +1337,14 @@ partial def delabBexp : Delab := whenPPOption getPPNotation do
   | e => `(term| bexp { $e })
 
 end Imp.Delab
+```
 
--- FULL
-/-
-  With the delaborators in place, Lean now prints Imp expressions using the
-  concrete syntax rather than their raw constructors.
--/
--- /FULL
+::::full
+With the delaborators in place, Lean now prints Imp expressions using the
+concrete syntax rather than their raw constructors.
+::::
 
+```lean
 /-- info: aexp {3 + X * 2} : Aexp -/
 #guard_msgs in
 #check aexp { 3 + (X * 2) }
@@ -1298,22 +1352,22 @@ end Imp.Delab
 /-- info: bexp {true && ! (X <= 4)} : Bexp -/
 #guard_msgs in
 #check bexp { true && !(X <= 4) }
+```
 
-/-
-  ######################################################################
-  ## Evaluation
--/
+## Evaluation
 
--- FULL
-/-
-  The arithmetic and boolean evaluators must now be extended to handle
-  variables, taking a state `st` as an extra argument.  A variable is
-  looked up in the state with the map-indexing notation `st[x]` from the
-  `Maps` chapter.
--/
--- /FULL
--- TERSE: /- Now we need to add an `st` parameter to both evaluation functions: -/
+::::full
+The arithmetic and boolean evaluators must now be extended to handle
+variables, taking a state `st` as an extra argument.  A variable is
+looked up in the state with the map-indexing notation `st[x]` from the
+`Maps` chapter.
+::::
 
+:::terse
+Now we need to add an `st` parameter to both evaluation functions:
+:::
+
+```lean
 def Aexp.eval (st : State) (a : Aexp) : Nat :=
   match a with
   | num   n     =>  n
@@ -1331,62 +1385,65 @@ def Bexp.eval (st : State) (b : Bexp) : Bool :=
   | gt   a1 a2  =>  a1.eval st >  a2.eval st
   | not  b1     =>  !b1.eval st
   | and  b1 b2  =>  b1.eval st && b2.eval st
+```
 
-/- We reuse the total-map notation (`x →ₜ v ; ∅` etc.) for states. -/
+We reuse the total-map notation (`x →ₜ v ; ∅` etc.) for states.
 
-/- test_aexp1 -/
+```lean
 example : aexp { 3 + (X * 2) }.eval (X →ₜ 5 ; ∅) = 13 := by rfl
 
-/- test_aexp2 -/
 example : aexp { Z + (X * Y) }.eval (X →ₜ 5 ; Y →ₜ 4 ; ∅) = 20 := by rfl
 
-/- test_bexp1 -/
 example : bexp { true && !(X <= 4) }.eval (X →ₜ 5 ; ∅) = true := by rfl
+```
 
--- dsainati: Bikeshedding: I'm not sure how I feel about this arrow subscript for maps. Easy to change later but just flagging to discuss. mwhicks1: This comes from the Maps chapter, which chenson2018 is working on. There is a keyboard shortcut for ↦ we could use (\mapsto).
+dsainati: Bikeshedding: I'm not sure how I feel about this arrow subscript for maps. Easy to change later but just flagging to discuss. mwhicks1: This comes from the Maps chapter, which chenson2018 is working on. There is a keyboard shortcut for ↦ we could use (\mapsto).
 
-/-
-  ######################################################################
-  # Commands
--/
+# Commands
 
--- FULL
-/-
-  Now we are ready to define the syntax and behavior of Imp _commands_
-  (or _statements_). Informally, commands `c` are described by the
-  following BNF grammar:
+::::full
+Now we are ready to define the syntax and behavior of Imp _commands_
+(or _statements_). Informally, commands `c` are described by the
+following BNF grammar:
 
-  ```
-  c := skip
-     | x := a
-     | c ; c
-     | if b then c else c end
-     | while b do c end
-  ```
+```
+c := skip
+   | x := a
+   | c ; c
+   | if b then c else c end
+   | while b do c end
+```
 
-  Here is the formal definition of the abstract syntax of commands.
--/
--- /FULL
+Here is the formal definition of the abstract syntax of commands.
+::::
 
+```lean
 inductive Com where
   | skip
   | asgn (x : Ident) (a : Aexp)
   | seq (c1 c2 : Com)
   | cond (b : Bexp) (c1 c2 : Com)
   | whileDo (b : Bexp) (c : Com)
+```
 
-/- Concrete syntax for commands, in the style of the `ssft24` Imp `Stmt`
+Concrete syntax for commands, in the style of the `ssft24` Imp `Stmt`
    grammar: an `imp_com` category with an `imp { … }` hook. Assignments and
    `skip` end in `;`, and sequencing is written by juxtaposition. Conditions use
    the `imp_bexp` grammar; the branch/loop bodies use the `imp_com` grammar. As
-   with expressions, `~c` escapes back to an ordinary Lean term of type `Com`. -/
+   with expressions, `~c` escapes back to an ordinary Lean term of type `Com`.
+
+```lean
 /-- Imp commands -/
 declare_syntax_cat imp_com
-/- `skip` is *not* a reserved keyword: it is accepted through a bare
+```
+
+`skip` is *not* a reserved keyword: it is accepted through a bare
    identifier-terminated command (`syntax ident ";" : imp_com`) and recognised
    in the macro below, which rejects any other identifier. This keeps `skip`
    usable as the bare constructor name `Com.skip` in `match`/`induction`
-   elsewhere in the file, and avoids reserving `skip` globally. -/
+   elsewhere in the file, and avoids reserving `skip` globally.
+
+```lean
 /-- The command that does nothing (`skip;`) -/
 syntax ident ";" : imp_com
 /-- Sequencing: one command after another -/
@@ -1418,17 +1475,17 @@ macro_rules
     `(Com.whileDo (bexp {$b}) (imp {$c}))
   | `(imp { ~$c }) =>
     pure c
+```
 
--- FULL
-/-
-  Just as we did for expressions, we add a delaborator so that Lean prints
-  commands back in the `imp { … }` concrete syntax (see the Delaborators
-  section above). It reuses the expression delaborators for the condition of an
-  `if`/`while` and for the right-hand side of an assignment, and prints an
-  unrecognized subcommand with the `~` escape.
--/
--- /FULL
+::::full
+Just as we did for expressions, we add a delaborator so that Lean prints
+commands back in the `imp { … }` concrete syntax (see the Delaborators
+section above). It reuses the expression delaborators for the condition of an
+`if`/`while` and for the right-hand side of an assignment, and prints an
+unrecognized subcommand with the `~` escape.
+::::
 
+```lean
 namespace Imp.Delab
 open Lean PrettyPrinter Delaborator SubExpr
 
@@ -1478,16 +1535,16 @@ partial def delabCom : Delab := whenPPOption getPPNotation do
   | e => `(term| imp { $e })
 
 end Imp.Delab
+```
 
--- FULL
-/-
-  As an example, here is the factorial function again, written as a formal
-  definition. When this command terminates, the variable `Y` will
-  contain the factorial of the initial value of `X`.  (Compare this to
-  the concrete Imp program at the very start of the chapter.)
--/
--- /FULL
+::::full
+As an example, here is the factorial function again, written as a formal
+definition. When this command terminates, the variable `Y` will
+contain the factorial of the initial value of `X`.  (Compare this to
+the concrete Imp program at the very start of the chapter.)
+::::
 
+```lean
 def fact_in_lean : Com := imp {
   Z := X;
   Y := 1;
@@ -1496,14 +1553,14 @@ def fact_in_lean : Com := imp {
     Z := Z - 1;
   }
 }
+```
 
--- FULL
-/-
-  Because we registered a delaborator, we can inspect a defined program with
-  `#print`, which shows the stored definition using the same concrete syntax:
--/
--- /FULL
+::::full
+Because we registered a delaborator, we can inspect a defined program with
+`#print`, which shows the stored definition using the same concrete syntax:
+::::
 
+```lean
 /--
 info: def fact_in_lean : Com :=
 imp {
@@ -1517,32 +1574,28 @@ imp {
 -/
 #guard_msgs in
 #print fact_in_lean
+```
 
-/-
-  ######################################################################
-  ## Desugaring Notations
--/
+## Desugaring Notations
 
--- FULL
-/-
-  The `imp { … }` notation, together with the delaborators, is purely a
-  convenience for reading and writing programs. Occasionally, such as when debugging
-  a definition or a stuck proof, the concrete syntax hides the underlying structure
-  we want to see. For those moments we can switch the Imp notation off in Lean's
-  output with `set_option pp.notation false`, which our delaborators honor.
+::::full
+The `imp { … }` notation, together with the delaborators, is purely a
+convenience for reading and writing programs. Occasionally, such as when debugging
+a definition or a stuck proof, the concrete syntax hides the underlying structure
+we want to see. For those moments we can switch the Imp notation off in Lean's
+output with `set_option pp.notation false`, which our delaborators honor.
 
-  Note that unlike a `def`, `imp { … }` is a `macro` which is expanded during elaboration,
-  *before* the resulting term is type-checked. So `fact_in_lean` is not a
-  program hidden behind a layer of notation that a proof must first peel back;
-  it simply *is* the underlying tree of `Com`, `Aexp`, and `Bexp` constructors.
-  Consequently, when a proof goal mentions an Imp program, tactics such as
-  `cases`, `injection`, and `simp` already act on those constructors directly
-  -- there is nothing to "unfold". The delaborators affect only how that tree
-  is *displayed*. Nevertheless, seeing the raw constructors is sometimes very helpful!
+Note that unlike a `def`, `imp { … }` is a `macro` which is expanded during elaboration,
+*before* the resulting term is type-checked. So `fact_in_lean` is not a
+program hidden behind a layer of notation that a proof must first peel back;
+it simply *is* the underlying tree of `Com`, `Aexp`, and `Bexp` constructors.
+Consequently, when a proof goal mentions an Imp program, tactics such as
+`cases`, `injection`, and `simp` already act on those constructors directly
+-- there is nothing to "unfold". The delaborators affect only how that tree
+is *displayed*. Nevertheless, seeing the raw constructors is sometimes very helpful!
+::::
 
--/
--- /FULL
-
+```lean
 /-- info: imp {
   X := X + 1;
 } : Com -/
@@ -1553,21 +1606,28 @@ imp {
 #guard_msgs in
 set_option pp.notation false in
 #check imp { X := X + 1; }
+```
 
--- HIDEFROMADVANCED
+## More Examples
 
-/-
-  ######################################################################
-  ## More Examples
--/
+A few more examples.
 
-/- A few more examples. -/
+:::slidebreak
+:::
 
-/- *** Assignment: -/
+Assignment:
+
+```lean
 def plus2 : Com := imp { X := X + 2; }
 def XtimesYinZ : Com := imp { Z := X * Y; }
+```
 
-/- *** Loops: -/
+:::slidebreak
+:::
+
+Loops:
+
+```lean
 def subtract_slowly_body : Com := imp {
   Z := Z - 1;
   X := X - 1;
@@ -1584,11 +1644,19 @@ def subtract_3_from_5_slowly : Com := imp {
   Z := 5;
   ~subtract_slowly
 }
+```
 
-/- *** An infinite loop: -/
+:::slidebreak
+:::
+
+An infinite loop:
+
+```lean
 def loop : Com := imp { while (true) { skip; } }
+```
 
--- HIDE
+::::hide
+```
 /- Exponentiation: -/
 def exp_body : Com := imp {
   Z := Z * X;
@@ -1600,38 +1668,31 @@ def pexp : Com := imp {
   }
 }
 /- (Note that `pexp` should be run in a state where `Z` is `1`.) -/
--- /HIDE
--- /HIDEFROMADVANCED
+```
+::::
 
-/-
-  ######################################################################
-  # Evaluating Commands
--/
+# Evaluating Commands
 
--- FULL
-/-
-  Next we need to define what it means to evaluate an Imp command.  The
-  fact that `while` loops don't necessarily terminate makes defining an
-  evaluation function tricky.
--/
--- /FULL
+::::full
+Next we need to define what it means to evaluate an Imp command.  The
+fact that `while` loops don't necessarily terminate makes defining an
+evaluation function tricky.
+::::
 
-/-
-  ######################################################################
-  ## Evaluation as a Function (Failed Attempt)
--/
+## Evaluation as a Function (Failed Attempt)
 
-/-
-  Here's an attempt at defining an evaluation function for commands (with
-  a bogus `while` case).
--/
+Here's an attempt at defining an evaluation function for commands (with
+a bogus `while` case).
 
-/- LATER: In SmallStep we need to package the state and command into a pair,
+```dev
+LATER: In SmallStep we need to package the state and command into a pair,
    so that we can talk about normal forms and such. Probably we should do it
    here too, for consistency. (Won't change much except the type
    declarations, but we'll need to add a comment why we wrote them this
-   way.) -/
+   way.)
+```
 
+```lean
 def Com.ceval_fun_no_while (st : State) (c : Com) : State :=
   match c with
   | imp {skip;} => st
@@ -1643,126 +1704,123 @@ def Com.ceval_fun_no_while (st : State) (c : Com) : State :=
       if Bexp.eval st b then ceval_fun_no_while st c1
       else ceval_fun_no_while st c2
   | imp {while (~_) {~_}} => st     -- bogus
+```
 
--- FULL
-/-
-  In a more conventional functional language like OCaml or Haskell we
-  could add the `while` case as follows:
+::::full
+In a more conventional functional language like OCaml or Haskell we
+could add the `while` case as follows:
 
-  ```
-  | .whileDo b c =>
-      if Bexp.eval st b then ceval_fun st (.seq c (.whileDo b c))
-      else st
-  ```
+```
+| .whileDo b c =>
+    if Bexp.eval st b then ceval_fun st (.seq c (.whileDo b c))
+    else st
+```
 
-  Lean doesn't accept such a definition ("fail to show termination")
-  because the function we want to define is not guaranteed to terminate.
-  Indeed, it _doesn't_ always terminate: the full `ceval_fun` applied to
-  the `loop` program above would run forever. Since Lean aims to be not
-  just a programming language but also a consistent logic, any
-  potentially non-terminating function must be rejected. Here is what
-  would go wrong if Lean allowed non-terminating recursive functions:
+Lean doesn't accept such a definition ("fail to show termination")
+because the function we want to define is not guaranteed to terminate.
+Indeed, it _doesn't_ always terminate: the full `ceval_fun` applied to
+the `loop` program above would run forever. Since Lean aims to be not
+just a programming language but also a consistent logic, any
+potentially non-terminating function must be rejected. Here is what
+would go wrong if Lean allowed non-terminating recursive functions:
 
-  ```
-  def loop_false (n : Nat) : False := loop_false n
-  ```
+```
+def loop_false (n : Nat) : False := loop_false n
+```
 
-  That is, propositions like `False` would become provable (`loop_false 0`
-  would be a proof of `False`), a disaster for logical consistency.
+That is, propositions like `False` would become provable (`loop_false 0`
+would be a proof of `False`), a disaster for logical consistency.
 
-  Thus, because it doesn't terminate on all inputs, the full `ceval_fun`
-  cannot be written in Lean -- at least not without additional tricks and
-  workarounds.
--/
--- /FULL
-/- HIDE: Perhaps that discussion should be moved to -- or previewed in --
+Thus, because it doesn't terminate on all inputs, the full `ceval_fun`
+cannot be written in Lean -- at least not without additional tricks and
+workarounds.
+::::
+
+```dev
+HIDE: Perhaps that discussion should be moved to -- or previewed in --
    Logic.v?  MRC'20: It's already in ProofObjects (which not everyone
-   sees). -/
--- TERSE: /- A nonterminating `def loop_false (n) : False := loop_false n` would make `False` provable, so Lean rejects it. -/
+   sees).
+```
 
-/-
-  ######################################################################
-  ## Evaluation as a Relation
--/
+:::terse
+A nonterminating `def loop_false (n) : False := loop_false n` would make `False` provable, so Lean rejects it.
+:::
 
-/-
-  Here's a better way: define `ceval` as a _relation_ rather than a
-  _function_ -- i.e., make its result a `Prop` rather than a `State`,
-  similar to what we did for `Aexp.evalR` above.
--/
+## Evaluation as a Relation
 
--- FULL
--- HIDEFROMADVANCED
-/-
-  This is an important change. Besides freeing us from awkward workarounds,
-  it gives us more flexibility in the definition. For example, if we
-  add nondeterministic features like `any` to the language, we want the
-  definition of evaluation to be nondeterministic -- i.e., not only will it
-  not be total, it will not even be a function!
--/
--- /HIDEFROMADVANCED
--- /FULL
+Here's a better way: define `ceval` as a _relation_ rather than a
+_function_ -- i.e., make its result a `Prop` rather than a `State`,
+similar to what we did for `Aexp.evalR` above.
 
-/-
-  mwhicks1: I kind of hate this notation. Is there something more standard
-  in Lean? CSLib precedent maybe?
--/
+::::full
+This is an important change. Besides freeing us from awkward workarounds,
+it gives us more flexibility in the definition. For example, if we
+add nondeterministic features like `any` to the language, we want the
+definition of evaluation to be nondeterministic -- i.e., not only will it
+not be total, it will not even be a function!
+::::
 
-/-
-  We'll use the notation `st =[ c ]=> st'` for the `ceval` relation:
-  `st =[ c ]=> st'` means that executing program `c` in a starting state
-  `st` results in an ending state `st'`.  This can be pronounced "`c` takes
-  state `st` to `st'`".
--/
+```dev
+mwhicks1: I kind of hate this notation. Is there something more standard
+in Lean? CSLib precedent maybe?
+```
 
-/- *** Operational Semantics -/
+We'll use the notation `st =[ c ]=> st'` for the `ceval` relation:
+`st =[ c ]=> st'` means that executing program `c` in a starting state
+`st` results in an ending state `st'`.  This can be pronounced "`c` takes
+state `st` to `st'`".
 
-/- SOONER: BCP 21: I wonder if E_Seq would be easier to work with if st' and
-   st'' were swapped... -/
+:::slidebreak
+:::
 
-/-
-  Here is an informal definition of evaluation, presented as inference rules
-  for readability:
+Operational Semantics
 
-  ```
-                        -----------------                  (E_Skip)
-                        st =[ skip ]=> st
+```dev
+SOONER: BCP 21: I wonder if E_Seq would be easier to work with if st' and
+   st'' were swapped...
+```
 
-                        Aexp.eval st a = n
-                --------------------------------           (E_Asgn)
-                st =[ x := a ]=> (x →ₜ n ; st)
+Here is an informal definition of evaluation, presented as inference rules
+for readability:
 
-                        st  =[ c1 ]=> st'
-                        st' =[ c2 ]=> st''
-                      ---------------------                (E_Seq)
-                      st =[ c1;c2 ]=> st''
+```
+                      -----------------                  (E_Skip)
+                      st =[ skip ]=> st
 
-                       Bexp.eval st b = true
-                        st =[ c1 ]=> st'
-             --------------------------------------        (E_IfTrue)
-             st =[ if b then c1 else c2 end ]=> st'
+                      Aexp.eval st a = n
+              --------------------------------           (E_Asgn)
+              st =[ x := a ]=> (x →ₜ n ; st)
 
-                      Bexp.eval st b = false
-                        st =[ c2 ]=> st'
-             --------------------------------------        (E_IfFalse)
-             st =[ if b then c1 else c2 end ]=> st'
+                      st  =[ c1 ]=> st'
+                      st' =[ c2 ]=> st''
+                    ---------------------                (E_Seq)
+                    st =[ c1;c2 ]=> st''
 
-                      Bexp.eval st b = false
-                 -----------------------------             (E_WhileFalse)
-                 st =[ while b do c end ]=> st
+                     Bexp.eval st b = true
+                      st =[ c1 ]=> st'
+           --------------------------------------        (E_IfTrue)
+           st =[ if b then c1 else c2 end ]=> st'
 
-                       Bexp.eval st b = true
-                        st =[ c ]=> st'
-               st' =[ while b do c end ]=> st''
-               --------------------------------            (E_WhileTrue)
-               st  =[ while b do c end ]=> st''
-  ```
+                    Bexp.eval st b = false
+                      st =[ c2 ]=> st'
+           --------------------------------------        (E_IfFalse)
+           st =[ if b then c1 else c2 end ]=> st'
 
-  Here is the formal definition.  Make sure you understand how it
-  corresponds to the inference rules.
--/
--- /FULL
+                    Bexp.eval st b = false
+               -----------------------------             (E_WhileFalse)
+               st =[ while b do c end ]=> st
 
+                     Bexp.eval st b = true
+                      st =[ c ]=> st'
+             st' =[ while b do c end ]=> st''
+             --------------------------------            (E_WhileTrue)
+             st  =[ while b do c end ]=> st''
+```
+
+Here is the formal definition.  Make sure you understand how it
+corresponds to the inference rules.
+
+```lean
 inductive Ceval : Com → State → State → Prop where
   | E_Skip (st : State) :
       Ceval (imp {skip;}) st st
@@ -1787,14 +1845,14 @@ inductive Ceval : Com → State → State → Prop where
       Ceval (imp {while (~b) {~c}}) st st''
 
 notation:40 st0 " =[ " c " ]=> " st1 => Ceval c st0 st1
+```
 
-/-
-  The cost of defining evaluation as a relation instead of a function is
-  that we now need to construct a _proof_ that some program evaluates to
-  some result state, rather than letting Lean's computation mechanism do
-  it for us.
--/
+The cost of defining evaluation as a relation instead of a function is
+that we now need to construct a _proof_ that some program evaluates to
+some result state, rather than letting Lean's computation mechanism do
+it for us.
 
+```lean
 example :
     ∅ =[ imp {
            X := 2;
@@ -1810,104 +1868,113 @@ example :
   · apply Ceval.E_IfFalse
     · rfl
     · apply Ceval.E_Asgn; rfl
+```
 
--- EX2 (ceval_example2)
+:::::exercise (rating := 2) (name := "ceval_example2")
+```lean
 example :
     ∅ =[ imp {
            X := 0;
            Y := 1;
            Z := 2;
          } ]=> (Z →ₜ 2 ; Y →ₜ 1 ; X →ₜ 0 ; ∅) := by
-  -- ADMITTED
-  apply Ceval.E_Seq (st' := (X →ₜ 0 ; ∅))
-  · apply Ceval.E_Asgn; rfl
-  · apply Ceval.E_Seq (st' := (Y →ₜ 1 ; X →ₜ 0 ; ∅))
+  solution!
+    apply Ceval.E_Seq (st' := (X →ₜ 0 ; ∅))
     · apply Ceval.E_Asgn; rfl
-    · apply Ceval.E_Asgn; rfl
-  -- /ADMITTED
--- []
+    · apply Ceval.E_Seq (st' := (Y →ₜ 1 ; X →ₜ 0 ; ∅))
+      · apply Ceval.E_Asgn; rfl
+      · apply Ceval.E_Asgn; rfl
+```
+:::::
 
--- TERSE: /- What sorts of things might we want to prove using these definitions?  Here are some simple examples... -/
+:::terse
+What sorts of things might we want to prove using these definitions?  Here are some simple examples...
+:::
 
-/- HIDE: PR: I phrased these quizzes with the following alternatives:
+```dev
+HIDE: PR: I phrased these quizzes with the following alternatives:
    (A) Not true
    (B) True and easily provable
    (C) True and takes more work to prove
-   (D) True and cannot be proved without additional axioms -/
+   (D) True and cannot be proved without additional axioms
+```
 
--- QUIZ
-/-
-  Is the following proposition provable?
+::::quiz
+Is the following proposition provable?
 
-  ```
-  ∀ (c : Com) (st st' : State),
-    st =[ imp { skip; ~c } ]=> st' →
-    st =[ c ]=> st'
-  ```
+```
+∀ (c : Com) (st st' : State),
+  st =[ imp { skip; ~c } ]=> st' →
+  st =[ c ]=> st'
+```
 
-  (A) Yes    (B) No    (C) Not sure
--/
--- HIDE
+(A) Yes    (B) No    (C) Not sure
+
+:::answer
+```
 theorem quiz1_answer (c : Com) (st st' : State)
     (h : st =[ imp { skip; ~c } ]=> st') : st =[ c ]=> st' := by
   cases h with
   | E_Seq _ _ _ smid _ h1 h2 =>
       cases h1 with
       | E_Skip _ => exact h2
--- /HIDE
--- /QUIZ
+```
+:::
+::::
 
--- QUIZ
-/-
-  Is the following proposition provable?
+::::quiz
+Is the following proposition provable?
 
-  ```
-  ∀ (c1 c2 : Com) (st st' : State),
-    st =[ imp { ~c1 ~c2 } ]=> st' →
-    st =[ c1 ]=> st →
-    st =[ c2 ]=> st'
-  ```
+```
+∀ (c1 c2 : Com) (st st' : State),
+  st =[ imp { ~c1 ~c2 } ]=> st' →
+  st =[ c1 ]=> st →
+  st =[ c2 ]=> st'
+```
 
-  (A) Yes    (B) No    (C) Not sure
--/
--- INSTRUCTORS: Answer is given later (`quiz2_answer`) as it depends on `ceval_deterministic`.
--- /QUIZ
+(A) Yes    (B) No    (C) Not sure
 
--- QUIZ
-/-
-  Is the following proposition provable?
+```instructors
+Answer is given later (`quiz2_answer`) as it depends on `ceval_deterministic`.
+```
+::::
 
-  ```
-  ∀ (b : Bexp) (c : Com) (st st' : State),
-    st =[ imp { if (~b) { ~c } else { ~c } } ]=> st' →
-    st =[ c ]=> st'
-  ```
+::::quiz
+Is the following proposition provable?
 
-  (A) Yes    (B) No    (C) Not sure
--/
--- INSTRUCTORS
+```
+∀ (b : Bexp) (c : Com) (st st' : State),
+  st =[ imp { if (~b) { ~c } else { ~c } } ]=> st' →
+  st =[ c ]=> st'
+```
+
+(A) Yes    (B) No    (C) Not sure
+
+:::answer
+```
 theorem quiz3_answer (b : Bexp) (c : Com) (st st' : State)
     (h : st =[ imp { if (~b) { ~c } else { ~c } } ]=> st') : st =[ c ]=> st' := by
   cases h with
   | E_IfTrue _ _ _ _ _ hb hc => exact hc
   | E_IfFalse _ _ _ _ _ hb hc => exact hc
--- /INSTRUCTORS
--- /QUIZ
+```
+:::
+::::
 
--- QUIZ
-/-
-  Is the following proposition provable?
+::::quiz
+Is the following proposition provable?
 
-  ```
-  ∀ (b : Bexp),
-    (∀ st, Bexp.eval st b = true) →
-    ∀ (c : Com) (st : State),
-    ¬ ∃ st', st =[ imp { while (~b) { ~c } } ]=> st'
-  ```
+```
+∀ (b : Bexp),
+  (∀ st, Bexp.eval st b = true) →
+  ∀ (c : Com) (st : State),
+  ¬ ∃ st', st =[ imp { while (~b) { ~c } } ]=> st'
+```
 
-  (A) Yes    (B) No    (C) Not sure
--/
--- HIDE
+(A) Yes    (B) No    (C) Not sure
+
+:::answer
+```
 -- This one is tricky!
 theorem quiz4_answer (b : Bexp) (hbtrue : ∀ st, Bexp.eval st b = true)
     (c : Com) (st : State) : ¬ ∃ st', st =[ imp { while (~b) { ~c } } ]=> st' := by
@@ -1927,22 +1994,23 @@ theorem quiz4_answer (b : Bexp) (hbtrue : ∀ st, Bexp.eval st b = true)
     | E_IfTrue s0 s0' b0 d1 d2 hb0 hc0 ih => intro heq; simp at heq
     | E_IfFalse s0 s0' b0 d1 d2 hb0 hc0 ih => intro heq; simp at heq
   exact key _ st st' hev rfl
--- /HIDE
--- /QUIZ
+```
+:::
+::::
 
--- QUIZ
-/-
-  Is the following proposition provable?
+::::quiz
+Is the following proposition provable?
 
-  ```
-  ∀ (b : Bexp) (c : Com) (st : State),
-    (¬ ∃ st', st =[ imp { while (~b) { ~c } } ]=> st') →
-    ∀ st'', Bexp.eval st'' b = true
-  ```
+```
+∀ (b : Bexp) (c : Com) (st : State),
+  (¬ ∃ st', st =[ imp { while (~b) { ~c } } ]=> st') →
+  ∀ st'', Bexp.eval st'' b = true
+```
 
-  (A) Yes    (B) No    (C) Not sure
--/
-/- HIDE: This claim is *false*, so it cannot be proved -- the proof gets
+(A) Yes    (B) No    (C) Not sure
+
+````dev
+HIDE: This claim is *false*, so it cannot be proved -- the proof gets
    stuck immediately:
 
    ```
@@ -1952,32 +2020,36 @@ theorem quiz4_answer (b : Bexp) (hbtrue : ∀ st, Bexp.eval st b = true)
    Proof.
      intros b c st H st''.
    Abort. (* Can't make any progress - claim is false! *)
-   ``` -/
--- /QUIZ
+   ```
+````
+::::
 
-/-
-  ######################################################################
-  ## Determinism of Evaluation
--/
+## Determinism of Evaluation
 
-/- LATER: Maybe this should go at the end of the file in a section marked
-   optional? Not everybody will want to spend time on it. -/
+```dev
+LATER: Maybe this should go at the end of the file in a section marked
+   optional? Not everybody will want to spend time on it.
+```
 
--- FULL
-/-
-  Changing from a computational to a relational definition of evaluation
-  is a good move because it frees us from the artificial requirement that
-  evaluation be a total function. But it raises a question: is the
-  relational definition really a partial _function_? Could the same
-  command, from the same state, evaluate to two different final states?
-  In fact this cannot happen: `ceval` _is_ a partial function.
--/
--- /FULL
--- TERSE: /- Finally, we should pause to check that our evaluation relation really is a (partial) function... -/
+::::full
+Changing from a computational to a relational definition of evaluation
+is a good move because it frees us from the artificial requirement that
+evaluation be a total function. But it raises a question: is the
+relational definition really a partial _function_? Could the same
+command, from the same state, evaluate to two different final states?
+In fact this cannot happen: `ceval` _is_ a partial function.
+::::
 
-/- LATER: Informal proof needed! (And one can surely be found in some past
-   CIS500 exam solutions!) -/
+:::terse
+Finally, we should pause to check that our evaluation relation really is a (partial) function...
+:::
 
+```dev
+LATER: Informal proof needed! (And one can surely be found in some past
+   CIS500 exam solutions!)
+```
+
+```lean
 theorem ceval_deterministic (c : Com) (st st1 st2 : State)
     (e1 : st =[ c ]=> st1) (e2 : st =[ c ]=> st2) : st1 = st2 := by
   induction e1 generalizing st2 with
@@ -2012,8 +2084,10 @@ theorem ceval_deterministic (c : Com) (st st1 st2 : State)
           have hst : st' = st2' := ih1 _ hc'
           subst hst
           exact ih2 _ hl'
+```
 
--- HIDE
+::::hide
+```
 /- Answer to the second quiz above (deferred because it depends on
    `ceval_deterministic`). -/
 theorem quiz2_answer (c1 c2 : Com) (st st' : State)
@@ -2023,61 +2097,64 @@ theorem quiz2_answer (c1 c2 : Com) (st st' : State)
       have hmid : smid = st := ceval_deterministic c1 st smid st hc1 h2
       subst hmid
       exact hc2
--- /HIDE
+```
+::::
 
--- EX3? (pup_to_n)
-/-
-  Write an Imp program that sums the numbers from `1` to `X` (inclusive)
-  in the variable `Y`.  Your program should update the state as shown in
-  `pup_to_2_ceval`, which you can reverse-engineer to discover the program
-  you should write.  The proof of that theorem will be somewhat lengthy.
--/
+:::::exercise (rating := 3) (name := "pup_to_n")
+Write an Imp program that sums the numbers from `1` to `X` (inclusive)
+in the variable `Y`.  Your program should update the state as shown in
+`pup_to_2_ceval`, which you can reverse-engineer to discover the program
+you should write.  The proof of that theorem will be somewhat lengthy.
 
-def pup_to_n : Com :=
-  -- ADMITDEF
+```lean
+def pup_to_n : Com := solution!(
   imp {
     Y := 0;
     while (1 <= X) {
       Y := Y + X;
       X := X - 1;
     }
-  }
-  -- /ADMITDEF
+  })
+```
 
-/- HIDE: Result is the same as `(X →ₜ 0 ; Y →ₜ 3 ; ∅)` if one admits
-   functional extensionality. -/
+```dev
+HIDE: Result is the same as `(X →ₜ 0 ; Y →ₜ 3 ; ∅)` if one admits
+   functional extensionality.
+```
+
+```lean
 theorem pup_to_2_ceval :
     (X →ₜ 2 ; ∅) =[ pup_to_n ]=>
       (X →ₜ 0 ; Y →ₜ 3 ; X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅) := by
-  -- ADMITTED
-  unfold pup_to_n
-  apply Ceval.E_Seq (st' := (Y →ₜ 0 ; X →ₜ 2 ; ∅))
-  · apply Ceval.E_Asgn; rfl
-  · apply Ceval.E_WhileTrue (st' := (X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅))
-    · rfl
-    · apply Ceval.E_Seq (st' := (Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅)) <;>
-        (apply Ceval.E_Asgn; rfl)
-    · apply Ceval.E_WhileTrue
-        (st' := (X →ₜ 0 ; Y →ₜ 3 ; X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅))
+  solution!
+    unfold pup_to_n
+    apply Ceval.E_Seq (st' := (Y →ₜ 0 ; X →ₜ 2 ; ∅))
+    · apply Ceval.E_Asgn; rfl
+    · apply Ceval.E_WhileTrue (st' := (X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅))
       · rfl
-      · apply Ceval.E_Seq (st' := (Y →ₜ 3 ; X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅)) <;>
+      · apply Ceval.E_Seq (st' := (Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅)) <;>
           (apply Ceval.E_Asgn; rfl)
-      · apply Ceval.E_WhileFalse; rfl
-  -- /ADMITTED
--- []
+      · apply Ceval.E_WhileTrue
+          (st' := (X →ₜ 0 ; Y →ₜ 3 ; X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅))
+        · rfl
+        · apply Ceval.E_Seq (st' := (Y →ₜ 3 ; X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅)) <;>
+            (apply Ceval.E_Asgn; rfl)
+        · apply Ceval.E_WhileFalse; rfl
+```
+:::::
 
-/- LATER: Comment from reader: Another good place to mention lack of
+```dev
+LATER: Comment from reader: Another good place to mention lack of
    functional extensionality.  The 6 `→ₜ`/`t_update`s in the above theorem
    are not redundant, nor would `pup_to_2_ceval` be provable if the
    algorithm were defined differently (e.g., if it used `Z` as a "buffer"
-   variable instead of decrementing `X`). -/
+   variable instead of decrementing `X`).
+```
 
-/-
-  ######################################################################
-  # Reasoning About Imp Programs
--/
+# Reasoning About Imp Programs
 
-/- LATER: This section doesn't seem very useful -- to anybody! It takes too
+```dev
+LATER: This section doesn't seem very useful -- to anybody! It takes too
    much time to go through it in class, and even for advanced students it's
    too low-level and grubby to be a very convincing motivation for what
    follows -- i.e., to feel motivated by its grubbiness, you have to
@@ -2086,17 +2163,17 @@ theorem pup_to_2_ceval :
    or at least make it optional.
    (BCP 10/18: However, this removes quite a few exercises. Is the homework
    assignment still meaty enough? I'm going to leave it as-is for now, but
-   we should reconsider this later.) -/
+   we should reconsider this later.)
+```
 
--- FULL
-/-
-  We'll get into more systematic and powerful techniques for reasoning
-  about Imp programs in the next chapter, but we can
-  already do a few things (albeit in a somewhat low-level way) just by
-  working with the bare definitions. This section explores some examples.
--/
--- /FULL
+::::full
+We'll get into more systematic and powerful techniques for reasoning
+about Imp programs in the next chapter, but we can
+already do a few things (albeit in a somewhat low-level way) just by
+working with the bare definitions. This section explores some examples.
+::::
 
+```lean
 theorem plus2_spec (st : State) (n : Nat) (st' : State)
     (hx : st[X] = n) (heval : st =[ plus2 ]=> st') :
     st'[X] = n + 2 := by
@@ -2108,11 +2185,16 @@ theorem plus2_spec (st : State) (n : Nat) (st' : State)
       simp only [Aexp.eval] at h
       rw [TotalMap.update_eq]
       lia
+```
 
-/- LATER: This used to be recommended.  Should it be reinstated? -/
--- EX3? (XtimesYinZ_spec)
-/- State and prove a specification of `XtimesYinZ`. -/
+```dev
+LATER: This used to be recommended.  Should it be reinstated?
+```
 
+:::::exercise (rating := 3) (name := "XtimesYinZ_spec")
+State and prove a specification of `XtimesYinZ`.
+
+```lean
 -- SOLUTION
 /- Here is a specification in the style of `plus2_spec`: -/
 theorem XtimesYinZ_spec1 (st : State) (nx ny : Nat) (st' : State)
@@ -2136,39 +2218,46 @@ theorem XtimesYinZ_spec (st : State) :
 /- A less informative specification would be ... -/
 theorem XtimesYinZ_spec2 (st : State) : ∃ st', st =[ XtimesYinZ ]=> st' := by
   exact ⟨(Z →ₜ st[X] * st[Y] ; st), by unfold XtimesYinZ; apply Ceval.E_Asgn; rfl⟩
--- /SOLUTION
--- GRADE_MANUAL 3: XtimesYinZ_spec
--- []
+-- END SOLUTION
+```
 
--- EX3! (loop_never_stops)
-/-
-  Hint: proceed by induction on the assumed derivation showing that `loop`
-  terminates.  Most of the cases are immediately contradictory and so can be
-  solved in one step (by `simp`/`discriminate` on the impossible command
-  equation).
--/
+:::grade
+```
+GRADE_MANUAL 3: XtimesYinZ_spec
+```
+:::
+:::::
+
+:::::exercise (rating := 3) (name := "loop_never_stops")
+Hint: proceed by induction on the assumed derivation showing that `loop`
+terminates.  Most of the cases are immediately contradictory and so can be
+solved in one step (by `simp`/`discriminate` on the impossible command
+equation).
+
+```lean
 theorem loop_never_stops (st st' : State) : ¬ (st =[ loop ]=> st') := by
-  -- ADMITTED
-  intro contra
-  -- Generalize over the command so the induction remembers what `loop` is.
-  have key : ∀ (c : Com) (s s' : State), (s =[ c ]=> s') → c = loop → False := by
-    intro c s s' hce
-    induction hce with
-    | E_WhileFalse b s0 c0 hb =>
-        intro heq; unfold loop at heq; injection heq with e1 _
-        subst e1; simp [Bexp.eval] at hb
-    | E_WhileTrue s0 s0' s0'' b c0 hb hc hloop ih1 ih2 =>
-        intro heq; exact ih2 heq
-    | E_Skip s0 => intro heq; simp [loop] at heq
-    | E_Asgn s0 a n x h => intro heq; simp [loop] at heq
-    | E_Seq c1 c2 s0 s0' s0'' h1 h2 ih1 ih2 => intro heq; simp [loop] at heq
-    | E_IfTrue s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
-    | E_IfFalse s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
-  exact key loop st st' contra rfl
-  -- /ADMITTED
--- []
+  solution!
+    intro contra
+    -- Generalize over the command so the induction remembers what `loop` is.
+    have key : ∀ (c : Com) (s s' : State), (s =[ c ]=> s') → c = loop → False := by
+      intro c s s' hce
+      induction hce with
+      | E_WhileFalse b s0 c0 hb =>
+          intro heq; unfold loop at heq; injection heq with e1 _
+          subst e1; simp [Bexp.eval] at hb
+      | E_WhileTrue s0 s0' s0'' b c0 hb hc hloop ih1 ih2 =>
+          intro heq; exact ih2 heq
+      | E_Skip s0 => intro heq; simp [loop] at heq
+      | E_Asgn s0 a n x h => intro heq; simp [loop] at heq
+      | E_Seq c1 c2 s0 s0' s0'' h1 h2 ih1 ih2 => intro heq; simp [loop] at heq
+      | E_IfTrue s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
+      | E_IfFalse s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
+    exact key loop st st' contra rfl
+```
+:::::
 
-/- LATER: Marc Bezem 2022:
+```dev
+LATER: Marc Bezem 2022:
    There are trade-offs between using tactics and additional lemmas. Here is
    a case where a lemma would make things clearer. For `loop_never_stops`,
    the surprise is that it is proved by induction, and the Rocq tactic
@@ -2183,15 +2272,15 @@ theorem loop_never_stops (st st' : State) : ¬ (st =[ loop ]=> st') := by
    BCP 23: Not sure I see a big difference between the two presentations: both
    statements are negations, and the `remember` in the proof is avoided in
    the new one by introducing an equality in the theorem statement that IMO
-   is not very pretty... -/
+   is not very pretty...
+```
 
--- EX3 (no_whiles_eqv)
-/-
-  The following function yields `true` just on programs with no while
-  loops. Using `inductive`, write a property `NoWhilesR` that holds
-  exactly when `c` is while-free, then prove it equivalent to `Com.no_whiles`.
--/
+:::::exercise (rating := 3) (name := "no_whiles_eqv")
+The following function yields `true` just on programs with no while
+loops. Using `inductive`, write a property `NoWhilesR` that holds
+exactly when `c` is while-free, then prove it equivalent to `Com.no_whiles`.
 
+```lean
 def Com.no_whiles (c : Com) : Bool :=
   match c with
   | imp {skip;} => true
@@ -2208,58 +2297,61 @@ inductive NoWhilesR : Com → Prop where
       NoWhilesR (imp { ~c1 ~c2 })
   | nw_If (b : Bexp) (c1 c2 : Com) (h1 : NoWhilesR c1) (h2 : NoWhilesR c2) :
       NoWhilesR (imp { if (~b) { ~c1 } else { ~c2 } })
-  -- /SOLUTION
+  -- END SOLUTION
 
 theorem no_whiles_eqv (c : Com) : Com.no_whiles c = true ↔ NoWhilesR c := by
-  -- ADMITTED
-  constructor
-  · induction c with
-    | skip => intro _; exact .nw_Skip
-    | asgn x a => intro _; exact .nw_Asgn x a
-    | seq c1 c2 ih1 ih2 =>
-        intro h; simp only [Com.no_whiles, Bool.and_eq_true] at h
-        exact .nw_Seq _ _ (ih1 h.1) (ih2 h.2)
-    | cond b c1 c2 ih1 ih2 =>
-        intro h; simp only [Com.no_whiles, Bool.and_eq_true] at h
-        exact .nw_If _ _ _ (ih1 h.1) (ih2 h.2)
-    | whileDo b c ih => intro h; simp [Com.no_whiles] at h
-  · intro h
-    induction h with
-    | nw_Skip => rfl
-    | nw_Asgn x a => rfl
-    | nw_Seq c1 c2 h1 h2 ih1 ih2 => simp [Com.no_whiles, ih1, ih2]
-    | nw_If b c1 c2 h1 h2 ih1 ih2 => simp [Com.no_whiles, ih1, ih2]
-  -- /ADMITTED
--- []
+  solution!
+    constructor
+    · induction c with
+      | skip => intro _; exact .nw_Skip
+      | asgn x a => intro _; exact .nw_Asgn x a
+      | seq c1 c2 ih1 ih2 =>
+          intro h; simp only [Com.no_whiles, Bool.and_eq_true] at h
+          exact .nw_Seq _ _ (ih1 h.1) (ih2 h.2)
+      | cond b c1 c2 ih1 ih2 =>
+          intro h; simp only [Com.no_whiles, Bool.and_eq_true] at h
+          exact .nw_If _ _ _ (ih1 h.1) (ih2 h.2)
+      | whileDo b c ih => intro h; simp [Com.no_whiles] at h
+    · intro h
+      induction h with
+      | nw_Skip => rfl
+      | nw_Asgn x a => rfl
+      | nw_Seq c1 c2 h1 h2 ih1 ih2 => simp [Com.no_whiles, ih1, ih2]
+      | nw_If b c1 c2 h1 h2 ih1 ih2 => simp [Com.no_whiles, ih1, ih2]
+```
+:::::
 
--- EX4 (no_whiles_terminating)
-/-
-  Imp programs that don't involve while loops always terminate.  State and
-  prove a theorem `no_whiles_terminating` that says this.  Use either
-  `Com.no_whiles` or `NoWhilesR`, as you prefer.
--/
+:::::exercise (rating := 4) (name := "no_whiles_terminating")
+Imp programs that don't involve while loops always terminate.  State and
+prove a theorem `no_whiles_terminating` that says this.  Use either
+`Com.no_whiles` or `NoWhilesR`, as you prefer.
 
+```lean
 theorem no_whiles_terminating (c : Com) (st : State) (h : NoWhilesR c) :
     ∃ st', st =[ c ]=> st' := by
-  -- SOLUTION
-  induction h generalizing st with
-  | nw_Skip => exact ⟨st, .E_Skip st⟩
-  | nw_Asgn x a => exact ⟨(x →ₜ Aexp.eval st a ; st), .E_Asgn st a (Aexp.eval st a) x rfl⟩
-  | nw_Seq c1 c2 h1 h2 ih1 ih2 =>
-      obtain ⟨st', hc1⟩ := ih1 st
-      obtain ⟨st'', hc2⟩ := ih2 st'
-      exact ⟨st'', .E_Seq c1 c2 st st' st'' hc1 hc2⟩
-  | nw_If b c1 c2 h1 h2 ih1 ih2 =>
-      cases hb : Bexp.eval st b with
-      | true =>
-          obtain ⟨st', hc1⟩ := ih1 st
-          exact ⟨st', .E_IfTrue st st' b c1 c2 hb hc1⟩
-      | false =>
-          obtain ⟨st', hc2⟩ := ih2 st
-          exact ⟨st', .E_IfFalse st st' b c1 c2 hb hc2⟩
+  solution!
+    induction h generalizing st with
+    | nw_Skip => exact ⟨st, .E_Skip st⟩
+    | nw_Asgn x a => exact ⟨(x →ₜ Aexp.eval st a ; st), .E_Asgn st a (Aexp.eval st a) x rfl⟩
+    | nw_Seq c1 c2 h1 h2 ih1 ih2 =>
+        obtain ⟨st', hc1⟩ := ih1 st
+        obtain ⟨st'', hc2⟩ := ih2 st'
+        exact ⟨st'', .E_Seq c1 c2 st st' st'' hc1 hc2⟩
+    | nw_If b c1 c2 h1 h2 ih1 ih2 =>
+        cases hb : Bexp.eval st b with
+        | true =>
+            obtain ⟨st', hc1⟩ := ih1 st
+            exact ⟨st', .E_IfTrue st st' b c1 c2 hb hc1⟩
+        | false =>
+            obtain ⟨st', hc2⟩ := ih2 st
+            exact ⟨st', .E_IfFalse st st' b c1 c2 hb hc2⟩
+```
 
-/- And here is an alternative solution by induction on `c` (using
-   `Com.no_whiles` instead of `NoWhilesR`): -/
+And here is an alternative solution by induction on `c` (using
+   `Com.no_whiles` instead of `NoWhilesR`):
+
+```lean
+-- SOLUTION
 theorem no_whiles_terminating' (c : Com) (st1 : State)
     (hb : Com.no_whiles c = true) : ∃ st2, st1 =[ c ]=> st2 := by
   induction c generalizing st1 with
@@ -2280,30 +2372,31 @@ theorem no_whiles_terminating' (c : Com) (st1 : State)
           obtain ⟨st2, h⟩ := ih2 st1 hb.2
           exact ⟨st2, .E_IfFalse st1 st2 b ct cf hbev h⟩
   | whileDo b c ih => simp [Com.no_whiles] at hb
-  -- /SOLUTION
--- []
+-- END SOLUTION
+```
+:::::
 
-/-
-  mwhicks1: NOT PORTED YET — remaining sections of sfdev/lf/Imp.v to port:
-    - Case Study (Optional), Imp.v:2774
-        * subtract_slowly_spec (EX4?, Imp.v:2919): loop-invariant style proof
-          about `subtract_slowly`.
-    - Additional Exercises, Imp.v:2986
-        * stack_compiler (EX3, Imp.v:2988): define `s_execute` (stack machine)
-          and `s_compile : aexp -> list sinstr`; needs a `SInstr` inductive
-          (SPush/SLoad/SPlus/SMinus/SMult) and a list-based stack.
-        * execute_app (EX3, Imp.v:3114)
-        * stack_compiler_correct (EX3, Imp.v:3134): the correctness theorem;
-          the standard proof needs a strengthened lemma over an arbitrary
-          initial stack (generalize the stack before inducting).
-        * short_circuit (EX3?, Imp.v:3184): short-circuiting `Bexp.eval`.
-        * break_imp (EX4?, Imp.v:3227): extends Com with `CBreak`; new
-          relational semantics `ceval` carrying a `result` (SContinue/SBreak).
-          Large. See verso-book branch (lf/Imp.lean ~line 1141, CEvalBreak) for
-          a prior take on the signal type.
-        * while_break_true (EX3A?, Imp.v:3454)
-        * ceval_deterministic for break (EX4A?, Imp.v:3477)
-        * exn_imp (EX4A?, Imp.v:3524): exceptions variant. Large.
-        * add_for_loop (EX4?, Imp.v:3728): add a C-style `for` loop to Com,
-          its notation, and extend ceval.
--/
+```dev
+mwhicks1: NOT PORTED YET — remaining sections of sfdev/lf/Imp.v to port:
+  - Case Study (Optional), Imp.v:2774
+      * subtract_slowly_spec (EX4?, Imp.v:2919): loop-invariant style proof
+        about `subtract_slowly`.
+  - Additional Exercises, Imp.v:2986
+      * stack_compiler (EX3, Imp.v:2988): define `s_execute` (stack machine)
+        and `s_compile : aexp -> list sinstr`; needs a `SInstr` inductive
+        (SPush/SLoad/SPlus/SMinus/SMult) and a list-based stack.
+      * execute_app (EX3, Imp.v:3114)
+      * stack_compiler_correct (EX3, Imp.v:3134): the correctness theorem;
+        the standard proof needs a strengthened lemma over an arbitrary
+        initial stack (generalize the stack before inducting).
+      * short_circuit (EX3?, Imp.v:3184): short-circuiting `Bexp.eval`.
+      * break_imp (EX4?, Imp.v:3227): extends Com with `CBreak`; new
+        relational semantics `ceval` carrying a `result` (SContinue/SBreak).
+        Large. See verso-book branch (lf/Imp.lean ~line 1141, CEvalBreak) for
+        a prior take on the signal type.
+      * while_break_true (EX3A?, Imp.v:3454)
+      * ceval_deterministic for break (EX4A?, Imp.v:3477)
+      * exn_imp (EX4A?, Imp.v:3524): exceptions variant. Large.
+      * add_for_loop (EX4?, Imp.v:3728): add a C-style `for` loop to Com,
+        its notation, and extend ceval.
+```

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -570,6 +570,10 @@ mwhicks1: Not sure if we need ⇓b, or whether we can define
 ⇓ overloaded. Don't understand Lean notation yet!
 :::
 
+:::dev
+chenson2018: About `Bexp.eval` below: We should discuss a way to recall definitions without having to write them out manually like this. I think a simple `#print` may work as an alternative, assuming there are no namespace issues..
+:::
+
 :::::exercise (rating := 1) (name := "beval_rules")
 Here, again, is the definition of the {name}`Bexp.eval` function:
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ all: verso lf hl ts check-bare-lean-chapters check-verso-chapters
 # when it has been incorporated into the book via a *Verso.lean include.
 .PHONY: check-lean
 check-bare-lean-chapters:
-	lake build HL.Imp
+	@echo "no bare (un-versified) chapters to build"
 
 # Temporary:
 # Build the generated HL/TS Verso chapters that aren't in a book yet, so the
@@ -63,7 +63,7 @@ check-bare-lean-chapters:
 # the sources first.  Drop a module here once it's `{include}`d in its book.
 .PHONY: check-verso-chapters
 check-verso-chapters: verso
-	lake build $(HL_VERSO_MODULES)
+	@if [ -n "$(HL_VERSO_MODULES)" ]; then lake build $(HL_VERSO_MODULES); else echo "no generated Verso chapters to build"; fi
 
 serve: all
 	python3 -m http.server 8000 -d _out/
@@ -88,7 +88,9 @@ LF_CHAPTERS := Induction UsingLean Lists Poly Tactics Logic IndProp IndPropRegex
 
 LF_VERSO_FILES := $(addprefix LF/,$(addsuffix Verso.lean,$(LF_CHAPTERS)))
 
-HL_CHAPTERS := Imp
+# Imp is now versified directly in HL/Imp.lean and {include}d in HL.lean, so it
+# is no longer generated here.  Add future not-yet-versified HL chapters below.
+HL_CHAPTERS :=
 
 HL_VERSO_FILES := $(addprefix HL/,$(addsuffix Verso.lean,$(HL_CHAPTERS)))
 

--- a/SFLMeta/Save.lean
+++ b/SFLMeta/Save.lean
@@ -187,13 +187,18 @@ private partial def blockToText (width : Nat) : Verso.Doc.Block Manual → Strin
 
 /-! ## Lake project scaffold templates -/
 
-/-- Contents of the generated project's `lakefile.toml`. -/
-private def lakefileTemplate (vol : String) : String :=
+/-- Contents of the generated project's `lakefile.toml`. `extraLibs` names the
+additional `lean_lib`s holding bundled prerequisite sources (e.g. `LF` for the
+bare `LF/Maps.lean` that Imp depends on). -/
+private def lakefileTemplate (vol : String) (extraLibs : Array String) : String :=
+  let extra := extraLibs.foldl (init := "") fun acc l =>
+    acc ++ "\n[[lean_lib]]\nname = \"" ++ l ++ "\"\n"
   "name = \"" ++ vol.toLower ++ "-extracted\"\n" ++
   "version = \"0.1.0\"\n" ++
   "defaultTargets = [\"" ++ vol ++ "\"]\n\n" ++
   "[[lean_lib]]\n" ++
-  "name = \"" ++ vol ++ "\"\n"
+  "name = \"" ++ vol ++ "\"\n" ++
+  extra
 
 /-! ## ExtraStep walker -/
 
@@ -718,15 +723,18 @@ Write a complete generated Lake project at `dest`: the per-file buffer
 contents under `dest/`, plus `lakefile.toml`, `lean-toolchain`, and a `LF.lean`
 that imports `LF.STLC`. -/
 private def writeProject (dest : System.FilePath) (toolchain : String)
-    (vol kind : String) (files : Array (String × String)) : IO Unit := do
+    (vol kind : String) (files : Array (String × String))
+    (extraLibs : Array String) : IO Unit := do
   IO.FS.createDirAll dest
-  -- Clear the volume source tree so chapter files that have since been renamed
-  -- or removed don't linger as stale orphans. Other artifacts (`.lake`,
-  -- `lakefile.toml`, `lean-toolchain`, `README.md`) are left alone.
-  let chapterRoot := dest / vol
-  if ← chapterRoot.pathExists then
-    IO.FS.removeDirAll chapterRoot
-  IO.FS.writeFile (dest / "lakefile.toml") (lakefileTemplate vol)
+  -- Clear the volume source tree (and any bundled-prerequisite lib trees) so
+  -- files that have since been renamed or removed don't linger as stale
+  -- orphans. Other artifacts (`.lake`, `lakefile.toml`, `lean-toolchain`,
+  -- `README.md`) are left alone.
+  for lib in vol :: extraLibs.toList do
+    let libRoot := dest / lib
+    if ← libRoot.pathExists then
+      IO.FS.removeDirAll libRoot
+  IO.FS.writeFile (dest / "lakefile.toml") (lakefileTemplate vol extraLibs)
   IO.FS.writeFile (dest / "lean-toolchain") toolchain
   IO.FS.writeFile (dest / "README.md")
     s!"# {vol} — {kind} version\n\nGenerated from the Verso source.\n"
@@ -753,6 +761,72 @@ private def buildProject (dest : System.FilePath) (kind : String) :
   else
     IO.println s!"Generated {kind} project built successfully."
 
+/-! ## Extracted-project imports & bundled prerequisites
+
+Extracted `.lean` projects are standalone Lake packages, so each chapter's
+outside dependencies must be reconstructed from its own header `import`s: drop
+the framework imports (they build the book, not student code), re-emit the rest,
+and bundle the source of any that is a content prerequisite (not toolchain, not
+an emitted book chapter — e.g. the bare `LF.Maps`) under its own `lean_lib`. A
+bundled module is copied verbatim, so it must be plain (non-Verso) Lean. -/
+
+/-- Module top-namespaces belonging to the authoring framework: their imports
+build the book but must never appear in an extracted `.lean` file. -/
+private def frameworkPrefixes : List String :=
+  ["VersoManual", "Verso", "Illuminate", "SFLMeta", "SubVerso"]
+
+/-- Toolchain-provided top-namespaces: always available in any Lake project, so
+they stay as `import` lines but are never bundled as source. -/
+private def corePrefixes : List String :=
+  ["Lean", "Std", "Init", "Batteries"]
+
+/-- Top namespace of a module name (`LF.Maps` ⇒ `LF`). -/
+private def modTop (m : String) : String := (m.splitOn ".").headD m
+
+/-- Should module `m` appear as an `import` in an extracted file? (Framework
+imports are dropped; everything else — toolchain and content — is kept.) -/
+private def keepImport (m : String) : Bool := ! frameworkPrefixes.contains (modTop m)
+
+/-- The relative source path of a module (`LF.Maps` ⇒ `LF/Maps.lean`). -/
+private def modToPath (m : String) : String := m.replace "." "/" ++ ".lean"
+
+/-- Header `import` module names in Lean source text, scanning only the file
+header (up to the first `#doc`). -/
+private def headerImports (src : String) : Array String := Id.run do
+  let mut out : Array String := #[]
+  for raw in src.splitOn "\n" do
+    let line := raw.trimAscii.toString
+    if line.startsWith "#doc" then break
+    if line.startsWith "import " then
+      out := out.push ((line.drop 7).trimAscii.toString)
+  return out
+
+/-- Transitively gather the bundled prerequisite files (path, verbatim source)
+and the extra `lean_lib` names they need. `needsBundle` decides which modules
+are content prerequisites (not framework, not toolchain, not an emitted
+chapter). -/
+private partial def bundleLoop (needsBundle : String → Bool)
+    (queue seen : List String)
+    (files : Array (String × String)) (libs : Array String) :
+    IO (Array (String × String) × Array String) := do
+  match queue with
+  | [] => return (files, libs)
+  | m :: rest =>
+    if seen.contains m then
+      bundleLoop needsBundle rest seen files libs
+    else
+      let path := modToPath m
+      if ! (← (System.FilePath.mk path).pathExists) then
+        -- Not a bundleable source file (e.g. a spurious match); skip it.
+        bundleLoop needsBundle rest (m :: seen) files libs
+      else
+        let content ← IO.FS.readFile path
+        let top := modTop m
+        let libs := if libs.contains top then libs else libs.push top
+        let deps := (headerImports content).toList.filter needsBundle
+        bundleLoop needsBundle (rest ++ deps) (m :: seen)
+          (files.push (path, content)) libs
+
 /--
 Shared implementation. Writes the extracted Lean project to
 `_out/<destSlug>/<variant>/lean/`, next to that variant's `html-multi/`
@@ -776,15 +850,42 @@ private def emitSavedImpl (destSlug modPrefix variant : String)
     let toolchain ← (IO.FS.readFile "lean-toolchain").toBaseIO >>= fun
       | .ok s => pure s
       | .error _ => pure "leanprover/lean4:v4.30.0-rc2\n"
-    let files : Array (String × String) :=
-      buf.fold (init := #[]) fun acc file (teacher, student, terse) =>
-        let chosen :=
-          if variant == "solutions" then teacher
-          else if variant == "terse" then terse
-          else student
-        acc.push (file, mergeAdjacentModuleDocs chosen)
+    let rootFile := modPrefix ++ ".lean"
+    -- Snapshot the buffer as a list so we can read source files (IO) per entry.
+    let entries := buf.fold (init := ([] : List (String × (String × String × String))))
+      fun acc k v => (k, v) :: acc
+    -- Emitted book chapters: buffer keys with a path separator (the root
+    -- `<Vol>.lean` has none). `HL/Imp.lean` ⇒ module `HL.Imp`.
+    let chapterModules := entries.map (·.1) |>.filter (·.any (· == '/'))
+      |>.map fun k => ((k.dropEnd 5).toString).replace "/" "."
+    let needsBundle (m : String) : Bool :=
+      keepImport m && ! corePrefixes.contains (modTop m) && ! chapterModules.contains m
+    -- Pick the variant per file; prepend each chapter's (framework-stripped)
+    -- import preamble; collect bundle seeds from the chapters' source imports.
+    let mut files : Array (String × String) := #[]
+    let mut seeds : List String := []
+    for (file, teacher, student, terse) in entries do
+      let chosen := mergeAdjacentModuleDocs <|
+        if variant == "solutions" then teacher
+        else if variant == "terse" then terse
+        else student
+      if file == rootFile then
+        files := files.push (file, chosen)
+      else
+        -- The buffer key is the chapter's repo-relative source path, so read its
+        -- real header imports and re-emit the non-framework ones.
+        let src ← (IO.FS.readFile file).toBaseIO >>= fun
+          | .ok s => pure s
+          | .error _ => pure ""
+        let imps := (headerImports src).toList.filter keepImport
+        seeds := seeds ++ imps.filter needsBundle
+        let preamble := imps.foldl (init := "") fun acc i => acc ++ "import " ++ i ++ "\n"
+        let preamble := if preamble.isEmpty then "" else preamble ++ "\n"
+        files := files.push (file, preamble ++ chosen)
+    let (bundleFiles, extraLibs) ← bundleLoop needsBundle seeds [] #[] #[]
+    let allFiles := files ++ bundleFiles
     let dest := System.FilePath.mk "_out" / destSlug / variant / "lean"
-    writeProject dest toolchain modPrefix variant files
+    writeProject dest toolchain modPrefix variant allFiles extraLibs
     if verify then buildProject dest variant
 
 /-- `ExtraStep` for the student build: solutions elided. -/

--- a/scripts/check_verso_markers.py
+++ b/scripts/check_verso_markers.py
@@ -65,7 +65,9 @@ _POLICY = [
     ("TERSE",                r"::+(?:terse|slidebreak)\b"),
     ("EX\\d+[A-Za-z!?]*",    r"::+exercise\b"),
     ("GRADE_\\w+",           r":::grade\b"),
-    ("INSTRUCTORS",          r"```instructors\b"),
+    # `-- INSTRUCTORS:` notes -> :::instructors; a bare `-- INSTRUCTORS` region
+    # is a hidden region (-> ::::hide, or :::answer inside a quiz).
+    ("INSTRUCTORS",          r":::instructors\b|::+hide\b|:::answer\b"),
     # A SOLUTION is one of two things: a *compilable* answer becomes the in-code
     # `solution!` / `-- SOLUTION` form SFLMeta rewrites; a *prose* answer becomes
     # a :::solution directive.  Either counts as translated.  QUIETSOLUTION (a
@@ -94,11 +96,11 @@ _POLICY = [
     ("ADMITDEF",             None),
 ]
 
-# Author / developer notes -> ```dev code blocks.  Matched separately because
+# Author / developer notes -> :::dev directives.  Matched separately because
 # the keyword is an author initial or task word, not a region name.
 _AUTHOR_KEYWORDS = ("BCP", "JC", "MWH", "CGH", "RAB", "CH", "HG", "NB", "MMG",
                     "APT", "DHS", "TODO", "TOFIX", "LATER", "SOONER")
-_AUTHOR_EXPECT = r"```dev\b"
+_AUTHOR_EXPECT = r":::dev\b"
 
 # A line reduces to a "marker keyword" candidate if, after stripping a leading
 # `--` line-comment prefix or a `/-`/`-/` block-comment fence and an optional

--- a/scripts/to_verso.py
+++ b/scripts/to_verso.py
@@ -1361,19 +1361,17 @@ class Renderer:
         self._append(':::solution\n' + _verbatim_block(text) + '\n:::\n\n')
 
     def _emit_noop_directive(self, directive, text):
-        # Author notes become noop annotation *code blocks* (```dev / ```instructors).
-        # The text is preserved in the Verso source, but the block discards its
-        # body so it never reaches the generated outputs.  ```dev and
-        # ```instructors are processed identically (see SFLMeta); they differ only
-        # in name so instructor notes can be treated differently later.
-        #
-        # A code block delivers its body to the expander as a raw string that
-        # Verso never parses as markdown, so arbitrary author text (underscores,
-        # `*`, `[...]`, a leading `#`, `:::`, ...) can't break the parser — unlike
-        # a `:::` directive, whose body IS parsed and so used to need an inner
-        # verbatim fence.  The single tagged fence replaces that nesting.
-        self._flush_code()  # still acts as a code-block separator
-        self._append(_code_block(directive, text) + '\n\n')
+        # Author notes become noop annotation *directives* (:::dev / :::instructors),
+        # consistent with :::hide / :::answer / :::grade / :::solution.  The body is
+        # wrapped in a verbatim fence so arbitrary author prose (underscores, `*`,
+        # `[...]`, a leading `#`, `:::`, ...) can never derail Verso's directive
+        # parser; the directive discards its body at elaboration, so nothing reaches
+        # the generated outputs.  :::dev and :::instructors are processed identically
+        # (see SFLMeta); they differ only in name so instructor notes can be treated
+        # differently later.  (Hand-authored chapters may instead inline the body as
+        # markdown, backticking/escaping as needed — see CONTRIBUTING.md.)
+        self._flush_code()  # still acts as a block separator
+        self._append(':::' + directive + '\n' + _verbatim_block(text) + '\n:::\n\n')
 
     # --- Main dispatch ---
 
@@ -1530,35 +1528,42 @@ def _normalize_heading_levels(text: str) -> str:
 
 
 def _fuse_noop_blocks(text: str) -> str:
-    """Fuse runs of consecutive ```dev / ```instructors code blocks (separated
-    only by blank lines) into a single same-tag block, so a run of adjacent
-    author notes renders as one box rather than a stack of tiny ones.  The fused
-    body is re-fenced via `_code_block`, so a fence that had to grow to outrun
-    backticks in one note still outruns backticks in the combined body.  Only
-    same-tag blocks fuse (a `dev` never merges into an `instructors`)."""
+    """Fuse runs of consecutive :::dev / :::instructors directives (separated
+    only by blank lines) into a single same-tag directive, so a run of adjacent
+    author notes renders as one box rather than a stack of tiny ones.  Each note
+    is a `:::<tag>` directive wrapping a verbatim fence (see `_emit_noop_directive`);
+    the fused body is re-wrapped via `_verbatim_block`, so a fence that had to grow
+    to outrun backticks in one note still outruns backticks in the combined body.
+    Only same-tag directives fuse (a `dev` never merges into an `instructors`)."""
     lines = text.split('\n')
     out, i, n = [], 0, len(lines)
     while i < n:
-        m = re.match(r'^(`{3,})(dev|instructors)$', lines[i])
-        if not m:
+        m = re.match(r'^:::(dev|instructors)$', lines[i])
+        # Only fuse a directive immediately wrapping a verbatim fence.
+        if not (m and i + 1 < n and re.match(r'^`{3,}$', lines[i + 1])):
             out.append(lines[i]); i += 1; continue
-        tag = m.group(2)
+        tag = m.group(1)
         bodies = []
         while i < n:
-            mm = re.match(r'^(`{3,})' + re.escape(tag) + r'$', lines[i])
-            if not mm:
+            mm = re.match(r'^:::' + tag + r'$', lines[i])
+            fm = re.match(r'^(`{3,})$', lines[i + 1]) if mm and i + 1 < n else None
+            if not fm:
                 break
-            fence = mm.group(1)
-            j = i + 1
+            fence = fm.group(1)
+            j = i + 2
             body = []
             while j < n and lines[j] != fence:
                 body.append(lines[j]); j += 1
+            j += 1                                  # skip the closing fence
+            if j < n and lines[j].strip() == ':::':  # skip the directive close
+                j += 1
             bodies.append('\n'.join(body))
-            k = j + 1
-            while k < n and lines[k].strip() == '':  # skip blanks between blocks
-                k += 1
-            i = k
-        out.append(_code_block(tag, '\n\n'.join(bodies)))
+            while j < n and lines[j].strip() == '':  # skip blanks between blocks
+                j += 1
+            i = j
+        out.append(':::' + tag)
+        out.append(_verbatim_block('\n\n'.join(bodies)))
+        out.append(':::')
         out.append('')
     return '\n'.join(out)
 

--- a/scripts/to_verso.py
+++ b/scripts/to_verso.py
@@ -16,8 +16,9 @@ Each /- ... -/ block comment becomes Verso prose.  Code is wrapped in
   -- BCP:/JC:/etc.    → :::dev blocks
   code                → ```lean blocks
 
-Note: -- ADMITDEF / -- /ADMITDEF and -- ADMITTED markers are left as Lean
-comments inside code blocks.  A future pass will convert them to solution!().
+Note: -- ADMITDEF / -- /ADMITDEF and -- ADMITTED markers are converted to
+solution!() wrappers (see `_convert_solution_markers`), so the student build
+stubs the elided definition/proof to `sorry` and the teacher build keeps it.
 
 A Rocq source (SOURCE.v) is also accepted: its comment/marker layer is first
 converted to the code-forward Lean-comment dialect above (the code lines stay
@@ -590,8 +591,13 @@ _GRADE_RE = re.compile(r'^--\s+GRADE_')
 # lines still fall through and are dropped, as before.
 _LINE_HEADER_HASH_RE = re.compile(r'^--\s+(#{1,6})\s+(\S.*)$')
 _LINE_HEADER_STAR_RE = re.compile(r'^--\s+(\*{1,3})\s+(\S.*)$')
-_HIDE_OPEN_RE = re.compile(r'^-- HIDE$')
-_HIDE_CLOSE_RE = re.compile(r'^-- /HIDE$')
+# Hidden regions: `-- HIDE … -- /HIDE` and the region form
+# `-- INSTRUCTORS … -- /INSTRUCTORS` (bare, no colon — distinct from the
+# `-- INSTRUCTORS:` author note handled by `_INSTRUCTOR_RE`).  Both are captured
+# verbatim and emitted as :::hide (or :::answer when nested inside a quiz); the
+# content is often deliberately admitted, so it must never be elaborated.
+_HIDE_OPEN_RE = re.compile(r'^-- (?:HIDE|INSTRUCTORS)$')
+_HIDE_CLOSE_RE = re.compile(r'^-- /(?:HIDE|INSTRUCTORS)$')
 # Paired `-- QUIZ` … `-- /QUIZ` review question.  Unlike HIDE, the region is
 # shown (-> ::::quiz); a `-- HIDE` nested inside becomes the quiz's :::answer.
 _QUIZ_OPEN_RE = re.compile(r'^-- QUIZ$')
@@ -607,8 +613,9 @@ _SOL_CLOSE_RE = re.compile(r'^--\s+/\s?(?:QUIET)?SOLUTION$')
 # Author-only / developer comment markers.  These are swept into :::dev blocks
 # (discarded from generated outputs, preserved verbatim in the Verso source).
 # The recognized tag set is `_DEV_TAGS` (defined above — add new tags there).
-# NB: INSTRUCTORS is handled separately (-> :::instructor); TERSE/FULL have their
-# own dedicated markers.
+# NB: the `-- INSTRUCTORS:` author note is handled separately (-> :::instructor),
+# and the bare `-- INSTRUCTORS` region form is a hidden region (see
+# `_HIDE_OPEN_RE`); TERSE/FULL have their own dedicated markers.
 _AUTHOR_RE = re.compile(r'^-- (' + _DEV_TAGS + r')[: (](.*)$')
 
 # `-- ==> …` / `-- ===> …` hand-written eval-output annotations: intentionally
@@ -1752,6 +1759,11 @@ def _convert_solution_markers(src: str) -> str:
         := <body>
         -- /ADMITDEF
 
+      def f … : T :=         ->   def f … : T := solution!(
+        -- ADMITDEF                 <body>)
+        <body>
+        -- /ADMITDEF
+
       <inside `by`>           ->   solution!
         -- ADMITTED                   <tactics, reindented one level deeper>
         <tactics>
@@ -1769,18 +1781,37 @@ def _convert_solution_markers(src: str) -> str:
         line = lines[i]
         s = line.strip()
 
-        # --- ADMITDEF: wrap the definition body (`:= …`) in solution!(…) ---
-        if s == '-- ADMITDEF':
+        # --- ADMITDEF: wrap the definition body in solution!(…) so the student
+        # build stubs the definition to `:= sorry` (keeping the name defined, so
+        # later references still elaborate) while the teacher build keeps the
+        # body.  The `:=` may sit either on the first body line (after the
+        # marker) or already on the definition's signature line above it. ---
+        if s in ('-- ADMITDEF', '/- ADMITDEF -/'):
             j = i + 1
             body = []
-            while j < n and lines[j].strip() != '-- /ADMITDEF':
+            while j < n and lines[j].strip() not in ('-- /ADMITDEF', '/- /ADMITDEF -/'):
                 body.append(lines[j]); j += 1
+            # index of the last non-blank body line (where the closing `)` goes)
+            last = len(body) - 1
+            while last > 0 and not body[last].strip():
+                last -= 1
             if body:
                 m = re.match(r'^(\s*:=)\s*(.*)$', body[0])
                 if m:
+                    # `:=` leads the body: `:= <expr>` -> `:= solution!(<expr>)`.
                     body[0] = m.group(1) + ' solution!(' + m.group(2)
-                    body[-1] = body[-1] + ')'
-                out.extend(body)
+                    body[last] = body[last] + ')'
+                    out.extend(body)
+                else:
+                    # `:=` is on the signature line already emitted above; find it
+                    # (skipping blank lines) and open `solution!(` there.
+                    p = len(out) - 1
+                    while p >= 0 and not out[p].strip():
+                        p -= 1
+                    if p >= 0 and out[p].rstrip().endswith(':='):
+                        out[p] = out[p].rstrip() + ' solution!('
+                        body[last] = body[last] + ')'
+                    out.extend(body)
             i = j + 1
             continue
 


### PR DESCRIPTION
I ran `to_verso.py` to convert `HL/Imp.lean` to verso format, and then
1. scrutinized the result, to make sure no content was lost
2. made sure everything builds properly, solutions are hidden/revealed, files render properly
3. dropped the non-verso Imp file and replaced it with the Imp one, and updated the Makefile accordingly

In this process I found that SFLMeta/Save.lean was missing some functionality: It needs to be able to import files from other volumes (i.e., LF, for LF/Maps.lean). So I updated that. I also found that to_verso.py was mis-translating some directives, so I fixed those too. Mostly around handling exercise solutions.

I used Claude to help with the script code changes.