### PR TITLE
Fix `irreducible` usage throughout development

### DIFF
--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1672,17 +1672,6 @@ rather than `rfl`-ing through the definition.
 
 ## Working with Numerals
 
-<<<<<<< HEAD
-=======
-:::dev "Benjamin Pierce (bcpierce00)"
-The following lemmas are also needed by the TERSE version,
-so I am un-fulling them for now.
-But indeed the whole discussion here needs both TERSE and FULL versions.
-Or probably some of it should turn into an exercise?
-RAB: This will be part of our discussion on presenting laws.
-:::
-
->>>>>>> 1a5154146468620661601b131d88102d0d94d9b8
 We know from our definitions above that `one` is just `succ zero`,
 `two` is `succ one`, and so on. We can write rules for these equalities too:
 

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1760,7 +1760,7 @@ RAB: Agreed if we're keeping these visible; putting off
      small decision until large decision is made.
 :::
 
-Prove this property using rewriting with the simplification rules for addition and multiplication.
+Prove these thoerems using rewriting with the simplification rules for addition and multiplication.
 
 ::::full
 (We have given you the first line.) Notice how `rewrite`
@@ -1775,7 +1775,34 @@ with multiple rules.
 
 ::::exercise (rating := 2) (name := "test_mult1")
 ```lean
-theorem test_mult1 : (two * two : Nat) = four := by
+theorem zero_add_one : (zero + one : Nat) = one := by
+  rewrite [one_eq_succ_zero]
+  solution!
+    rewrite [add_succ, add_zero]
+    rfl
+
+theorem one_add_one : (one + one : Nat) = two := by
+  rewrite [one_eq_succ_zero]
+  solution!
+    rewrite [add_succ, add_zero]
+    rfl
+
+
+theorem zero_mul_two : (zero * two : Nat) = zero := by
+  rewrite [two_eq_succ_one, one_eq_succ_zero]
+  solution!
+    rewrite [mul_succ, mul_succ, mul_zero]
+    rewrite [add_zero, add_zero]
+    rfl
+
+theorem one_mul_two : (one * two : Nat) = two := by
+  rewrite [two_eq_succ_one, one_eq_succ_zero]
+  solution!
+    rewrite [mul_succ, mul_succ, mul_zero]
+    rewrite [add_succ, add_zero, add_succ, add_zero]
+    rfl
+
+theorem two_mul_two : (two * two : Nat) = four := by
   rewrite [two_eq_succ_one, one_eq_succ_zero]
   solution!
     rewrite [mul_succ, mul_succ, mul_zero]
@@ -2399,6 +2426,8 @@ inductive Bin : Type where
   | b0 (n : Bin)
   | b1 (n : Bin)
 
+attribute [pp_nodot] Bin.b1 Bin.b0
+
 def incr (m : Bin) : Bin
   := solution!(match m with
   | .z => .b1 .z
@@ -2424,11 +2453,31 @@ theorem binToNat_b0 m : binToNat (.b0 m) = binToNat m * two := solution!(by rfl)
 theorem binToNat_b1 m : binToNat (.b1 m) = binToNat m * two + one := solution!(by rfl)
 ```
 
+You may find your previous proofs of `zero_add_one`, `one_add_one`, `zero_mul_two`,
+`one_mul_two`, and `two_mul_two` useful here.
+
 ```lean
-example : binToNat (.b0 (.b1 .z)) = two := solution!(by rfl)
-example : binToNat (incr (.b1 .z)) = add one (binToNat (.b1 .z)) := solution!(by rfl)
-example : binToNat (incr (incr (.b1 .z))) = add two (binToNat (.b1 .z)) := solution!(by rfl)
-example : binToNat (.b0 (.b0 (.b1 .z))) = four := solution!(by rfl)
+example : binToNat (.b0 (.b1 .z)) = two := solution!(by
+  rewrite [binToNat_b0, binToNat_b1, binToNat_z]
+  rewrite [zero_mul_two, zero_add_one, one_mul_two]
+  rfl
+
+)
+example : binToNat (incr (.b1 .z)) = add one (binToNat (.b1 .z)) := solution!(by
+    rewrite [binToNat_b1, binToNat_z, incr_b1, binToNat_b0, incr_z, binToNat_b1, binToNat_z]
+    rewrite [zero_mul_two, zero_add_one, one_mul_two, one_add_one]
+    rfl
+)
+example : binToNat (incr (incr (.b1 .z))) = add two (binToNat (.b1 .z)) := solution!(by
+  rewrite [binToNat_b1, binToNat_z, incr_b1, incr_b0, binToNat_b1, incr_z, binToNat_b1, binToNat_z]
+  rewrite [zero_mul_two, zero_add_one, one_mul_two]
+  rfl
+)
+example : binToNat (.b0 (.b0 (.b1 .z))) = four := solution!(by
+  rewrite [binToNat_b0, binToNat_b0, binToNat_b1, binToNat_z]
+  rewrite [zero_mul_two, zero_add_one, one_mul_two, two_mul_two]
+  rfl
+)
 
 attribute [irreducible] incr binToNat
 ```

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -822,15 +822,11 @@ result.
 ::::exercise (rating := 1) (name := "is_weekend")
 Define a function that takes a day and returns true if the day is
 a weekend, and false otherwise.
-You may wonder what the `@[irreducible]`, `seal` and `unseal`,
-that we use in the examples below mean.
-Hold onto this question; we will explain shortly.
 
 Hint: You could do this by pattern matching on each possible day of the week,
 or you could try to come up with a shorter solution...
 
 ```lean
-@[irreducible]
 def is_weekend (d : Day) : Bool
   := solution!
     (match d with
@@ -839,10 +835,8 @@ def is_weekend (d : Day) : Bool
     | _ => false
     )
 
-unseal is_weekend
 example : is_weekend Day.sunday = true := solution!(by rfl)
 example : is_weekend Day.friday = false := solution!(by rfl)
-seal is_weekend
 ```
 :::dev
 RAB, to NH: 1/2 new exercises to grade. Thanks!
@@ -865,7 +859,6 @@ Red is an inversion of blue, and vice versa.
 Green is not an inversion of anything.
 
 ```lean
-@[irreducible]
 def is_inversion (c1 c2 : Color) : Bool
   := solution!
     (match c1, c2 with
@@ -876,14 +869,12 @@ def is_inversion (c1 c2 : Color) : Bool
     | _, _ => false
     )
 
-unseal is_inversion
 example : is_inversion Color.black Color.white = true := solution!(by rfl)
 example : is_inversion Color.white Color.black = Bool.true := solution!(by rfl)
 example : is_inversion (Color.primary RGB.red) (Color.primary RGB.blue) = Bool.true :=
   solution!(by rfl)
 example : is_inversion (Color.primary RGB.green) (Color.primary RGB.red) = Bool.false :=
   solution!(by rfl)
-seal is_inversion
 ```
 :::dev
 RAB, to NH: 2/2 new exercise to grade
@@ -1266,13 +1257,11 @@ def four  : Nat := succ three
 We can also write functions on `Nat`.
 
 ```lean
-@[irreducible]
 def pred (n : Nat) : Nat :=
   match n with
   | zero => zero
   | succ n' => n'
 
-@[irreducible]
 def minustwo (n : Nat) : Nat :=
   match n with
   | zero => zero
@@ -1320,17 +1309,14 @@ Here are some recursive functions on natural numbers:
 :::
 
 ```lean
-@[irreducible]
 def even (n : Nat) : Bool :=
   match n with
   | zero => true
   | succ (zero) => false
   | succ (succ n') => even n'
 
-unseal even
 example : even one = false  := by rfl
 example : even four = true := by rfl
-seal even
 ```
 
 :::slidebreak
@@ -1340,14 +1326,11 @@ We could define `odd` by a similar recursive declaration, but
 here is a simpler way:
 
 ```lean
-@[irreducible]
 def odd (n : Nat) : Bool :=
   not (even n)
 
-unseal odd even
 example : odd one = true  := by rfl
 example : odd four = false := by rfl
-seal odd even
 ```
 
 :::slidebreak
@@ -1356,7 +1339,6 @@ seal odd even
 This function takes multiple parameters, recursing on the second:
 
 ```lean
-@[irreducible]
 def add (n : Nat) (m : Nat) : Nat :=
   match m with
   | zero => n
@@ -1401,7 +1383,6 @@ We can prove properties of recursive functions like `add`:
 ::::
 
 ```lean
-unseal add in
 theorem add_zero : ∀ n : Nat, n + zero = n := by
   intro n
   rfl
@@ -1520,7 +1501,6 @@ Here's another rule we can use for `add`:
 ::::
 
 ```lean
-unseal add in
 theorem add_succ : ∀ n m : Nat, n + (succ m) = succ (n + m) := by
   intro n m
   rfl
@@ -1548,7 +1528,6 @@ attribute [pp_nodot] succ
 Step through the proof below again and see how Lean's printing has changed.
 
 ```lean
-unseal add in
 theorem add_succ' : ∀ n m : Nat, n + (succ m) = succ (n + m) := by
   intro n m
   rfl
@@ -1573,13 +1552,6 @@ changes the proof state and hovering over each argument to `rewrite` to see its 
 ## Irreducibility, Rewriting, and Proof Engineering
 
 ::::full
-The definitions and proofs above use a few somewhat mysterious conventions:
-we write `@[irreducible]` above some of our definitions, and we
-write `unseal` before some of our proofs and `seal` after them.
-These are not things you will usually see in real Lean developments;
-however, we use them in this book to enforce a particular convention
-to help you build good Lean habits.
-
 Lean, like any other programming language, has conventions and best practices
 for writing good software. You are probably familiar with object oriented programming,
 for example, in which it is considered good practice not to access the
@@ -1593,58 +1565,49 @@ definitions by using `rfl` to implicitly simplify expressions
 that aren't syntactically identical. If you take a look at the proofs of
 `add_zero` and `add_succ` above, you will notice this is exactly what we did
 when we used the `rfl` tactic.
-::::
 
-::::terse
-Marking a definition `@[irreducible]` prevents proofs from "peeking" through it with `rfl`.
-::::
+However, the foundational theorems `add_zero` and `add_succ` provide a
+characterization of the behavior of `add` that makes using `rfl` to simplify
+expressions unnecessary; instead, we can rewrite by these theorems anywhere we want to describe
+how `add` evaluates.
 
-::::full
 In this text, to enforce idiomatic style, we mark
-definitions with `@[irreducible]` to prevent this peeking,
+definitions with `attribute [irreducible]` to prevent this peeking,
 also called *definitional equality abuse* (*defeq abuse*, for short).
-The `unseal` we wrote before the proof of `add_zero` temporarily
-allows this, but only in that proof. We allow unsealing the definition
-for `add_zero` and `add_succ`, but then expect that from this point on,
-these foundational theorems should provide a characterization of the behavior
-of `add` that makes further unsealing unnecessary. Instead,
-we can rewrite by these theorems anywhere we want to describe how `add`
-evaluates. The motivation for this strict discipline is both readability
-and performance; unfolding definitions can have negative effects as libraries scale.
+We place this attribute after the proofs of `add_zero` and `add_succ`,
+and can then rewrite by these theorems anywhere we want to describe
+how `add` evaluates.
+
+We will relax this discipline in later chapters, but for now we enforce it to build good
+proof engineering habits.
 ::::
 
 ::::terse
-`unseal` lifts that restriction just long enough to prove the theorems that characterize the definition.
+After proving the theorems that characterize a definition,
+we mark the definition `irreducible` to require rewriting by them instead
+of using `rfl`.
 ::::
 
-:::dev
-BCP: We start by saying that what we're going to here is not what real lean developments do, but then
-explain why what we're doing in a way that makes it sound like it is (or should be) standard. And we
-never say what is the style that we *don't* do (but that standard Lean practice does).
-RAB: This will (hopefully) be addressed by our decision on hiding these
-definitions. Even if not, it seems odd to discuss how to write this section
-before we make that choice.
-:::
+```lean
+attribute [irreducible] add
+```
 
-These two theorems also follow a particular pattern. Let's look again at the
-definition of `add`:
+These characterizing theorems also follow a particular pattern. Let's look again at the
+definition of `add`, without the `+` notation for maximum clarity:
 
 ```lean
 namespace AddPlayground
 
-/- repeating the definition here for ease of reference:
 def add (n : Nat) (m : Nat) : Nat :=
   match m with
   | zero => n
-  | succ m' => succ (add n m') -/
+  | succ m' => succ (add n m')
 
-unseal add in
-theorem add_zero : ∀ (n : Nat), n + zero = n := by
+theorem add_zero : ∀ (n : Nat), add n zero = n := by
   intro n
   rfl
 
-unseal add in
-theorem add_succ : ∀ (n m : Nat), n + (succ m) = succ (n + m) := by
+theorem add_succ : ∀ (n m : Nat), add n (succ m) = succ (add n m) := by
   intro n m
   rfl
 
@@ -1654,13 +1617,13 @@ end AddPlayground
 ::::full
 Each of `add_zero` and `add_succ` correspond to one branch of the `match`
 statement defining `add` and describe how the evaluation of `add` proceeds
-in that case. The `add_zero` theorem describes how `n + zero` evaluates,
-while `add_succ` describes (symbolically) how `n + succ m` evaluates.
+in that case. The `add_zero` theorem describes how `add n zero` evaluates,
+while `add_succ` describes (symbolically) how `add n (succ m)` evaluates.
 Because these theorems describe how to simplify more complex expressions
 involving `add`, we call them _simplification lemmas_ for `add`.
 
 These are instances of a general pattern: each definition
- operating over enumerated types like `Nat`, `Bool`, `Day`, or `Color`
+operating over enumerated types like `Nat`, `Bool`, `Day`, or `Color`
 needs a simplification lemma for each branch of control flow through
 the function.
 
@@ -1673,30 +1636,33 @@ Each branch of a definition's control flow gets one _simplification lemma_. Here
 ::::
 
 ```lean
-unseal Nat.pred in
-theorem pred_zero : Nat.pred zero = zero := by rfl
+theorem pred_zero : pred zero = zero := by rfl
+theorem pred_succ n : pred (succ n) = n := by rfl
+```
 
-unseal Nat.pred in
-theorem pred_succ n : Nat.pred (succ n) = n := by rfl
+Now that we have defined and proved `pred`'s simplification lemmas,
+we can mark it `irreducible`, to enforce rewriting by these lemmas.
+
+```lean
+attribute [irreducible] pred
 ```
 
 Similarly, for each of the three branches of the definition of `even`,
 we need one simplification lemma:
 
 ```lean
-unseal even
 theorem even_zero : even zero = true := rfl
 theorem even_one : even (succ zero) = false := rfl
 theorem even_succ_succ n : even (succ (succ n)) = even n := rfl
-seal even
+
+attribute [irreducible] even odd
 ```
 
 ::::full
 In the remainder of this textbook, we will pair definitions
-with their simplification lemmas. After proving these lemmas, instead of using `rfl`
-to peek through the definitions, we will prefer rewriting
-by the lemmas, using `@[irreducible]` to enforce this policy,
-and only `unseal`ing the definition in the proofs of those lemmas themselves.
+with their simplification lemmas. After proving these lemmas,
+instead of using `rfl` to peek through the definitions, we will prefer rewriting
+by the lemmas.
 ::::
 
 ::::terse
@@ -1705,14 +1671,6 @@ rather than `rfl`-ing through the definition.
 ::::
 
 ## Working with Numerals
-
-:::dev
-BCP: The following lemmas are also needed by the TERSE version,
-so I am un-fulling them for now.
-But indeed the whole discussion here needs both TERSE and FULL versions.
-Or probably some of it should turn into an exercise?
-RAB: This will be part of our discussion on presenting laws.
-:::
 
 We know from our definitions above that `one` is just `succ zero`,
 `two` is `succ one`, and so on. We can write rules for these equalities too:
@@ -1773,7 +1731,6 @@ Now that we know how addition is defined, we can use it to define multiplication
 :::
 
 ```lean
-@[irreducible]
 def mul (n m : Nat) : Nat :=
   match m with
   | zero => zero
@@ -1786,15 +1743,15 @@ Multiplication, like any function we will prove properties about,
    also has simplification rules.
 
 ```lean
-unseal mul in
 theorem mul_zero : ∀ n : Nat, n * zero = zero := by
   intro n
   rfl
 
-unseal mul add in
 theorem mul_succ : ∀ n m : Nat, n * (succ m) = (n * m) + n := by
   intro n m
   rfl
+
+attribute [irreducible] mul
 ```
 
 :::dev
@@ -1850,7 +1807,6 @@ Here is a function `beq` that tests natural numbers for
 equality, yielding a boolean.
 
 ```lean
-@[irreducible]
 def beq (n m : Nat) : Bool :=
   match n with
   | zero => match m with
@@ -1864,7 +1820,6 @@ def beq (n m : Nat) : Bool :=
 We could also write this by pattern matching on both `n` and `m` at the same time:
 
 ```lean
-@[irreducible]
 def beq' (n m : Nat) : Bool :=
   match n, m with
   | zero, zero => true
@@ -1882,7 +1837,6 @@ Similarly, the `ble` function tests whether its first argument is
 less than or equal to its second argument, yielding a boolean.
 
 ```lean
-@[irreducible]
 def ble (n m : Nat) : Bool :=
   match n with
   | zero => true
@@ -1891,7 +1845,6 @@ def ble (n m : Nat) : Bool :=
       | zero => false
       | succ m' => ble n' m'
 
-unseal ble
 theorem zero_ble (n : Nat) : ble zero n = true := by rfl
 theorem succ_ble_zero (n : Nat) : ble (succ n) zero = false := by rfl
 theorem succ_ble_succ (n m : Nat) : ble (succ n) (succ m) = ble n m := by rfl
@@ -1899,8 +1852,29 @@ theorem succ_ble_succ (n m : Nat) : ble (succ n) (succ m) = ble n m := by rfl
 example : ble two two = true  := by rfl
 example : ble two four = true  := by rfl
 example : ble four two = false := by rfl
-seal ble
+
 ```
+
+::::exercise (rating := 1) (name := "blt")
+Define a less-than function in terms of `ble`.
+
+```lean
+def blt (n m : Nat) : Bool
+  := solution!(ble (succ n) m)
+
+example : blt two two = false := solution!(by rfl)
+example : blt two four = true  := solution!(by rfl)
+example : blt four two = false := solution!(by rfl)
+
+attribute [irreducible] blt ble
+```
+
+:::grade
+```
+GRADE_THEOREM 1: blt_test3
+```
+:::
+::::
 
 :::slidebreak
 :::
@@ -1931,35 +1905,13 @@ one for each of the four cases of control flow through the function.
 ::::
 
 ```lean
-unseal beq
 theorem zero_zero_beq_true : (zero == zero) = true := by rfl
 theorem zero_succ_beq_false (n : Nat) : (zero == (succ n)) = false := by rfl
 theorem succ_zero_beq_false (n : Nat) : ((succ n) == zero) = false := by rfl
 theorem succ_succ_beq (n m : Nat) : ((succ n) == (succ m)) = (n == m) := by rfl
-seal beq
-```
 
-::::exercise (rating := 1) (name := "blt")
-Define a less-than function in terms of `ble`.
-
-```lean
-@[irreducible]
-def blt (n m : Nat) : Bool
-  := solution!(ble (succ n) m)
-
-unseal blt ble
-example : blt two two = false := solution!(by rfl)
-example : blt two four = true  := solution!(by rfl)
-example : blt four two = false := solution!(by rfl)
-seal blt ble
+attribute [irreducible] beq
 ```
-
-:::grade
-```
-GRADE_THEOREM 1: blt_test3
-```
-:::
-::::
 
 # General Proofs about Natural Numbers
 
@@ -2447,21 +2399,18 @@ inductive Bin : Type where
   | b0 (n : Bin)
   | b1 (n : Bin)
 
-@[irreducible]
 def incr (m : Bin) : Bin
   := solution!(match m with
   | .z => .b1 .z
   | .b0 m' => .b1 m'
   | .b1 m' => .b0 (incr m'))
 
-@[irreducible]
 def binToNat (m : Bin) : Nat
   := solution!(match m with
   | .z => zero
   | .b0 m' => binToNat m' * two
   | .b1 m' => binToNat m' * two + one)
 
-unseal incr
 example : incr (.b1 .z) = .b0 (.b1 .z) := solution!(by rfl)
 example : incr (.b0 (.b1 .z)) = .b1 (.b1 .z) := solution!(by rfl)
 example : incr (.b1 (.b1 .z)) = .b0 (.b0 (.b1 .z)) := solution!(by rfl)
@@ -2469,22 +2418,19 @@ example : incr (.b1 (.b1 .z)) = .b0 (.b0 (.b1 .z)) := solution!(by rfl)
 theorem incr_z : incr .z = .b1 .z := solution!(by rfl)
 theorem incr_b0 m : incr (.b0 m) = .b1 m := solution!(by rfl)
 theorem incr_b1 m : incr (.b1 m) = .b0 (incr m) := solution!(by rfl)
-seal incr
 
-unseal binToNat
 theorem binToNat_z : binToNat .z = zero := solution!(by rfl)
 theorem binToNat_b0 m : binToNat (.b0 m) = binToNat m * two := solution!(by rfl)
 theorem binToNat_b1 m : binToNat (.b1 m) = binToNat m * two + one := solution!(by rfl)
-seal binToNat
 ```
 
 ```lean
-unseal Nat.mul Nat.add incr binToNat
 example : binToNat (.b0 (.b1 .z)) = two := solution!(by rfl)
 example : binToNat (incr (.b1 .z)) = add one (binToNat (.b1 .z)) := solution!(by rfl)
 example : binToNat (incr (incr (.b1 .z))) = add two (binToNat (.b1 .z)) := solution!(by rfl)
 example : binToNat (.b0 (.b0 (.b1 .z))) = four := solution!(by rfl)
-seal Nat.mul Nat.add incr binToNat
+
+attribute [irreducible] incr binToNat
 ```
 
 :::grade

--- a/LF/IndProp.lean
+++ b/LF/IndProp.lean
@@ -1637,7 +1637,6 @@ theorem ev_plus_plus : ∀ n m p,
 -/
 -- /TERSE
 
-@[irreducible]
 def In' {α : Type} (x : α) (xs : List α) : Prop :=
   match xs with
   | [] => False

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -534,16 +534,7 @@ def double (n : Nat) : Nat :=
   | succ n' => succ (succ (double n'))
 ```
 
-<<<<<<< HEAD
-=======
-:::dev "Benjamin Pierce (bcpierce00)"
-```
-All this `unseal` stuff is a bit ugly and potentially confusing for students.
-Anything we can to about this?
-```
-:::
 
->>>>>>> 1a5154146468620661601b131d88102d0d94d9b8
 ```lean
 theorem double_zero : double zero = zero := by rfl
 theorem double_succ : ∀ n, double (succ n) = succ (succ (double n)) := by

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -251,7 +251,6 @@ theorem succ_eq_add_one : ∀ n : Nat, succ n = n + one := by
   for `+` on the _right_ using just `rfl`:
 
 ```
-  unseal add in
   theorem add_zero : forall (n : Nat), n + zero = n := by
     intro n
     rfl
@@ -271,7 +270,6 @@ But the proof that it is also a neutral element on the
 ```lean
 /-- warning: declaration uses `sorry` -/
 #guard_msgs in
-unseal add in
 example : ∀ n : Nat, zero + n = n := by
   intro n
   -- `rfl` doesn't work here!
@@ -392,7 +390,6 @@ Let's try this one together:
 ::::
 
 ```lean
-unseal beq in
 theorem beq_self : ∀ n : Nat,
     (n == n) = true := by
   workinclass!
@@ -531,27 +528,18 @@ ASSUME HIDDEN
 :::
 
 ```lean
-@[irreducible]
 def double (n : Nat) : Nat :=
   match n with
   | zero    => zero
   | succ n' => succ (succ (double n'))
 ```
 
-:::dev
-```
-BCP: All this `unseal` stuff is a bit ugly and potentially confusing for students.
-Anything we can to about this?
-```
-:::
-
 ```lean
-unseal double in
 theorem double_zero : double zero = zero := by rfl
-
-unseal double in
 theorem double_succ : ∀ n, double (succ n) = succ (succ (double n)) := by
   intro n; rfl
+
+attribute [irreducible] double
 ```
 
 END ASSUME
@@ -615,7 +603,6 @@ The following theorem relates the computational equality `beq` on
 `Nat` with the definitional equality `=` on `Bool`.
 
 ```lean
-unseal beq in
 theorem beq_refl (n : Nat) :
     (n == n) = true := by
   solution!
@@ -653,7 +640,6 @@ with induction:
 `rw [even]`.)
 
 ```lean
-unseal even in
 theorem even_succ (n : Nat) :
     even (succ n) = !even n := by
   solution!
@@ -818,7 +804,7 @@ completely forget about informal ones!  Formal proofs are useful
 in many ways, but they are _not_ very efficient ways of
 communicating ideas between human beings.
 
-For example, here is a proof that addition is associative 
+For example, here is a proof that addition is associative
    (you might have written it yourself, earlier in this chapter!):
 
 ```lean
@@ -898,7 +884,7 @@ _Qed_.
  MMG: the proof above makes no use of lemmas, so it's hard for
    students to know what to do.  It might be good to also give them a
    sample proof of mult_1_l so they know how to "invoke" things
-   they've already proved.  
+   they've already proved.
 ```
 ::::
 
@@ -1226,7 +1212,6 @@ from Basics.  That will make it possible for this file to be graded
 on its own.
 
 ```lean
-@[irreducible]
 def incr (m : Bin) : Bin
   := solution!(match m with
   | .z     => .b1 .z
@@ -1234,31 +1219,22 @@ def incr (m : Bin) : Bin
   | .b1 m' => .b0 (incr m'))
 ```
 
-:::dev
-```
-BCP: Will students need to do all this unseal/seal stuff to do the exercises?
-```
-:::
-
 ```lean
-unseal incr
 theorem incr_z : incr .z = .b1 .z := solution!(by rfl)
 theorem incr_b0 m : incr (.b0 m) = .b1 m := solution!(by rfl)
 theorem incr_b1 m : incr (.b1 m) = .b0 (incr m) := solution!(by rfl)
-seal incr
+```
 
-@[irreducible]
+```lean
 def binToNat (m : Bin) : Nat
   := solution!(match m with
   | .z     => zero
   | .b0 m' => (binToNat m') * two
   | .b1 m' => ((binToNat m') * two) + one)
 
-unseal binToNat
 theorem binToNat_z : binToNat .z = zero := solution!(by rfl)
 theorem binToNat_b0 m : binToNat (.b0 m) = mul (binToNat m) two := solution!(by rfl)
 theorem binToNat_b1 m : binToNat (.b1 m) = add (mul (binToNat m) two) one := solution!(by rfl)
-seal binToNat
 
 attribute [pp_nodot] Bin.b0 Bin.b1
 ```
@@ -1325,7 +1301,6 @@ Write a function to convert natural numbers to binary numbers.
   Also write some simplification lemmas for it.
 
 ```lean
-@[irreducible]
 def natToBin (n : Nat) : Bin := solution!(
   match n with
   | zero    => .z
@@ -1343,15 +1318,13 @@ CH: David set it up so that if you put:
 -- SOLUTION
 -- END SOLUTION
 
-in an exercise that it will turn into 
-  -- FILL IN HERE 
+in an exercise that it will turn into
+  -- FILL IN HERE
 in both student version of the Lean files and the generated HTML.
 
 ```lean
-unseal natToBin
 theorem natToBin_zero : natToBin zero = .z := solution!(by rfl)
 theorem natToBin_succ m : natToBin (succ m) = incr (natToBin m) := solution!(by rfl)
-seal natToBin
 ```
 
 :::dev
@@ -1429,7 +1402,6 @@ GRADE_THEOREM 0.5: double_incr
 Now define a similar doubling function for `Bin`.
 
 ```lean
-@[irreducible]
 def doubleBin (b : Bin) : Bin := solution!(
   match b with
   | .z => .z
@@ -1443,17 +1415,15 @@ TODO (DHS): How to hide these theorem statements so that students can get practi
 :::
 
 ```lean
-unseal doubleBin
 theorem doubleBin_z : doubleBin .z = .z := solution!(by rfl)
 theorem doubleBin_b0 m : doubleBin (.b0 m) = .b0 (.b0 m) := solution!(by rfl)
 theorem doubleBin_b1 m : doubleBin (.b1 m) = .b0 (.b1 m) := solution!(by rfl)
-seal doubleBin
+
 ```
 
 Check that your function correctly doubles zero.
 
 ```lean
-unseal doubleBin in
 example : doubleBin .z = .z := solution!(by rfl)
 ```
 
@@ -1529,7 +1499,6 @@ end of the `Bin` and _only_ processes each bit once. Do not
 try to "look ahead" at future bits.
 
 ```lean
-@[irreducible]
 def normalize (b : Bin) : Bin := solution!(
   match b with
   | .z     => .z
@@ -1544,11 +1513,10 @@ TODO (DHS): How to hide these theorem statements so that students can get practi
 :::
 
 ```lean
-unseal normalize
 theorem normalize_z : normalize .z = .z := solution!(by rfl)
 theorem normalize_b0 m : normalize (.b0 m) = doubleBin (normalize m) := solution!(by rfl)
 theorem normalize_b1 m : normalize (.b1 m) = incr (doubleBin (normalize m)) := solution!(by rfl)
-seal normalize
+
 ```
 
 It would be wise to do some `example` proofs to check that your
@@ -1558,7 +1526,6 @@ proceed. They won't be graded, but fill them in below.
 ```lean
 -- SOLUTION
 /- normalize_test_zero -/
-unseal normalize doubleBin incr
 example : normalize .z = .z := by rfl
 /- normalize_test_1 -/
 example : normalize (.b1 .z) = .b1 .z := by rfl
@@ -1568,8 +1535,9 @@ example : normalize (.b0 .z) = .z := by rfl
 example : normalize (.b0 (.b0 .z)) = .z := by rfl
 /- normalize_test_4 -/
 example : normalize (.b1 (.b0 .z)) = .b1 .z := by rfl
-seal normalize doubleBin incr
 -- END SOLUTION
+
+attribute [irreducible] normalize doubleBin natToBin incr binToNat
 ```
 
 Finally, prove the main theorem. The inductive cases could be a
@@ -1653,4 +1621,3 @@ end NatPlayground.Nat
   SF.
 ```
 ::::
-

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -778,8 +778,6 @@ end Bag
 /- TERSE: As with numbers, some proofs about list functions need only
    simplification... -/
 /- TODO (KH): The above comment is wrong, since we use `rw` here.
-   Should we put
-   uses `unseal` and `dsimp` extensively.
    -/
 
 theorem nil_app (l : NatList) : ([] : NatList) ++ l = l := by rw [nil_append]

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -220,40 +220,40 @@ def mylist3 : NatList := [1, 2, 3]
    and a `count` and returns a list of length `count` in which every element is `n`.
    (We use `myRepeat` because `repeat` is a reserved keyword in Lean.) -/
 
-@[irreducible]
+
 def myRepeat (n count : Nat) : NatList :=
   match count with
   | 0 => []
   | count' + 1 => n :: myRepeat n count'
 
 -- Some simple facts about repetition
-unseal myRepeat in
+
 theorem repeat_zero v : myRepeat v 0 = [] := rfl
 
-unseal myRepeat in
+
 theorem repeat_succ v count : myRepeat v (count + 1) = v :: myRepeat v count := rfl
 
 -- Length
 
 -- FULL: The `length` function calculates the length of a list.
 
-@[irreducible]
+
 def length (l : NatList) : Nat :=
   match l with
   | [] => 0
   | _ :: t => (length t) + 1
 
 -- Some simple facts about list lengths
-unseal length in
+
 theorem nil_length : [].length = 0 := rfl
 
-unseal length in
+
 theorem cons_length (n : Nat) (l : NatList) : (n::l).length = l.length + 1 := rfl
 
 -- *** Append
 
 -- FULL: The `app` function appends (concatenates) two lists.
-@[irreducible]
+
 def app (l1 l2 : NatList) : NatList :=
   match l1 with
   | [] => l2
@@ -279,20 +279,20 @@ instance : HAppend NatList NatList NatList where
 -- Now `l1 ++ l2` means `app l1 l2` within `NatList`.
 
 -- Some simple facts about appending lists
-unseal app in
+
 theorem nil_append (l : NatList) : [] ++ l = l := rfl
 
-unseal app in
+
 theorem cons_append (n : Nat) (l1 l2 : NatList) : (n::l1) ++ l2 = n :: (l1 ++ l2) := rfl
 
 -- test_app1
-unseal app
+
 example : [1, 2, 3] ++ [4, 5] = [1, 2, 3, 4, 5] := by rfl
 -- test_app2
 example : ([] : NatList) ++ [4, 5] = [4, 5] := by rfl
 -- test_app3
 example : [1, 2, 3] ++ ([] : NatList) = [1, 2, 3] := by rfl
-seal app
+
 
 /- TODO (OA): Experiment: introduce `BEq.refl` here, at the point where the `BEq` class is named. -/
 
@@ -325,28 +325,28 @@ seal app
    the list, while `tl` returns everything but the first element (the
    "tail").  Since the empty list has no first element, we pass
    a default value to be returned in that case. -/
-@[irreducible]
+
 def hd (default : Nat) (l : NatList) : Nat :=
   match l with
   | [] => default
   | h :: _ => h
 
 -- Basic theorems about how `hd` behaves:
-unseal hd in
+
 theorem hd_cons h x (t : NatList) : (h :: t).hd x = h := by rfl
-unseal hd in
+
 theorem hd_nil x : [].hd x = x := by rfl
 
-@[irreducible]
+
 def tl (l : NatList) : NatList :=
   match l with
   | [] => []
   | _ :: t => t
 
 -- Basic theorems about how `tl` behaves:
-unseal tl in
+
 theorem tl_cons h (t : NatList) : (h :: t).tl = t := by rfl
-unseal tl in
+
 theorem tl_nil : [].tl = [] := by rfl
 
 -- test_hd1
@@ -373,7 +373,7 @@ def foo (n : Nat) : NatList :=
 -- `countoddmembers` below. Have a look at the tests to understand
 -- what these functions should do.
 
-@[irreducible]
+
 def nonzeros (l : NatList) : NatList :=
   -- ADMITDEF
   match l with
@@ -385,21 +385,21 @@ def nonzeros (l : NatList) : NatList :=
   -- /ADMITDEF
 
 -- test_nonzeros
-unseal nonzeros in
+
 example : nonzeros [0, 1, 0, 2, 3, 0, 0] = [1, 2, 3] := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_nonzeros
 
 -- the following lemmas should hold about your definition
-unseal nonzeros
+
 theorem nonzeros_cons_zero (t : NatList) :
   nonzeros (0 :: t) = nonzeros t := by rfl -- ADMITTED
 theorem nonzeros_nil :
   nonzeros [] = [] := by rfl -- ADMITTED
 theorem nonzeros_cons_nonzero h (t : NatList) :
   nonzeros ((h + 1) :: t) = (h + 1) :: nonzeros t := by rfl -- ADMITTED
-seal nonzeros
 
-@[irreducible]
+
+
 def oddmembers (l : NatList) : NatList :=
   -- ADMITDEF
   match l with
@@ -408,7 +408,7 @@ def oddmembers (l : NatList) : NatList :=
   -- /ADMITDEF
 
 -- test_oddmembers
-unseal oddmembers in
+
 example : oddmembers [0, 1, 0, 2, 3, 0, 0] = [1, 3] := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_oddmembers
 
@@ -420,13 +420,13 @@ abbrev countoddmembers (l : NatList) : Nat :=
   -- /ADMITDEF
 
 -- test_countoddmembers1
-unseal oddmembers length
+
 example : countoddmembers [1, 0, 3, 1, 4, 5] = 4 := by rfl  -- ADMITTED
 -- test_countoddmembers2
 example : countoddmembers [0, 2, 4] = 0 := by rfl  -- ADMITTED
 -- test_countoddmembers3
 example : countoddmembers [] = 0 := by rfl  -- ADMITTED
-seal oddmembers length
+
 -- GRADE_THEOREM 0.5: NatList.test_countoddmembers2
 -- GRADE_THEOREM 0.5: NatList.test_countoddmembers3
 -- []
@@ -441,7 +441,7 @@ seal oddmembers length
   _structurally recursive_, as mentioned in `"Basics"`.
   If you encounter this difficulty,
   consider pattern matching against both lists at the same time. -/
-@[irreducible]
+
 def alternate (l1 l2 : NatList) : NatList :=
   -- ADMITDEF
   match l1, l2 with
@@ -450,7 +450,7 @@ def alternate (l1 l2 : NatList) : NatList :=
   | h1 :: t1, h2 :: t2 => h1 :: h2 :: alternate t1 t2
   -- /ADMITDEF
 
-unseal alternate
+
 -- test_alternate1
 example : alternate [1, 2, 3] [4, 5, 6] = [1, 4, 2, 5, 3, 6] := by rfl  -- ADMITTED
 -- GRADE_THEOREM 1: NatList.test_alternate1
@@ -461,7 +461,7 @@ example : alternate [1] [4, 5, 6] = [1, 4, 5, 6] := by rfl  -- ADMITTED
 example : alternate [1, 2, 3] [4] = [1, 4, 2, 3] := by rfl  -- ADMITTED
 -- test_alternate4
 example : alternate ([] : NatList) [20, 30] = [20, 30] := by rfl  -- ADMITTED
-seal alternate
+
 -- GRADE_THEOREM 1: NatList.test_alternate4
 -- []
 
@@ -482,7 +482,7 @@ namespace Bag
 /- Complete the following definitions for the functions `count`,
    `sum`, `add`, and `member` for bags. -/
 
-@[irreducible]
+
 def count (v : Nat) (s : Bag) : Nat :=
   -- ADMITDEF
   match s with
@@ -491,10 +491,10 @@ def count (v : Nat) (s : Bag) : Nat :=
   -- /ADMITDEF
 
 -- These lemmas should hold about your definition
-unseal count in
+
 theorem count_nil x  : count x [] = 0 := by rfl -- ADMITTED
 
-unseal count in
+
 theorem count_cons_same x y l : (y == x) = true → count x (y :: l) = count x l + 1 := by
   -- ADMITTED
   intro h
@@ -503,7 +503,7 @@ theorem count_cons_same x y l : (y == x) = true → count x (y :: l) = count x l
   dsimp
   -- /ADMITTED
 
-unseal count in
+
 theorem count_cons_diff x y l : (y == x) = false → count x (y :: l) = count x l := by
   -- ADMITTED
   intro h
@@ -515,11 +515,11 @@ theorem count_cons_diff x y l : (y == x) = false → count x (y :: l) = count x 
 -- All these proofs can be completed with `rfl`.
 
 -- test_count1
-unseal count
+
 example : count 1 [1, 2, 3, 1, 4, 1] = 3 := by rfl  -- ADMITTED
 -- test_count2
 example : count 6 [1, 2, 3, 1, 4, 1] = 0 := by rfl  -- ADMITTED
-seal count
+
 -- GRADE_THEOREM 0.5: NatList.test_count2
 
 /- Multiset `sum` is similar to set `union`: `sum a b` contains all
@@ -538,15 +538,15 @@ abbrev sum : Bag → Bag → Bag :=
   -- /ADMITDEF
 
 -- test_sum1
-unseal count in
-unseal app in
+
+
 example : count 1 (sum [1, 2, 3] [1, 4, 1]) = 3 := by rfl -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_sum1
 
-unseal app in
+
 theorem nil_sum (l : NatList) : sum [] l = l := rfl -- ADMITTED
 
-unseal app in
+
 theorem cons_sum (n : Nat) (l1 l2 : Bag) : sum (n::l1) l2 = n :: (sum l1 l2) := rfl -- ADMITTED
 
 abbrev add (v : Nat) (s : Bag) : Bag :=
@@ -569,7 +569,7 @@ example : count 5 (add 1 [1, 4, 1]) = 0 := by
 -- GRADE_THEOREM 0.5: NatList.test_add1
 -- GRADE_THEOREM 0.5: NatList.test_add2
 
-@[irreducible]
+
 def member (v : Nat) (s : Bag) : Bool :=
   -- ADMITDEF
   match s with
@@ -578,20 +578,20 @@ def member (v : Nat) (s : Bag) : Bool :=
   -- /ADMITDEF
 
 -- test_member1
-unseal member in
+
 example : member 1 [1, 4, 1] = true := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_member1
 
 -- test_member2
-unseal member in
+
 example : member 2 [1, 4, 1] = false := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_member2
 -- []
 
-unseal member in
+
 theorem member_nil v : member v [] = false := by rfl -- ADMITTED
 
-unseal member in
+
 theorem member_add_same v t : member v (add v t) = true := by
   -- ADMITTED
   dsimp [add, member]
@@ -602,7 +602,7 @@ theorem member_add_same v t : member v (add v t) = true := by
   dsimp
   -- /ADMITTED
 
-unseal member in
+
 theorem member_add_diff v1 v2 t : (v1 == v2) = false -> member v1 (add v2 t) = member v1 t := by
   -- ADMITTED
   intro h
@@ -623,7 +623,7 @@ theorem member_add_diff v1 v2 t : (v1 == v2) = false -> member v1 (add v2 t) = m
    between standard and advanced tracks, which made the wording above
    confusing. Maybe just make this an exercise for everybody? -/
 
-@[irreducible]
+
 def remove_one (v : Nat) (s : Bag) : Bag :=
   -- ADMITDEF
   match s with
@@ -632,8 +632,8 @@ def remove_one (v : Nat) (s : Bag) : Bag :=
   -- /ADMITDEF
 
 -- test_remove_one1
-unseal count
-unseal remove_one
+
+
 example : count 5 (remove_one 5 [2, 1, 5, 4, 1]) = 0 := by rfl  -- ADMITTED
 -- test_remove_one2
 example : count 5 (remove_one 5 [2, 1, 4, 1]) = 0 := by rfl  -- ADMITTED
@@ -643,13 +643,13 @@ example : count 4 (remove_one 5 [2, 1, 4, 5, 1, 4]) = 2 := by rfl  -- ADMITTED
 -- test_remove_one4
 example : count 5 (remove_one 5 [2, 1, 5, 4, 5, 1, 4]) = 1 := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_remove_one4
-seal count
-seal remove_one
 
-unseal remove_one in
+
+
+
 theorem remove_one_nil v : remove_one v [] = [] := by rfl -- ADMITTED
 
-unseal remove_one in
+
 theorem remove_one_add_same v1 v2 t : (v2 == v1) = true -> remove_one v1 (add v2 t) = t := by
   -- ADMITTED
   intro h
@@ -658,7 +658,7 @@ theorem remove_one_add_same v1 v2 t : (v2 == v1) = true -> remove_one v1 (add v2
   dsimp
   -- /ADMITTED
 
-unseal remove_one in
+
 theorem remove_one_add_diff v1 v2 t : (v2 == v1) = false -> remove_one v1 (add v2 t) = add v2 (remove_one v1 t) := by
   -- ADMITTED
   intro h
@@ -667,7 +667,7 @@ theorem remove_one_add_diff v1 v2 t : (v2 == v1) = false -> remove_one v1 (add v
   dsimp
   -- /ADMITTED
 
-@[irreducible]
+
 def remove_all (v : Nat) (s : Bag) : Bag :=
   -- ADMITDEF
   match s with
@@ -675,8 +675,8 @@ def remove_all (v : Nat) (s : Bag) : Bag :=
   | h :: t => bif h == v then remove_all v t else h :: remove_all v t
   -- /ADMITDEF
 
-unseal count
-unseal remove_all
+
+
 -- test_remove_all1
 example : count 5 (remove_all 5 [2, 1, 5, 4, 1]) = 0 := by rfl  -- ADMITTED
 -- test_remove_all2
@@ -687,13 +687,13 @@ example : count 4 (remove_all 5 [2, 1, 4, 5, 1, 4]) = 2 := by rfl  -- ADMITTED
 -- test_remove_all4
 example : count 5 (remove_all 5 [2, 1, 5, 4, 5, 1, 4, 5, 1, 4]) = 0 := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_remove_all4
-seal count
-seal remove_all
 
-unseal remove_all in
+
+
+
 theorem remove_all_nil v : remove_all v [] = [] := by rfl -- ADMITTED
 
-unseal remove_all in
+
 theorem remove_all_add_same v t : remove_all v (add v t) = remove_all v t := by
   -- ADMITTED
   dsimp [add, remove_all]
@@ -701,7 +701,7 @@ theorem remove_all_add_same v t : remove_all v (add v t) = remove_all v t := by
   dsimp
   -- /ADMITTED
 
-unseal remove_all in
+
 theorem remove_all_add_diff v1 v2 t : (v2 == v1) = false -> remove_all v1 (add v2 t) = add v2 (remove_all v1 t) := by
   -- ADMITTED
   intro h
@@ -710,7 +710,7 @@ theorem remove_all_add_diff v1 v2 t : (v2 == v1) = false -> remove_all v1 (add v
   dsimp
   -- /ADMITTED
 
-@[irreducible]
+
 def included (s1 s2 : Bag) : Bool :=
   -- ADMITDEF
   match s1 with
@@ -719,23 +719,23 @@ def included (s1 s2 : Bag) : Bool :=
   -- /ADMITDEF
 
 -- test_included1
-unseal included
-unseal member
-unseal remove_one
+
+
+
 example : included [1, 2] [2, 1, 4, 1] = true := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_included1
 -- test_included2
 example : included [1, 2, 2] [2, 1, 4, 1] = false := by rfl  -- ADMITTED
 -- GRADE_THEOREM 0.5: NatList.test_included2
 -- []
-seal included
-seal member
-seal remove_one
 
-unseal included in
+
+
+
+
 theorem included_nil s : included [] s = true := by rfl -- ADMITTED
 
-unseal included in
+
 theorem included_add_member v s1 s2 : member v s2 = true -> included (add v s1) s2 = included s1 (remove_one v s2) := by
   -- ADMITTED
   intro h
@@ -744,7 +744,7 @@ theorem included_add_member v s1 s2 : member v s2 = true -> included (add v s1) 
   rfl
   -- /ADMITTED
 
-unseal included in
+
 theorem included_add_nonmember v s1 s2 : member v s2 = false -> included (add v s1) s2 = false := by
   -- ADMITTED
   intro h
@@ -778,7 +778,7 @@ end Bag
 /- TERSE: As with numbers, some proofs about list functions need only
    simplification... -/
 /- TODO (KH): The above comment is wrong, since we use `rw` here.
-   Should we put unseal + rfl? Or change the comments? I am a bit confused because this file
+   Should we put
    uses `unseal` and `dsimp` extensively.
    -/
 
@@ -929,24 +929,24 @@ theorem myRepeat_plus (c1 c2 n : Nat) :
    `rev`: -/
 -- TERSE: A more interesting example of induction over lists:
 
-@[irreducible]
+
 def rev (l : NatList) : NatList :=
   match l with
   | [] => []
   | h :: t => t.rev ++ [h]
 
-unseal rev in
+
 theorem rev_nil : [].rev = [] := by rfl
 
-unseal rev in
+
 theorem rev_cons h (t : NatList) : (h :: t).rev = t.rev ++ [h] := by rfl
 
 -- test_rev1
-unseal rev in
-unseal app in
+
+
 example : [1, 2, 3].rev = [3, 2, 1] := by rfl
 -- test_rev2
-unseal rev in
+
 example : ([] : NatList).rev = [] := by rfl
 
 
@@ -1218,7 +1218,7 @@ theorem nonzeros_app (l1 l2 : NatList) :
 -- lists of numbers for equality.  Prove that `eqblist l l`
 -- yields `true` for every list `l`.
 
-@[irreducible]
+
 def eqblist (l1 l2 : NatList) : Bool :=
   -- ADMITDEF
   match l1, l2 with
@@ -1227,17 +1227,17 @@ def eqblist (l1 l2 : NatList) : Bool :=
   | _, _ => false
   -- /ADMITDEF
 
-unseal eqblist in
+
 theorem eqblist_nil : eqblist [] [] = true := by rfl -- ADMITTED
 
-unseal eqblist in
+
 theorem eqblist_cons_same h t1 t2 : eqblist (h :: t1) (h :: t2) = eqblist t1 t2 := by
   -- ADMITTED
   dsimp [eqblist]
   rw [BEq.refl, Bool.true_and]
   -- /ADMITTED
 
-unseal eqblist in
+
 theorem eqblist_cons_diff h1 h2 t1 t2 : (h1 == h2) = false -> eqblist (h1 :: t1) (h2 :: t2) = false := by
   -- ADMITTED
   intro h
@@ -1246,13 +1246,13 @@ theorem eqblist_cons_diff h1 h2 t1 t2 : (h1 == h2) = false -> eqblist (h1 :: t1)
   -- /ADMITTED
 
 -- test_eqblist1
-unseal eqblist
+
 example : eqblist [] [] = true := by rfl  -- ADMITTED
 -- test_eqblist2
 example : eqblist [1, 2, 3] [1, 2, 3] = true := by rfl  -- ADMITTED
 -- test_eqblist3
 example : eqblist [1, 2, 3] [1, 2, 4] = false := by rfl  -- ADMITTED
-seal eqblist
+
 
 -- eqblist_refl
 theorem eqblist_refl (l : NatList) :
@@ -1430,7 +1430,7 @@ theorem rev_injective (l1 l2 : NatList) :
 -- TERSE: Suppose we'd like a function to retrieve the `n`th element
 --     of a list.  What to do if the list is too short?
 
-@[irreducible]
+
 def nth_bad (l : NatList) (n : Nat) : Nat :=
   match l with
   | [] => 42
@@ -1458,7 +1458,7 @@ inductive NatOption : Type where
     this new function `nth_error` to indicate that it may result in an
     error. -/
 
-@[irreducible]
+
 def nth_error (l : NatList) (n : Nat) : NatOption :=
   match l with
   | [] => .none
@@ -1467,13 +1467,13 @@ def nth_error (l : NatList) (n : Nat) : NatOption :=
     | n' + 1 => nth_error l' n'
 
 -- test_nth_error1
-unseal nth_error
+
 example : nth_error [4, 5, 6, 7] 0 = .some 4 := by rfl
 -- test_nth_error2
 example : nth_error [4, 5, 6, 7] 3 = .some 7 := by rfl
 -- test_nth_error3
 example : nth_error [4, 5, 6, 7] 9 = .none := by rfl
-seal nth_error
+
 
 -- FULL
 
@@ -1481,16 +1481,16 @@ seal nth_error
 -- returning a supplied default in the `none` case.
 
 -- /FULL
-@[irreducible]
+
 def option_elim (d : Nat) (o : NatOption) : Nat :=
   match o with
   | .some n => n
   | .none => d
 
-unseal option_elim in
+
 theorem option_elim_none d : option_elim d .none = d := by rfl
 
-unseal option_elim in
+
 theorem option_elim_some d1 d2 : option_elim d1 (.some d2) = d2 := by rfl
 -- FULL
 
@@ -1498,7 +1498,7 @@ theorem option_elim_some d1 d2 : option_elim d1 (.some d2) = d2 := by rfl
 -- Using the same idea, fix the `hd` function from earlier so we
 -- don't have to pass a default element for the `nil` case.
 
-@[irreducible]
+
 def hd_error (l : NatList) : NatOption :=
   -- ADMITDEF
   match l with
@@ -1507,21 +1507,21 @@ def hd_error (l : NatList) : NatOption :=
   -- /ADMITDEF
 
 -- test_hd_error1
-unseal hd_error
+
 example : hd_error ([] : NatList) = .none := by rfl  -- ADMITTED
 -- test_hd_error2
 example : hd_error [1] = .some 1 := by rfl  -- ADMITTED
 -- test_hd_error3
 example : hd_error [5, 6] = .some 5 := by rfl  -- ADMITTED
-seal hd_error
+
 -- GRADE_THEOREM 1: test_hd_error1
 -- GRADE_THEOREM 1: test_hd_error2
 -- []
 
-unseal hd_error in
+
 theorem hd_error_nil : hd_error [] = .none := by rfl -- ADMITTED
 
-unseal hd_error in
+
 theorem hd_error_cons h t : hd_error (h :: t) = .some h := by rfl -- ADMITTED
 
 

--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -791,16 +791,13 @@ example : True := by constructor
     to convert an unprovable statement (like `False`) to one that is
     provable (like `True`). -/
 
-@[irreducible]
 def discr_fun (n : Nat) : Prop :=
   match n with
   | 0 => True
   | _ + 1 => False
 
-unseal discr_fun in
 theorem discr_fun_zero : discr_fun 0 = True := rfl
 
-unseal discr_fun in
 theorem discr_fun_succ n : discr_fun (n + 1) = False := rfl
 
 theorem discr_example (n : Nat) : ¬ (0 = n + 1) := by
@@ -818,16 +815,13 @@ theorem discr_example (n : Nat) : ¬ (0 = n + 1) := by
     Do not use the `contradiction` tactic. -/
 
 -- QUIETSOLUTION
-@[irreducible]
 def is_nil {α : Type} (xs : List α) : Prop :=
   match xs with
   | [] => True
   | _ :: _ => False
 
-unseal is_nil in
 theorem is_nil_nil {α} : @is_nil α [] = True := rfl
 
-unseal is_nil in
 theorem is_nil_cons {α} (x : α) (xs : List α) : is_nil (x :: xs) = False := rfl
 -- /QUIETSOLUTION
 
@@ -1107,28 +1101,23 @@ theorem add_exists_leb' : ∀ n m, (∃ x, m = x + n) → n ≤? m = true := by
 /- We can translate this directly into a straightforward recursive function
     taken an element and a list and returning... a proposition! -/
 
-@[irreducible]
 def In {α : Type} (x : α) (xs : List α) : Prop :=
   match xs with
   | [] => False
   | x' :: xs' => x = x' ∨ In x xs'
 
-unseal In in
 theorem In_nil {α} (x : α) : In x [] = False := rfl
 
-unseal In in
 theorem In_cons {α} (x x' : α) (xs : List α) : In x (x' :: xs) = (x = x' ∨ In x xs) := rfl
 
 /- When `In` is applied to a concrete list, it exapnds into a concrete sequence
    of nested disjunctions. -/
 
-unseal In in
 example : In 4 [1, 2, 3, 4, 5] := by
   -- WORKINCLASS
   dsimp [In]; right; right; right; left; rfl
   -- /WORKINCLASS
 
-unseal In in
 example (n : Nat) (h : In n [2, 4]) : ∃ n' : Nat, n = 2 * n' := by
   -- WORKINCLASS
   dsimp [In] at h
@@ -1204,7 +1193,6 @@ theorem In_map_iff (α β : Type) (f : α → β) (xs : List α) (y : β) :
     lemma below.  (Of course, your definition should _not_ just
     restate the left-hand side of `All_In`.) -/
 
-@[irreducible]
 def All {α : Type} (P : α → Prop) (xs : List α) : Prop :=
   -- ADMITDEF
   match xs with
@@ -1212,10 +1200,8 @@ def All {α : Type} (P : α → Prop) (xs : List α) : Prop :=
   | x :: xs' => P x ∧ All P xs'
   -- /ADMITDEF
 
-unseal All in
 theorem All_nil {α} (P : α → Prop) : All P [] = True := rfl -- ADMITTED
 
-unseal All in
 theorem All_cons {α} (P : α → Prop) x xs : All P (x :: xs) = (P x ∧ All P xs) := rfl -- ADMITTED
 
 theorem All_In α (P : α → Prop) (xs : List α) :
@@ -1717,7 +1703,6 @@ example : even 101 = false := rfl
 /- In contrast, propositional negation can be difficult to work with directly.
     For example, suppose we state the nonevenness of `101` propositionally: -/
 
--- JC (TODO): mark `even` as irreducible (this example was `unseal even in`)
 /- Proving this directly -- by assuming that there is some `n` such that
     `101 = double n` and then somehow reasoning to a contradiction --
     would be rather complicated.
@@ -1796,7 +1781,6 @@ theorem orb_true_iff (b1 b2 : Bool) :
     of the `beq_list` function below. to make sure that your definition
     is correct, prove the lemma `beq_list_true_iff`. -/
 
-@[irreducible]
 def beq_list {α : Type} (beq : α → α → Bool) (xs1 xs2 : List α) : Bool :=
   -- ADMITDEF
   match xs1, xs2 with
@@ -1805,20 +1789,16 @@ def beq_list {α : Type} (beq : α → α → Bool) (xs1 xs2 : List α) : Bool :
   | _, _ => false
   -- /ADMITDEF
 
-unseal beq_list in
 theorem beq_list_nil_nil {α} (beq : α → α → Bool) :
     beq_list beq [] [] = true := rfl -- ADMITTED
 
-unseal beq_list in
 theorem beq_list_cons_cons {α} (beq : α → α → Bool) x1 x2 xs1 xs2 :
     beq_list beq (x1 :: xs1) (x2 :: xs2) =
     (beq x1 x2 && beq_list beq xs1 xs2) := rfl -- ADMITTED
 
-unseal beq_list in
 theorem beq_list_nil_cons {α} (beq : α → α → Bool) x xs :
     beq_list beq [] (x :: xs) = false := rfl -- ADMITTED
 
-unseal beq_list in
 theorem beq_list_cons_nil {α} (beq : α → α → Bool) x xs :
     beq_list beq (x :: xs) [] = false := rfl -- ADMITTED
 
@@ -1869,7 +1849,6 @@ theorem beq_list_true_iff α (beq : α → α → Bool)
 
 /- Copy the definition of `forallb` from Tactics here so that this file can be
     graded on its own. -/
-@[irreducible]
 def Logic.forallb {α : Type} (test : α → Bool) (xs : List α) : Bool :=
   -- ADMITDEF
   match xs with
@@ -1877,10 +1856,8 @@ def Logic.forallb {α : Type} (test : α → Bool) (xs : List α) : Bool :=
   | x :: xs' => test x && forallb test xs'
   -- /ADMITDEF
 
-unseal Logic.forallb in
 theorem forallb_nil {α} (test : α → Bool) : Logic.forallb test [] = true := rfl -- ADMITTED
 
-unseal Logic.forallb in
 theorem forallb_cons {α} (test : α → Bool) x xs :
     Logic.forallb test (x :: xs) = (test x && Logic.forallb test xs) := rfl -- ADMITTED
 
@@ -2131,16 +2108,13 @@ example : (fun xs => 1 :: xs) = (fun xs => [1] ++ xs) := rfl
 
     We can improve this with the following two-argument definition: -/
 
-@[irreducible]
 def rev_append {α} (xs1 xs2 : List α) : List α :=
   match xs1 with
   | [] => xs2
   | x1 :: xs1' => rev_append xs1' (x1 :: xs2)
 
-unseal rev_append in
 theorem rev_append_nil {α} (xs : List α) : rev_append [] xs = xs := rfl
 
-unseal rev_append in
 theorem rev_append_cons {α} (x : α) xs1 xs2 :
     rev_append (x :: xs1) xs2 = rev_append xs1 (x :: xs2) := rfl
 
@@ -2154,7 +2128,6 @@ abbrev tr_rev {α} (xs : List α) : List α := rev_append xs []
     Prove that the two definitions are indeed equivalent. -/
 
 -- QUIETSOLUTION
-unseal List.rev in
 theorem rev_append_rev {α} : ∀ xs1 xs2 : List α,
     rev_append xs1 xs2 = xs1.rev ++ xs2 := by
   intro xs1; induction xs1

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -149,17 +149,14 @@ inductive MyList (α : Type) : Type where
 -- TERSE: We can now define polymorphic versions of the functions
 -- we've already seen...
 
-@[irreducible]
 def myRepeat (α : Type) (x : α) (count : Nat) : MyList α :=
   match count with
   | 0 => .nil
   | count' + 1 => .cons x (myRepeat α x count')
 
 -- Some simple facts about list lengths
-unseal myRepeat in
 theorem repeat_zero α v : myRepeat α v 0 = MyList.nil := rfl
 
-unseal myRepeat in
 theorem repeat_succ α v count : myRepeat α v (count + 1) = MyList.cons v (myRepeat α v count) := rfl
 
 /- HIDEFROMADVANCED -/
@@ -168,14 +165,12 @@ theorem repeat_succ α v count : myRepeat α v (count + 1) = MyList.cons v (myRe
     first to a type and then to an element of this type (and a number): -/
 
 /- test_repeat1 -/
-unseal myRepeat in
 example : myRepeat Nat 4 2 = .cons 4 (.cons 4 .nil) := by rfl
 
 /- FULL: To use `myRepeat` to build other kinds of lists, we simply
    pass an element of the appropriate type: -/
 
 /- test_repeat2 -/
-unseal myRepeat in
 example : myRepeat Bool false 1 = .cons false .nil := by rfl
 
 /- QUIZ
@@ -249,7 +244,6 @@ def list123 : List Nat := [1, 2, 3]
 /- Let's write the definition of `repeat` again, but this time we won't specify
     the type of the parameter `α`. Will Lean still accept it? -/
 
-@[irreducible]
 def repeat' α (x : α) (count : Nat) : List α :=
   match count with
   | 0 => .nil
@@ -544,19 +538,13 @@ end MumbleGrumble
 /- ######################################################
    ### Exercises -/
 
-seal List.append
-seal List.length
-
-@[irreducible]
 def List.rev {α:Type} (l:List α) : List α :=
   match l with
   | .nil => .nil
   | .cons h t => rev t ++ (.cons h .nil)
 
-unseal List.rev in
 theorem rev_nil α : ([] : List α).rev = [] := by rfl
 
-unseal List.rev in
 theorem rev_cons α h (t : List α) : (h :: t).rev = t.rev ++ [h] := by rfl
 
 /- TERSE: HIDEFROMHTML -/
@@ -696,23 +684,19 @@ example : (3, 5).2 = 5 := by rfl
    TERSE: ***
    TERSE: What does this function do? -/
 
-@[irreducible]
 def zip {α : Type} {β : Type} (lx : List α) (ly : List β) : List (α × β) :=
   match lx, ly with
   | [], _ => []
   | _, [] => []
   | x :: tx, y :: ty => (x, y) :: zip tx ty
 
-unseal zip in
 theorem zip_nil_r α β ly : zip [] ly = ([] : List (α × β)) := by rfl
 
-unseal zip in
 theorem zip_nil_l α β lx : zip lx [] = ([] : List (α × β)) := by
    cases lx
    . rfl
    . rfl
 
-unseal zip in
 theorem zip_cons α β lx ly (x : α) (y : β) :
    zip (x :: lx) (y :: ly) = (x, y) :: zip lx ly := by rfl
 
@@ -734,7 +718,6 @@ theorem zip_cons α β lx ly (x : α) (y : β) :
    Fill in the definition of `unzip` below. Make sure it passes the
    given unit test, and you can prove the simplification lemmas about it -/
 
-@[irreducible]
 def unzip {α : Type} {β : Type} (l : List (α × β)) : List α × List β :=
   /- ADMITDEF -/
   match l with
@@ -745,19 +728,15 @@ def unzip {α : Type} {β : Type} (l : List (α × β)) : List α × List β :=
   /- /ADMITDEF -/
 
 
-unseal unzip in
 theorem unzip_nil α β : unzip [] = (([], []) : List α × List β) := by rfl /- ADMITTED -/
 
-unseal unzip in
 theorem unzip_cons_fst α β l (x : α) (y : β) :
    (unzip ((x, y) :: l)).fst = x :: (unzip l).fst := by dsimp [unzip] /- ADMITTED -/
 
-unseal unzip in
 theorem unzip_cons_snd α β l (x : α) (y : β) :
    (unzip ((x, y) :: l)).snd = y :: (unzip l).snd := by dsimp [unzip] /- ADMITTED -/
 
 /- test_split -/
-unseal unzip in
 example : unzip [(1, false), (2, false)] = ([1, 2], [false, false]) := by rfl  /- ADMITTED -/
 /- GRADE_THEOREM 1: split
    GRADE_THEOREM 1: test_split
@@ -781,7 +760,6 @@ example : unzip [(1, false), (2, false)] = ([1, 2], [false, false]) := by rfl  /
    FULL: We can now rewrite the `nth_error` function so that it works
    with any type of list. -/
 
-@[irreducible]
 def nthError {α : Type} (l : List α) (n : Nat) : Option α :=
   match l with
   | [] => none
@@ -791,13 +769,11 @@ def nthError {α : Type} (l : List α) (n : Nat) : Option α :=
 
 /- HIDEFROMADVANCED
    test_nth_error1 -/
-unseal nthError
 example : nthError [4, 5, 6, 7] 0 = some 4 := by rfl
 /- test_nth_error2 -/
 example : nthError [[1], [2]] 1 = some [2] := by rfl
 /- test_nth_error3 -/
 example : nthError [true] 2 = none := by rfl
-seal nthError
 
 /- /HIDEFROMADVANCED
    FULL
@@ -806,7 +782,6 @@ seal nthError
    `hd_error` function from the last chapter. Be sure that it
    passes the unit tests below. -/
 
-@[irreducible]
 def hdError {α : Type} (l : List α) : Option α :=
   /- ADMITDEF -/
   match l with
@@ -816,18 +791,14 @@ def hdError {α : Type} (l : List α) : Option α :=
 
 #check hdError  /- hdError : {α : Type} → List α → Option α -/
 
-unseal hdError in
 theorem hd_error_nil α : hdError ([] : List α) = none := by rfl -- ADMITTED
 
-unseal hdError in
 theorem hd_error_cons α (h : α) t : hdError (h :: t) = some h := by rfl -- ADMITTED
 
 /- test_hd_error1 -/
-unseal hdError in
 example : hdError [1, 2] = some 1 := by rfl  /- ADMITTED -/
 /- GRADE_THEOREM 0.5: test_hd_error1
    test_hd_error2 -/
-unseal hdError in
 example : hdError [[1], [2]] = some [1] := by rfl  /- ADMITTED -/
 /- GRADE_THEOREM 0.5: test_hd_error2
    []
@@ -884,7 +855,6 @@ example : doit3times not true = false := by rfl
    and "filtering" the list to yield a new list containing just
    those elements for which the predicate returns `true`. -/
 
-@[irreducible]
 def filter {α : Type} (test : α → Bool) (l : List α) : List α :=
   match l with
   | [] => []
@@ -897,7 +867,6 @@ def filter {α : Type} (test : α → Bool) (l : List α) : List α :=
    even members. -/
 
 /- test_filter1 -/
-unseal filter in
 example : filter even [1, 2, 3, 4] = [2, 4] := by rfl
 
 /- TERSE: *** -/
@@ -905,15 +874,12 @@ abbrev lengthIs1 {α : Type} (l : List α) : Bool :=
   l.length == 1
 
 /- test_filter2 -/
-unseal filter in
 example : filter lengthIs1
     [[1, 2], [3], [4], [5, 6, 7], [], [8]]
   = [[3], [4], [8]] := by dsimp [filter, lengthIs1]
 
-unseal filter in
 theorem filter_nil {α : Type} {test : α → Bool} : filter test [] = [] := by rfl
 
-unseal filter in
 theorem filter_cons_success {α : Type} {test : α → Bool} h t :
    test h -> filter test (h :: t) = h :: filter test t := by
    intro htest
@@ -921,7 +887,6 @@ theorem filter_cons_success {α : Type} {test : α → Bool} h t :
    rw [htest]
    dsimp
 
-unseal filter in
 theorem filter_cons_fail {α : Type} {test : α → Bool} h t :
    test h = false -> filter test (h :: t) = filter test t := by
    intro htest
@@ -945,15 +910,11 @@ abbrev countoddmembers' (l : List Nat) : Nat :=
   (filter odd l).length
 
 /- test_countoddmembers'1 -/
-unseal filter
-unseal List.length
 example : countoddmembers' [1, 0, 3, 1, 4, 5] = 4 := by rfl
 /- test_countoddmembers'2 -/
 example : countoddmembers' [0, 2, 4] = 0 := by rfl
 /- test_countoddmembers'3 -/
 example : countoddmembers' [] = 0 := by rfl
-seal filter
-seal List.length
 
 /- /HIDEFROMADVANCED -/
 
@@ -1005,8 +966,6 @@ example : doit3times (· + 1) 0 = 3 := by rfl
    function. -/
 
 /- test_filter2' -/
-unseal filter
-unseal List.length
 example : filter (fun l => l.length == 1)
     [[1, 2], [3], [4], [5, 6, 7], [], [8]]
   = [[3], [4], [8]] := by rfl
@@ -1014,8 +973,6 @@ example : filter (fun l => l.length == 1)
 example : filter (·.length == 1)
     [[1, 2], [3], [4], [5, 6, 7], [], [8]]
   = [[3], [4], [8]] := by rfl
-seal filter
-seal List.length
 
 /- FULL
    EX2 (filter_even_gt7)
@@ -1029,14 +986,10 @@ abbrev filterEvenGt7 (l : List Nat) : List Nat :=
   /- /ADMITDEF -/
 
 /- test_filter_even_gt7_1 -/
-unseal filter
-unseal List.length
 example : filterEvenGt7 [1, 2, 6, 9, 10, 3, 12, 8] = [10, 12, 8] := by rfl  /- ADMITTED -/
 
 /- test_filter_even_gt7_2 -/
 example : filterEvenGt7 [5, 2, 6, 19, 129] = [] := by rfl  /- ADMITTED -/
-seal filter
-seal List.length
 /- GRADE_THEOREM 1: test_filter_even_gt7_1
    GRADE_THEOREM 1: test_filter_even_gt7_2
    [] -/
@@ -1056,14 +1009,10 @@ abbrev partition {α : Type} (test : α → Bool) (l : List α) : List α × Lis
   (filter test l, filter (!test ·) l)
   /- /ADMITDEF -/
 
-unseal filter
-unseal List.length
 /- test_partition1 -/
 example : partition (· % 2 != 0) [1, 2, 3, 4, 5] = ([1, 3, 5], [2, 4]) := by rfl  /- ADMITTED -/
 /- test_partition2 -/
 example : partition (fun _ => false) [5, 9, 0] = ([], [5, 9, 0]) := by rfl  /- ADMITTED -/
-seal filter
-seal List.length
 /- GRADE_THEOREM 1: partition
    GRADE_THEOREM 1: test_partition1
    GRADE_THEOREM 1: test_partition2
@@ -1075,7 +1024,6 @@ seal List.length
 
 /- FULL: Another handy higher-order function is called `map`. -/
 
-@[irreducible]
 def map {α : Type} {β : Type} (f : α → β) (l : List α) : List β :=
   match l with
   | [] => []
@@ -1086,7 +1034,6 @@ def map {α : Type} {β : Type} (f : α → β) (l : List α) : List β :=
    been applied to each element of `l` in turn. For example: -/
 
 /- test_map1 -/
-unseal map in
 example : map (· + 3) [2, 0, 2] = [5, 3, 5] := by rfl
 
 /- HIDEFROMADVANCED
@@ -1096,7 +1043,6 @@ example : map (· + 3) [2, 0, 2] = [5, 3, 5] := by rfl
    numbers to booleans to yield a list of booleans: -/
 
 /- test_map2 -/
-unseal map in
 example : map odd [2, 1, 2, 5] = [false, true, false, true] := by rfl
 
 /- FULL: It can even be applied to a list of numbers and
@@ -1104,7 +1050,6 @@ example : map odd [2, 1, 2, 5] = [false, true, false, true] := by rfl
    yield a _list of lists_ of booleans: -/
 
 /- test_map3 -/
-unseal map in
 example : map (fun n => [even n, odd n]) [2, 1, 2, 5]
   = [[true, false], [false, true], [true, false], [false, true]] := by rfl
 
@@ -1133,10 +1078,8 @@ example : map (fun n => [even n, odd n]) [2, 1, 2, 5]
 /- TERSE: ***
    FULL: *** Exercises -/
 
-unseal map in
 theorem map_nil {α : Type} {β : Type} (f : α → β) : map f [] = [] := by rfl
 
-unseal map in
 theorem map_cons {α : Type} {β : Type} (f : α → β) h t : map f (h :: t) = f h :: map f t := by rfl
 
 /- FULL
@@ -1180,7 +1123,6 @@ theorem map_rev {α : Type} {β : Type} : ∀ (f : α → β) (l : List α),
        flatMap (fun n => [n, n + 1, n + 2]) [1, 5, 10]
          = [1, 2, 3, 5, 6, 7, 10, 11, 12] -/
 
-@[irreducible]
 def flatMap {α : Type} {β : Type} (f : α → List β) (l : List α) : List β :=
   /- ADMITDEF -/
   match l with
@@ -1189,19 +1131,15 @@ def flatMap {α : Type} {β : Type} (f : α → List β) (l : List α) : List β
   /- /ADMITDEF -/
 
 /- test_flat_map1 -/
-unseal flatMap in
-unseal List.append in
 example : flatMap (fun n => [n, n, n]) [1, 5, 4]
   = [1, 1, 1, 5, 5, 5, 4, 4, 4] := by rfl  /- ADMITTED -/
 /- GRADE_THEOREM 1: flatMap
    GRADE_THEOREM 1: test_flat_map1
    [] -/
 
-unseal flatMap in
 theorem flatMap_nil {α : Type} {β : Type} (f : α → List β) : flatMap f [] = [] :=
    by rfl -- ADMITTED
 
-unseal flatMap in
 theorem flatMap_cons {α : Type} {β : Type} (f : α → List β) h t :
    flatMap f (h :: t) = f h ++ flatMap f t := by rfl -- ADMITTED
 /- /FULL
@@ -1210,7 +1148,6 @@ theorem flatMap_cons {α : Type} {β : Type} (f : α → List β) h t :
 /- Lists are not the only inductive type for which `map` makes sense.
    Here is a `map` for the `Option` type: -/
 
-@[irreducible]
 def optionMap {α : Type} {β : Type} (f : α → β) (x? : Option α) : Option β :=
   match x? with
   | none => none
@@ -1238,7 +1175,6 @@ def optionMap {α : Type} {β : Type} (f : α → β) (x? : Option α) : Option 
    operation that lies at the heart of Google's map/reduce
    distributed programming framework. -/
 
-@[irreducible]
 def fold {α : Type} {β : Type} (f : α → β → β) (l : List α) (b : β) : β :=
   match l with
   | [] => b
@@ -1263,25 +1199,19 @@ def fold {α : Type} {β : Type} (f : α → β → β) (l : List α) (b : β) :
        1 + (2 + (3 + (4 + 0))). -/
 
 /- fold_example1 -/
-unseal fold
 example : fold (· && ·) [true, true, false, true] true = false := by rfl
 
 /- fold_example2 -/
 example : fold (· * ·) [1, 2, 3, 4] 1 = 24 := by rfl
 
 /- fold_example3 -/
-unseal List.append in
 example : fold (· ++ ·) [[1], [], [2, 3], [4]] [] = [1, 2, 3, 4] := by rfl
 
 /- fold_example4 -/
-unseal List.length in
 example : fold (fun l n => l.length + n) [[1], [], [2, 3, 2], [4]] 0 = 5 := by rfl
-seal fold
 
-unseal fold in
 theorem fold_nil {α : Type} {β : Type} (f : α → β → β) (b : β) : fold f [] b = b := by rfl
 
-unseal fold in
 theorem fold_cons {α : Type} {β : Type} (f : α → β → β) h t (b : β) :
    fold f (h :: t) b = f h (fold f t b) := by rfl
 
@@ -1413,8 +1343,6 @@ abbrev foldLength {α : Type} (l : List α) : Nat :=
   fold (fun _ n => n + 1) l 0
 
 /- test_fold_length1 -/
-unseal fold in
-unseal List.length in
 example : foldLength [4, 7, 0] = 3 := by rfl
 
 /- Prove the correctness of `foldLength`.
@@ -1503,7 +1431,6 @@ abbrev prodUncurry {α β γ : Type} (f : α → β → γ) (p : α × β) : γ 
    to shorten one of the examples that we saw above: -/
 
 /- test_map1' -/
-unseal map in
 example : map (Nat.add 3) [2, 0, 2] = [5, 3, 5] := by rfl
 
 /- Thought exercise: before running the following commands, can you

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -920,8 +920,6 @@ theorem replace_example m :
 
 /- Use `have` or `replace` to prove the the following lemma, following the
     model of the examples above. Do not use `induction`. -/
--- TODO:CGH  temporary unseal so we can test the Verso build!
-unseal nthError in
 theorem nth_error_always_none (l : List Nat) :
     (∀ i, nthError l i = none) →
     l = [] := by
@@ -1451,8 +1449,6 @@ theorem sub_add_leb : ∀ (n m : Nat),
 -- EX3! (gen_dep_practice)
 -- Prove this by induction on `l`.
 
--- TODO:CGH  temporary unseal so we can test the Verso build!
-unseal nthError in
 theorem nth_error_after_last {α : Type} (n : Nat) (l : List α) :
     l.length = n →
     nthError l n = none := by
@@ -1767,8 +1763,6 @@ def split {α β : Type} (l : List (α × β)) : (List α) × (List β) :=
     | (lx, ly) => (x :: lx, y :: ly)
 
 /- Prove that `split` and `zip` are inverses in the following sense: -/
--- TODO:CGH  temporary unseal so we can test the Verso build!
-unseal zip in
 theorem split_zip {α β : Type} (l : List (α × β)) l1 l2 :
     split l = (l1, l2) →
     zip l1 l2 = l := by
@@ -2071,8 +2065,6 @@ def split_combine_statement : Prop :=
     split (zip l1 l2) = (l1, l2)
 -- /ADMITDEF
 
--- TODO:CGH  temporary unseal so we can test the Verso build!
-unseal zip in
 theorem split_combine : split_combine_statement := by
 -- ADMITTED
   intros α β l1 l2 h
@@ -2092,9 +2084,6 @@ theorem split_combine : split_combine_statement := by
 -- QUIETSOLUTION
 
 /- Here are more approaches -/
-
--- TODO:CGH  temporary unseal so we can test the Verso build!
-unseal zip in
 theorem split_combine' (α β :Type) l (l1 : List α) (l2 : List β) :
     (l1, l2) = split l → split (zip l1 l2) = (l1, l2) := by
   intro h
@@ -2150,8 +2139,6 @@ Proof.
 
 -- FULL
 -- EX3A (filter_exercise)
--- TODO:CGH  temporary unseal so we can test the Verso build!
-unseal filter in
 theorem filter_exercise {α : Type} (test : α → Bool) (a : α) (l lf : List α) :
     filter test l = a :: lf →
     test a = true := by
@@ -2262,8 +2249,6 @@ def forallbF {X : Type} (test : X → Bool) (l : List X) : Bool :=
 def existsbF {X : Type} (test : X → Bool) (l : List X) : Bool :=
   fold (fun x b => (test x) || b) l false
 
--- TODO:CGH  temporary unseal so we can test the Verso build!
-unseal fold in
 theorem existsbF_existsb {α : Type} (test : α → Bool) (l : List α) :
     existsbF test l = existsb test l := by
   unfold existsbF


### PR DESCRIPTION
This PR does a few things
- In `Basics` and `Induction` it changes the use of irreducible to the nicer version with `attribute`
- Removes `irreducible` after those files
- Cleans up the story in `Basics` around irreducible