### PR TITLE
Salvage the still-relevant parts of bcp-misc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,8 @@ should be kept in sync as chapters are rewritten.
 - `IndPropRegexp` has been folded into `Automation`
 - `Maps` will be folded into `Typeclasses`
 - Candidate tactics still to be placed include `show`, `rename_i`, `revert`, `suffices`, `tauto`. 
-- Tactics `grind`, `aesop`, are deferred to a later volume. 
+- Tactics `grind`, `aesop`, are deferred to a later volume, following
+  FPiL's caution that `grind` is overwhelming for beginners. 
 
 Related notation introduced alongside tactics: anonymous constructor
 `⟨…⟩` (`Lists`); destructuring `let ⟨…⟩ := …` and `cases h : …`,
@@ -897,7 +898,7 @@ maintain content in this repo.  AI-generated content, especially
 public-facing content such as words and proofs in book chapters,
 should be carefully vetted.
 
-For PRs with publict-facing content, we follow the [mathlib AI
+For PRs with public-facing content, we follow the [mathlib AI
 policy][mathlib-ai-policy], which mandates summarizing how AI is used
 in the PR description. PR descriptions should be written (or at least
 carefully rewritten) by hand.

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -1547,7 +1547,7 @@ The following lemma about `Nat.ble` might help you in the next
 exercise (it will also be useful in later chapters).
 
 ```lean
-theorem leb_n_Sn (n : Nat) :
+theorem ble_n_Sn (n : Nat) :
     Nat.ble n (n + 1) = true := by
   induction n with
   | zero       => rfl
@@ -1580,20 +1580,20 @@ theorem count_remove_one v s :
       rw [remove_one_add_same, count_cons_same]
       dsimp; exact h; exact h
 
-theorem leb_pred_n_n n :
+theorem ble_pred_n_n n :
     Nat.ble n.pred n = true := by
   induction n with
   | zero => dsimp [Nat.ble]
   | succ n ih =>
     dsimp
-    rw [leb_n_Sn]
+    rw [ble_n_Sn]
 
 theorem remove_does_not_increase_count' (s : Bag) (n : Nat) :
     Nat.ble (count n (remove_one n s)) (count n s) = true := by
   induction s with
   | nil => rw [remove_one_nil, count_nil]; rfl
   | cons n' l ih =>
-    rw [count_remove_one, leb_pred_n_n]
+    rw [count_remove_one, ble_pred_n_n]
 ```
 ::::
 
@@ -1608,7 +1608,7 @@ theorem remove_does_not_increase_count (s : Bag) :
     | cons n s' ih =>
       cases n with
       | zero =>
-        rw [remove_one_add_same, count_cons_same, leb_n_Sn] <;> rfl
+        rw [remove_one_add_same, count_cons_same, ble_n_Sn] <;> rfl
       | succ n' =>
         rw [remove_one_add_diff, count_cons_diff, count_cons_diff]
         exact ih; rfl; rfl; rfl

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1705,6 +1705,19 @@ theorem zero_leb (m : Nat) : (0 ≤? m) = true := rfl
 theorem succ_leb_succ (n m : Nat) : ((n + 1) ≤? (m + 1)) = (n ≤? m) := rfl
 ```
 
+:::dev "Claude" BeforeNextRelease
+Claude-generated note. In `Lists` the two lemmas stated over `Nat.ble` were
+renamed `leb_n_Sn` → `ble_n_Sn` and `leb_pred_n_n` → `ble_pred_n_n`, so the name
+tracks the function they are about. The same argument applies to the `leb` names
+that are still here and in `Logic`: `zero_leb` and `succ_leb_succ` above, and
+`leb_plus_exists` / `leb_plus` in `Logic`, are all stated over `≤?`, which is
+notation for `Nat.ble` (declared just above). Should they be renamed `ble_*` too?
+
+Worth deciding as one sweep rather than piecemeal. Note that `LF/Scratch.lean`
+uses a genuinely different `leb` — the chapter's own definition, not `Nat.ble` —
+so those names should stay as they are.
+:::
+
 Suppose that we want to show that `add` is the inverse of
 `sub`.  Since we are working with natural numbers, we need an
 assumption to prevent `sub` from truncating its result. With


### PR DESCRIPTION
A few miscellaneous improvements (that I forgot to merge earlier):

- CONTRIBUTING.md: record the FPiL rationale for deferring `grind` 
- LF/Lists.lean: rename `leb_n_Sn` -> `ble_n_Sn` and `leb_pred_n_n` ->
  `ble_pred_n_n`, so the names track `Nat.ble`, the function they are about.
- LF/Tactics.lean: Claude-generated `:::dev` note reminding us the remaining `leb` names (here and in `Logic`) should be renamed too -- they are also stated over `≤?`, which is notation for `Nat.ble`. 