### PR TITLE
Update AI policy and mention mathlib's AI policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -897,20 +897,20 @@ maintain content in this repo.  AI-generated content, especially
 public-facing content such as words and proofs in book chapters,
 should be carefully vetted.
 
-When submitting a PR that contains public-facing content, we follow the
-[mathlib AI policy][mathlib-ai-policy], and explain how AI is used in
-the PR description. Moreover, PR descriptions must be written by hand.
+For PRs with publict-facing content, we follow the [mathlib AI
+policy][mathlib-ai-policy], which mandates summarizing how AI is used
+in the PR description. PR descriptions should be written (or at least
+carefully rewritten) by hand.
 
-Here is the relevant part of the [mathlib AI policy][mathlib-ai-policy] that
+Here is the part of the [mathlib AI policy][mathlib-ai-policy] that
 should be applied when AI tools are adding or changing public-facing content:
-
 > Explain which tool(s) you used and how you used it. This provides 
 > useful context for reviewers: tools make different mistakes than humans,
 > so knowing this makes it easier to spot common errors.
 
-Scripts and other infrastructure in the repository that are used to help
-create public-facing content are excluded, i.e. they don't need to be
-explained in the PR description.
+Scripts and other infrastructure in the repository that are used to
+help create public-facing content are excluded, i.e., AI usage here
+doesn't need to be explained in the PR description.
 
 Instructions for Claude live in `CLAUDE.md` (which also asks Claude to
 pay attention to the conventions in this file).
@@ -919,8 +919,8 @@ Raw AI output should not be posted to GitHub or zulip without an
 indication that that's what it is.  
 
 Scripts that are mostly or wholly AI generated should be marked as
-such, because these will typically be lower quality than human-created
-or heavily vetted code, and people looking at them should understand
+such: these will typically be lower quality than human-created or
+heavily vetted code, and people looking at them should understand
 that.
 
 [mathlib-ai-policy]: https://leanprover-community.github.io/contribute/index.html#use-of-ai

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -897,6 +897,21 @@ maintain content in this repo.  AI-generated content, especially
 public-facing content such as words and proofs in book chapters,
 should be carefully vetted.
 
+When submitting a PR that contains public-facing content, we follow the
+[mathlib AI policy][mathlib-ai-policy], and explain how AI is used in
+the PR description. Moreover, PR descriptions must be written by hand.
+
+Here is the relevant part of the [mathlib AI policy][mathlib-ai-policy] that
+should be applied when AI tools are adding or changing public-facing content:
+
+> Explain which tool(s) you used and how you used it. This provides 
+> useful context for reviewers: tools make different mistakes than humans,
+> so knowing this makes it easier to spot common errors.
+
+Scripts and other infrastructure in the repository that are used to help
+create public-facing content are excluded, i.e. they don't need to be
+explained in the PR description.
+
 Instructions for Claude live in `CLAUDE.md` (which also asks Claude to
 pay attention to the conventions in this file).
 
@@ -907,3 +922,5 @@ Scripts that are mostly or wholly AI generated should be marked as
 such, because these will typically be lower quality than human-created
 or heavily vetted code, and people looking at them should understand
 that.
+
+[mathlib-ai-policy]: https://leanprover-community.github.io/contribute/index.html#use-of-ai


### PR DESCRIPTION
As discussed on Zulip, explaining how AI tools were used when making a PR helps with reviewing.

I also added that PR descriptions must be written by hand, because the AI tool shouldn't be the one explaining how it's used.