### PR TITLE
Make SFLMeta an umbrella and get rid of InlineLean hiding lean

### DIFF
--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -1,26 +1,12 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.DisplayMath
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 import LF.Maps
+
 import Lean.PrettyPrinter.Delaborator
 import Lean.PrettyPrinter.Parenthesizer
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Imp: Simple Imperative Programs" =>
 %%%

--- a/HL/Intro.lean
+++ b/HL/Intro.lean
@@ -1,14 +1,4 @@
-import VersoManual
-import SFLMeta.Bnf
-import SFLMeta.Comment
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Ignore
-import SFLMeta.Instructors
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
 
 open Verso.Genre Manual
 open SFLMeta

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1,23 +1,8 @@
 prelude
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
 
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Basics: Functional Programming in Lean" =>
 %%%

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -1,26 +1,10 @@
 prelude
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.DisplayMath
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Epigraph
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 import LF.Basics
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Induction: Proof by Induction" =>
 %%%

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -1,26 +1,10 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.DisplayMath
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Epigraph
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 import LF.Induction
 import LF.UsingLean
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Lists: Working with Structured Data" =>
 %%%

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -1,26 +1,10 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.DisplayMath
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Epigraph
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 import LF.Induction
 import LF.UsingLean
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Poly: Polymorphism and Higher-Order Functions" =>
 %%%
@@ -32,7 +16,7 @@ file := some "Poly"
 :::instructors
 To get through this plus Tactics.lean in two 80-minute
 lectures is a bit tight -- if that's your plan, don't dawdle on
-this chapter. 
+this chapter.
 
 (This comment may now be misaligned with the flow of lectures in CIS5000 at least, since we've
 added significant new material before we get here.)
@@ -431,7 +415,7 @@ Check repeat
     annotations (which can clutter and distract) and too few (which
     can sometimes require readers to perform complex type inference in
     their heads in order to understand your code)."
-     
+
 ```
 ::::
 
@@ -740,7 +724,7 @@ from Lean's standard library:
    `List.cons_append {α} {a : α} {as bs : List α} : a :: as ++ bs = a :: (as ++ bs)`
 
 :::instructors
-(Maybe outdated after the switch to Lean?) 
+(Maybe outdated after the switch to Lean?)
 There's a little inconsistency between this definition
 and the standard library one: in the library, the type argument is
 implicit. :-( I (BCP) have chosen to leave things inconsistent to
@@ -1461,7 +1445,7 @@ can throw away afterwards.)
 ## Fold
 
 ::::full
-An even more powerful higher-order function is 
+An even more powerful higher-order function is
 `fold`. It is the inspiration for the "reduce"
 operation that lies at the heart of Google's map/reduce
 distributed programming framework.
@@ -2063,4 +2047,3 @@ end Church
 end Exercises
 ```
 ::::::
-

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1,26 +1,10 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.DisplayMath
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Epigraph
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 import LF.Poly
 import LF.CustomTactics
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Tactics: More Basic Tactics" =>
 %%%
@@ -1706,7 +1690,7 @@ theorem succ_ble_succ (n m : Nat) : ((n + 1) ≤? (m + 1)) = (n ≤? m) := rfl
 ```
 
 :::dev "Claude" BeforeNextRelease
-Claude-generated note. 
+Claude-generated note.
 (BCP: Whoever reviews this part of the chapter next should read and delete it.)
 
 The `leb_*` → `ble_*` rename is now applied across
@@ -2009,7 +1993,7 @@ Proof.
   destruct m eqn:E.
   - reflexivity.
   - reflexivity.
-Qed. 
+Qed.
 ```
 ::::
 
@@ -2174,7 +2158,7 @@ This is precisely what the
 :::
 
 :::terse
-Adding the `h:` qualifier saves this information so we can use it. 
+Adding the `h:` qualifier saves this information so we can use it.
 :::
 
 ```lean
@@ -2645,4 +2629,3 @@ theorem existsbF_existsb {α : Type} (test : α → Bool) (l : List α) :
     rw [ih]
 ```
 ::::
-

--- a/LF/UsingLean.lean
+++ b/LF/UsingLean.lean
@@ -1,27 +1,10 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.DisplayMath
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Epigraph
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 import LF.Basics
 import LF.Induction
-import Batteries.CodeAction
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "UsingLean: Using the full power of a proof assistant" =>
 %%%

--- a/SFLMeta.lean
+++ b/SFLMeta.lean
@@ -1,4 +1,6 @@
 -- Shared Verso infrastructure for all SF-in-Lean volumes.
+import Batteries.CodeAction
+
 import SFLMeta.Bnf
 import SFLMeta.Comment
 import SFLMeta.Details
@@ -14,3 +16,9 @@ import SFLMeta.SlideBreak
 import SFLMeta.Solution
 import SFLMeta.Terse
 import SFLMeta.Theme
+
+namespace SFLMeta
+
+export Verso.Genre.Manual.InlineLean (name leanCommand leanTerm module leanSection)
+
+end SFLMeta

--- a/SFLMeta/Save.lean
+++ b/SFLMeta/Save.lean
@@ -740,7 +740,7 @@ and the `{lean}` inline-term role (`@[role lean]` on `leanInline`) under the
 constant `InlineLean.lean`.
 
 Our `SFLMeta.lean` override above shadows `InlineLean.lean` as a code block. In a
-document that does `open InlineLean hiding lean` (needed so the bare name `lean`
+document that does `import SFLMeta` (needed so the bare name `lean`
 resolves to *our* code block without ambiguity), `{lean}` therefore resolves to
 `SFLMeta.lean` — which has no role registered under it, so the role fails with
 "can be used as a code block … but is not registered as a role".

--- a/TS/Intro.lean
+++ b/TS/Intro.lean
@@ -1,14 +1,4 @@
-import VersoManual
-import SFLMeta.Bnf
-import SFLMeta.Comment
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Ignore
-import SFLMeta.Instructors
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
 
 open Verso.Genre Manual
 open SFLMeta

--- a/TS/Slang.lean
+++ b/TS/Slang.lean
@@ -1,22 +1,7 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Slang: Arithmetic and Boolean Expressions" =>
 %%%

--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -1,24 +1,9 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 import TS.Slang
 
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 #doc (Manual) "Smallstep: Small-step Operational Semantics" =>
 %%%

--- a/scripts/to_verso.py
+++ b/scripts/to_verso.py
@@ -46,28 +46,12 @@ import textwrap
 # ---------------------------------------------------------------------------
 
 HEADER_TEMPLATE = """\
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.DisplayMath
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Epigraph
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.Quiz
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
+import SFLMeta
+
 {extra_imports}
+
 open Verso.Genre Manual
 open SFLMeta
-
-open InlineLean hiding lean
 
 {doc_options}#doc (Manual) "{title}" =>
 %%%


### PR DESCRIPTION
This PR is a follow-up of #116. It reduces the large import header at top of each file and drops `open InlineLean hiding lean` by re-exporting `InlineLean` definitions to the umbrella module `SFLMeta`. 