### PR TITLE
Add `suggested!` marker for OPEN/CLOSE COMMENT WHEN HIDING SOLUTIONS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,15 @@ Two complementary automated checks help here (both take
   NB: `WORKINCLASS` is *not* in this category — it is translated to the
   `workinclass!` tactic (proof shown in student/solutions builds, `sorry` in
   the terse build); see `workinclass.md` for the design and edge cases.
+* `OPEN COMMENT WHEN HIDING SOLUTIONS` / `CLOSE COMMENT WHEN HIDING SOLUTIONS`
+  (with their preceding empty `ADMITTED` region) wrap a *suggested proof* the
+  student is invited to uncomment and adapt. `to_verso` translates the whole
+  idiom to the `suggested!` tactic (`SFLMeta/Exercise.lean`): the proof is
+  elaborated and shown live in the teacher/terse builds, but in the student
+  build the goal is closed with `sorry` and the proof is preserved *commented
+  out* (rather than replaced by a bare `sorry` as `solution!` would). The
+  `OPEN`/`CLOSE` keywords map to `suggested!` in `check_verso_markers.py`'s
+  `_POLICY`.
 
 **Must be preserved** (these were bugs, now fixed): block-style author/dev
 notes (`/- MWH: … -/`, `/- BCP: … -/`, `/- NDS'25: … -/`, `/- NOTATION: … -/`,

--- a/SFLMeta/Exercise.lean
+++ b/SFLMeta/Exercise.lean
@@ -166,6 +166,14 @@ private def recordTerseEdit (edits : Array (Syntax × String)) : IO Unit := do
       terseEditRef.modify
         (·.push ⟨ranges, h⟩)
 
+/-- Record student-variant edits given `Replacement`s directly (rather than
+deriving their ranges from syntax).  Needed by `suggested!`, whose student edit
+includes a zero-width insertion — a comment closer spliced at the body's end
+position — for which there is no corresponding syntax node. -/
+private def recordStudentRepls (repls : Array Replacement) : IO Unit := do
+    if h : repls.size > 0 then
+      studentEditRef.modify (·.push ⟨repls, h⟩)
+
 syntax (name := solutionTerm) "solution!" "(" term ")" : term
 
 @[term_elab solutionTerm]
@@ -208,5 +216,43 @@ def evalWorkinclassTac : Tactic := fun stx => do
     recordTerseEdit #[(stx, "sorry")]
     recordStudentEdit #[(tk, "all_goals")]
     recordTeacherEdit #[(tk, "all_goals")]
+    evalTactic t
+  | _ => throwUnsupportedSyntax
+
+/-! ## `suggested!` marker
+
+The SF idiom `OPEN COMMENT WHEN HIDING SOLUTIONS` … `CLOSE COMMENT WHEN HIDING
+SOLUTIONS`: an exercise whose "solution" is a suggested proof that the student
+is invited to uncomment and adapt.  The body is a real proof, elaborated (and
+so typechecked) in the teacher and terse builds and shown live there — exactly
+as `solution!` treats the teacher build.  In the *student* build it is not
+stubbed to a bare `sorry`; instead the goal is closed with `sorry` and the
+suggested proof is preserved, commented out, for the student to uncomment. -/
+
+syntax (name := suggestedTac) withPosition("suggested!" tacticSeqIndentGt) : tactic
+
+@[tactic suggestedTac]
+def evalSuggestedTac : Tactic := fun stx => do
+  match stx with
+  | `(tactic| suggested!%$tk $t:tacticSeq ) =>
+    -- Teacher and terse builds keep the suggested proof live and shown.
+    recordTeacherEdit #[(tk, "all_goals")]
+    recordTerseEdit #[(tk, "all_goals")]
+    -- Student build: close the goal with `sorry`, then wrap the suggested proof
+    -- in a block comment so it survives verbatim for the student to uncomment.
+    -- The opening `/-` replaces the `suggested!` keyword (indented to its
+    -- column); the closing `-/` is a zero-width insertion at the body's end.
+    let fileMap ← getFileMap
+    let indent := match tk.getPos? with
+      | some p => String.ofList (List.replicate (fileMap.toPosition p).column ' ')
+      | none   => ""
+    match tk.getRange?, t.raw.getRange? with
+    | some tkR, some tR =>
+      recordStudentRepls #[
+        { range := tkR,
+          replacement := s!"sorry\n{indent}/- Suggested proof — uncomment and adapt:" },
+        { range := { start := tR.stop, stop := tR.stop },
+          replacement := s!"\n{indent}-/" }]
+    | _, _ => recordStudentEdit #[(stx, "sorry")]
     evalTactic t
   | _ => throwUnsupportedSyntax

--- a/scripts/check_verso_markers.py
+++ b/scripts/check_verso_markers.py
@@ -100,6 +100,13 @@ _POLICY = [
     # Left as Lean comments inside the code block; the code itself is preserved.
     ("ADMITTED",             None),
     ("ADMITDEF",             None),
+    # `OPEN`/`CLOSE COMMENT WHEN HIDING SOLUTIONS` wraps a suggested proof that
+    # (with its preceding empty ADMITTED region) becomes a `suggested!` tactic
+    # block: the proof is shown live in the teacher/terse builds and kept as a
+    # comment in the student build.  One `suggested!` is emitted per open/close
+    # pair, so both keywords expect the same construct.
+    ("OPEN",                 r"suggested!"),
+    ("CLOSE",                r"suggested!"),
 ]
 
 # Author / developer notes -> :::dev directives.  Matched separately because

--- a/scripts/to_verso.py
+++ b/scripts/to_verso.py
@@ -2279,7 +2279,7 @@ def _convert_solution_markers(src: str) -> str:
         <tactics>
         -- /ADMITTED
 
-      <inside `by`>           ->   solution!
+      <inside `by`>           ->   suggested!
         -- ADMITTED                   <suggested proof, reindented>
         -- /ADMITTED
         /- OPEN COMMENT WHEN HIDING SOLUTIONS -/
@@ -2375,8 +2375,12 @@ def _convert_solution_markers(src: str) -> str:
             # An *empty* region followed by an `OPEN COMMENT WHEN HIDING
             # SOLUTIONS` … `CLOSE COMMENT …` wrapper (the source idiom for
             # "students see the suggested proof as a comment", cf. the
-            # NoStutter examples in IndProp) takes the wrapped suggested
-            # proof as its `solution!` body.
+            # NoStutter examples in IndProp) takes the wrapped suggested proof
+            # as its body and emits the `suggested!` marker instead of
+            # `solution!`: the teacher/terse builds show the live proof, but the
+            # student build keeps it commented out rather than replacing it with
+            # a bare `sorry`.
+            marker = 'solution!'
             if not any(b.strip() for b in body):
                 k = resume
                 while k < n and not lines[k].strip():
@@ -2389,15 +2393,16 @@ def _convert_solution_markers(src: str) -> str:
                     if k < n:
                         body = wrapped
                         resume = k + 1
-            # `solution!` must align with the proof body (which sits inside the
-            # `by`), not with the `-- ADMITTED` marker — the marker is often at
-            # column 0 while the tactics are indented, and a column-0 `solution!`
+                        marker = 'suggested!'
+            # The marker must align with the proof body (which sits inside the
+            # `by`), not with the `-- ADMITTED` marker — the latter is often at
+            # column 0 while the tactics are indented, and a column-0 marker
             # would be read as a new command after an empty `by` block.
             first_body = next((b for b in body if b.strip()), '')
             indent = _indent_of(first_body) if first_body else _indent_of(line)
-            out.append(indent + 'solution!')
+            out.append(indent + marker)
             for bl in body:
-                # tacticSeqIndentGt: body must sit deeper than `solution!`.
+                # tacticSeqIndentGt: body must sit deeper than the marker.
                 out.append(('  ' + bl) if bl.strip() else bl)
             out.extend(trailing)
             i = resume


### PR DESCRIPTION
Claude summary:

The SF idiom `OPEN/CLOSE COMMENT WHEN HIDING SOLUTIONS` wraps a suggested proof the student is meant to uncomment and adapt. Previously `to_verso` folded it (with its empty ADMITTED region) into `solution!`, which gives the student a bare `sorry` and discards the "shown as a comment you can uncomment" affordance the surrounding prose promises.

- SFLMeta/Exercise.lean: new `suggested!` tactic marker. Teacher/terse builds keep the proof live and shown (as `solution!` does for the teacher build); the student build closes the goal with `sorry` and preserves the proof commented out. Implemented via a two-edit student replacement (keyword -> `sorry` + `/-`; zero-width insert of `-/` at the body's end), recorded through a new `recordStudentRepls` helper.
- scripts/to_verso.py: emit `suggested!` (not `solution!`) for the empty- ADMITTED + OPEN/CLOSE idiom.
- scripts/check_verso_markers.py: map `OPEN`/`CLOSE` keywords to `suggested!` in `_POLICY` (previously they'd have been UNKNOWN).
- CLAUDE.md: document the mapping.

Verified against IndProp's NoStutter examples: LF.IndPropVerso builds (teacher + student + terse elaboration), and the extracted student .lean shows `sorry` followed by the suggested proof in a `/- … -/` block.