### PR TITLE
leb -> ble

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -869,7 +869,11 @@ python3 scripts/to_verso.py old/orig-plf-files/Hoare.v HL/Hoare.lean
 
 ## (Temp) Porting from Rocq: comment fidelity and framing
 
-(Claude-drafted; human review welcome.)  
+[BCP: This section seems out of date: We do not use Claude any more
+for rough translations of chapters from Rocq; instead, we use
+to_verso.py to go directly from the Rocq to a non-compiling Verso file
+with all the easy markup changes implemented and all the interesting
+actual translation work left for manual effort.]  
 
 When porting a Rocq
 `sfdev/<vol>/<Ch>.v` to `<Ch>.lean`:

--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -1008,8 +1008,8 @@ theorem dist_exists_or (X : Type) (P Q : X → Prop) :
 -- GRADE_THEOREM 2: dist_exists_or
 -- []
 
--- EX3? (leb_plus_exists)
-theorem leb_plus_exists : ∀ n m : Nat, (n ≤? m = true) → ∃ x, m = x + n := by
+-- EX3? (ble_plus_exists)
+theorem ble_plus_exists : ∀ n m : Nat, (n ≤? m = true) → ∃ x, m = x + n := by
   -- ADMITTED
   intro n
   induction n
@@ -1019,7 +1019,7 @@ theorem leb_plus_exists : ∀ n m : Nat, (n ≤? m = true) → ∃ x, m = x + n 
     case zero => intro h; contradiction
     case succ m' =>
       intro h
-      rw [succ_leb_succ] at h
+      rw [succ_ble_succ] at h
       apply ih at h
       let ⟨x, hx⟩ := h
       exists x
@@ -1027,27 +1027,27 @@ theorem leb_plus_exists : ∀ n m : Nat, (n ≤? m = true) → ∃ x, m = x + n 
   -- /ADMITTED
 
 -- QUIETSOLUTION
-theorem leb_plus (n m : Nat) : (n ≤? (m + n)) = true := by
+theorem ble_plus (n m : Nat) : (n ≤? (m + n)) = true := by
   induction n
   case zero => rfl
-  case succ n' ih => rw [Nat.add_succ m, succ_leb_succ]; exact ih
+  case succ n' ih => rw [Nat.add_succ m, succ_ble_succ]; exact ih
 -- /QUIETSOLUTION
 
-theorem add_exists_leb (n m : Nat) (h : ∃ x, m = x + n) : n ≤? m = true := by
+theorem add_exists_ble (n m : Nat) (h : ∃ x, m = x + n) : n ≤? m = true := by
   -- ADMITTED
   let ⟨x, hx⟩ := h
   rw [hx]
-  apply leb_plus
+  apply ble_plus
   -- /ADMITTED
 
 -- HIDE
 /- A direct proof without a lemma. -/
-theorem add_exists_leb' : ∀ n m, (∃ x, m = x + n) → n ≤? m = true := by
+theorem add_exists_ble' : ∀ n m, (∃ x, m = x + n) → n ≤? m = true := by
   intro n; induction n
   case zero => intro m H; rfl
   case succ n' ih =>
     intro m ⟨x, hx⟩
-    rw [hx, Nat.add_succ x, succ_leb_succ]
+    rw [hx, Nat.add_succ x, succ_ble_succ]
     apply ih; exists x
 -- /HIDE
 -- []

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1701,21 +1701,24 @@ Answer: No, just replaces uses of it by Nat.ble!
 ```lean
 infix:52 " ≤? " => Nat.ble
 
-theorem zero_leb (m : Nat) : (0 ≤? m) = true := rfl
-theorem succ_leb_succ (n m : Nat) : ((n + 1) ≤? (m + 1)) = (n ≤? m) := rfl
+theorem zero_ble (m : Nat) : (0 ≤? m) = true := rfl
+theorem succ_ble_succ (n m : Nat) : ((n + 1) ≤? (m + 1)) = (n ≤? m) := rfl
 ```
 
 :::dev "Claude" BeforeNextRelease
-Claude-generated note. In `Lists` the two lemmas stated over `Nat.ble` were
-renamed `leb_n_Sn` → `ble_n_Sn` and `leb_pred_n_n` → `ble_pred_n_n`, so the name
-tracks the function they are about. The same argument applies to the `leb` names
-that are still here and in `Logic`: `zero_leb` and `succ_leb_succ` above, and
-`leb_plus_exists` / `leb_plus` in `Logic`, are all stated over `≤?`, which is
-notation for `Nat.ble` (declared just above). Should they be renamed `ble_*` too?
+Claude-generated note. The `leb_*` → `ble_*` rename is now applied across
+`Lists`, `Tactics`, and `Logic`, matching the `ble_complete` / `ble_correct` /
+`ble_iff` names already used in `IndProp`: every one of these is stated over
+`≤?`, which is notation for `Nat.ble` (declared just above), so the name now
+tracks the function. Statements keep the `≤?` notation rather than spelling out
+`Nat.ble`, following `IndProp`.
 
-Worth deciding as one sweep rather than piecemeal. Note that `LF/Scratch.lean`
-uses a genuinely different `leb` — the chapter's own definition, not `Nat.ble` —
-so those names should stay as they are.
+Two things deliberately left alone. `LF/Scratch.lean` uses a genuinely different
+`leb` — the chapter's own definition, not `Nat.ble` — so those names stay. And
+`beq_succ` (above, and used in `Logic`) is a separate `BEq` question: it could
+likewise be restated via `Nat.beq_eq_true_eq` / `BEq.comm`, which would let the
+`beq_symm` exercise below drop its induction. Worth a decision, but it changes
+an exercise's shape, not just a name.
 :::
 
 Suppose that we want to show that `add` is the inverse of
@@ -1728,7 +1731,7 @@ we induct on `n` before introducing `m`, so that the induction
 hypothesis becomes sufficiently general.
 
 ```lean
-theorem sub_add_leb : ∀ (n m : Nat),
+theorem sub_add_ble : ∀ (n m : Nat),
     n ≤? m = true → (m - n) + n = m := by
   intro n
   induction n
@@ -1740,7 +1743,7 @@ theorem sub_add_leb : ∀ (n m : Nat),
     intro m h; cases m
     case zero => contradiction
     case succ m' =>
-      rw [succ_leb_succ] at h
+      rw [succ_ble_succ] at h
       rw [succ_sub_succ, add_succ]
     -- At this point, we need to show `(m' - n') + n' + 1 = m' + 1`
     -- from the assumption `(n' <= m') = true`.  We could use the

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1706,15 +1706,17 @@ theorem succ_ble_succ (n m : Nat) : ((n + 1) ≤? (m + 1)) = (n ≤? m) := rfl
 ```
 
 :::dev "Claude" BeforeNextRelease
-Claude-generated note. The `leb_*` → `ble_*` rename is now applied across
+Claude-generated note. 
+(BCP: Whoever reviews this part of the chapter next should read and delete it.)
+
+The `leb_*` → `ble_*` rename is now applied across
 `Lists`, `Tactics`, and `Logic`, matching the `ble_complete` / `ble_correct` /
 `ble_iff` names already used in `IndProp`: every one of these is stated over
 `≤?`, which is notation for `Nat.ble` (declared just above), so the name now
 tracks the function. Statements keep the `≤?` notation rather than spelling out
 `Nat.ble`, following `IndProp`.
 
-Two things deliberately left alone. `LF/Scratch.lean` uses a genuinely different
-`leb` — the chapter's own definition, not `Nat.ble` — so those names stay. And
+One thing to think about:
 `beq_succ` (above, and used in `Logic`) is a separate `BEq` question: it could
 likewise be restated via `Nat.beq_eq_true_eq` / `BEq.comm`, which would let the
 `beq_symm` exercise below drop its induction. Worth a decision, but it changes

--- a/VERSIFICATION-STATUS.md
+++ b/VERSIFICATION-STATUS.md
@@ -95,14 +95,14 @@ Chapter sources — marker/structure repairs (found by the checks):
   terse-visible, matching its marking).
 - Five dropped `TERSE: ***` slide breaks (`-- TERSE:` with lost payload):
   Lists 64, Poly 939, Tactics 134 & 1324, IndProp 574.
-- Tactics: `theorem zero_leb` added next to `succ_leb_succ` (deleted from
+- Tactics: `theorem zero_ble` added next to `succ_ble_succ` (deleted from
   UsingLean 2026-06-29 but still used by IndProp).
 
 ## Remaining work
 
 ### IndProp (deferred — needs more work)
 
-Bare `LF.IndProp` **builds again** (was broken): `zero_leb` restored;
+Bare `LF.IndProp` **builds again** (was broken): `zero_ble` restored;
 `exists 0; rw [double_zero]` → `exists 0` (×2, `exists` closes the goal);
 `inversion contra` → `cases contra` on the empty relation (`inversion` can't
 handle a no-constructor indexed inductive).


### PR DESCRIPTION
There were still some places where our theorem names used `leb` while the standard library uses `ble`.