### PR TITLE
Move per-chapter notes from INPROGRESS.md into chapter :::dev notes

### DIFF
--- a/INPROGRESS.md
+++ b/INPROGRESS.md
@@ -1,22 +1,8 @@
 This file has been used for temporary / ongoing discussions among translators. 
-It should probably be deleted.
+It should probably be deleted once the following comments are checked.
 
-Normative conventions — live in [STYLEGUIDE.md](STYLEGUIDE.md) now. 
-
-# Potential rules for collaboration
-
-**To do**: take inspiration from Jimmy Wales' [Seven Rules of Trust](https://en.wikipedia.org/wiki/The_Seven_Rules_of_Trust), which underpin Wikipedia's distributed development.
-
-# Commentary
-
-General notes on translation specifics go here.
 
 ## Differences from Rocq
-
-### Aborting
-
-Suggestion from Roger: Use unnamed `example`s closed with `sorry`
-to replace functionality of (named) `Abort`ed lemmas.
 
 ### Induction/inversion and generalization
 
@@ -49,8 +35,6 @@ This can be overwhelming in the beginning, so this chapter uses only decide and 
 Tactics to consider introducing:
 `rcases`, `show`, `rename_i`, `revert`, `split`, `subst`, `suffices`
 
-(The per-chapter tactic-introduction inventory now lives as a table in
-[STYLEGUIDE.md](STYLEGUIDE.md), derived from the current sources.)
 
 ### `rewrite` vs `rw`
 
@@ -67,116 +51,3 @@ as possible about what's happening in proofs. However I think after the first fe
 JC: Because the `rewrite [...]; rfl` occurs so often immediately,
 I've opted to use `rewrite` the first time,
 then introduce `rw` and mostly just use `rw` onwards.
-
-## Course content
-
-### `Basics.lean`
-
-JC: There should be some instruction on interaction with the IDE, namely:
-* how to read the proof state
-* clicking immediately after a tactic will show you what it changed
-* clicking after each `h` in `rw [h₁, h₂, ...]` will show you what was rewritten
-* hovering over a tactic will provide documentation on how to use it
-* hovering over a definition will give its type
-* hovering over a Unicode character will tell you how to type it
-* Ctrl-clicking on a definition will take you to the definition location
-
-### `Induction.lean`
-
-JC: A lot of the proofs on the naturals rely on how operations on naturals were defined in `Basics.lean`,
-but in the stdlib they're slightly different
-(e.g. `sub` is defined via `pred` rather than directly by recursion),
-and the notations all go through typeclasses,
-which makes the proofs a lot less direct
-(e.g. the existing `0 + n` proof refers to `Nat.add_succ`).
-We should do one of the following:
-1.  Not use `+`, `-`, `*` notation and instead use `add`, `sub`, `mul` directly; or
-2.  Override stdlib notation with ones pointing to the definitions in `Basics.lean`.
-
-HG: 1. is a very reasonable way to go about this if we’re attached to arithmetic being the way we teach induction.
-My primary concern is that operators and type classes are already so confusing
-that adding another meaning of `+` is liable to throw someone way off.
-Is there another context we can teach induction in that also doesn’t require a ton of background?
-
-JC: `Basics.lean` now overrides the typeclasses for `-`, `*`, and `^`,
-but not `+`, since that one is pervasive throughout the stdlib and causes problems;
-I think this works okay and isn't too confusing.
-
-JC: If we continue doing arithmetic proofs,
-this is a good place to introduce equational reasoning via `calc`.
-
-### `Lists.lean`
-
-DHS: Weird that this file contains the first `inductive` definition students have seen up to this point,
-but that definition is also actually a `structure`. Probably need to restructure this.
-
-DHS: Unsure if it's a good idea to actually use the built-in `List` definition here, since it's polymorphic,
-and we aren't introducing this idea until a later chapter. This also means we don't get the chance
-to show students how to actually produce an inductive definition if we're relying on the built-in ones.
-DHS: We probably need to actually take time to explain what a `@[simp]` annotation on a lemma
-means before we introduce it, and I don't think this chapter is the right place to do it anyway.
-This is probably a better fit for `Auto.lean`.
-
-DHS: Claude picked a bad definition for `nonzeroes`:
-```
-  match l with
-  | [] => []
-  | 0 :: t => nonzeros t
-  | h :: t => h :: nonzeros t
-```
-which makes many of the later proofs hard to do without the full automation of `simp`. 
-I changed it, but it's worth pointing this out.
-
-KK: The `Baz` "how many elements does this type have?" exercise (the last exercise
-in the chapter) is a *manual* exercise, and that's a poor fit: a student who
-doesn't realize an inductive definition needs a base case will simply fail it and
-only see why in the grader comment — and it's easy to wrongly think you have the
-right answer and move on without thinking. Better to either add a short section
-that explains this directly, or add a hint like the `one_true_baz` / `count_trues`
-scaffold ("try to write a value of type `Baz` for which the lemma holds"). Worth
-reworking for easier grading.
-
-### `Poly.lean`
-
-DHS: None of the comments at the start of the chapter motivating the polymorphic
-definition of lists make sense with the change to use `List Nat` in the previous chapter.
-
-DHS: Using the built-in definition of `List.reverse` is dramatically more complicated
-than implementing our own reverse function, since it is implemented in terms of an auxiliary
-function.
-
-DHS: The associativity of `++` in Lean is different than Rocq. In Rocq the definition
-of `app_assoc` is `l ++ m ++ n = (l ++ m) ++ n`, but in Lean it's
-`l ++ m ++ n = l ++ (m ++ n)`.
-
-### `Tactics.lean`
-
-DHS: There is a section here on unfolding definitions that should probably move earlier,
-to `Basics` or `Induction`, once those chapters are rewritten to not use arithmetic. This will
-also require changing the examples.
-
-### `Logic.lean`
-
-JC: Classical axioms are more pervasive in Lean and the section from Rocq needs to be rewritten
-to acknowledge this and teach idiomatic style.
-
-CH: There's several style things to mention here like `classical` vs. `open Classical`.
-
-
-### (Another note about simplification)
-
-1. While writing library code, it's fine and necessary to unfold and simplify through definitions. When using that code, the idiomatic way is not to "peek through the interface".
-
-
-## Book Structure
-
-The Structure of SFL will differ from Rocq SF in that the LF/PLF books will be
-divided into three books: Logical Foundations, something about Hoare Logic and imperative PL, 
-and something about types and functional PL. The contents will also be somewhat different:
-
-* Volume 1 will go until the Automation chapter; the Imp chapter will be moved to the Hoare Logic volume.
-  * This will also mean that the automation material in `Imp` should be moved to the Volume 1 automation chapter, which has the benefit of separating the concerns of learning about automation from learning about operational semantics. 
-  * The automation chapter will focus on `simp` and other tactics of similar power level to `lia` or `auto` (i.e., `tauto`, `omega`, etc), but not `grind` or `aesop` or `try`, which probably make sense to delay until a future volume about AI use for Lean. The `RegExp` example which was previously a large chunk of the `IndProp` chapter will be moved from that chapter to the automation chapter, and retooled to have a smoother on-ramp but also focus on teaching automation and how to use `simp`. 
-* Volume 2 will be the Type Systems and Lambda Calculus book
-* Volume 3 will be the Imperative Languages and Hoare Logic book
-  * Moving this to after the Type Systems book should make a smoother transition to later material about specification and imperative proofs, rather than having it come before the Type Systems work. 

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -11,6 +11,18 @@ htmlSplit := .never
 file := "Basics"
 %%%
 
+:::dev "Jonathan Chan (ionathanch)"
+[BCP: Old comment -- might be out of date?]
+There should be some instruction on interaction with the IDE, namely:
+* how to read the proof state
+* clicking immediately after a tactic will show you what it changed
+* clicking after each `h` in `rw [h₁, h₂, ...]` will show you what was rewritten
+* hovering over a tactic will provide documentation on how to use it
+* hovering over a definition will give its type
+* hovering over a Unicode character will tell you how to type it
+* Ctrl-clicking on a definition will take you to the definition location
+:::
+
 :::instructors
 This file and Induction.lean each take about an hour to
 get through in a not-too-rushed fashion (with questions, etc.).

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -12,7 +12,7 @@ file := "Basics"
 %%%
 
 :::dev "Jonathan Chan (ionathanch)"
-[BCP: Old comment -- might be out of date?]
+\[BCP: Old comment -- might be out of date?\]
 There should be some instruction on interaction with the IDE, namely:
 * how to read the proof state
 * clicking immediately after a tactic will show you what it changed

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -14,7 +14,7 @@ file := some "Induction"
 %%%
 
 :::dev "Jonathan Chan (ionathanch)"
-[BCP: Old comment -- might be out of date?]
+\[BCP: Old comment -- might be out of date?\]
 A lot of the proofs on the naturals rely on how operations on naturals were defined in `Basics.lean`,
 but in the stdlib they're slightly different
 (e.g. `sub` is defined via `pred` rather than directly by recursion),

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -13,6 +13,35 @@ htmlSplit := .never
 file := some "Induction"
 %%%
 
+:::dev "Jonathan Chan (ionathanch)"
+[BCP: Old comment -- might be out of date?]
+A lot of the proofs on the naturals rely on how operations on naturals were defined in `Basics.lean`,
+but in the stdlib they're slightly different
+(e.g. `sub` is defined via `pred` rather than directly by recursion),
+and the notations all go through typeclasses,
+which makes the proofs a lot less direct
+(e.g. the existing `0 + n` proof refers to `Nat.add_succ`).
+We should do one of the following:
+1.  Not use `+`, `-`, `*` notation and instead use `add`, `sub`, `mul` directly; or
+2.  Override stdlib notation with ones pointing to the definitions in `Basics.lean`.
+:::
+
+:::dev "Harrison Goldstein (hgoldstein95)"
+Option 1 is a very reasonable way to go about this if we're attached to arithmetic being the way we teach induction.
+My primary concern is that operators and type classes are already so confusing
+that adding another meaning of `+` is liable to throw someone way off.
+Is there another context we can teach induction in that also doesn't require a ton of background?
+:::
+
+:::dev "Jonathan Chan (ionathanch)"
+`Basics.lean` now overrides the typeclasses for `-`, `*`, and `^`,
+but not `+`, since that one is pervasive throughout the stdlib and causes problems;
+I think this works okay and isn't too confusing.
+
+If we continue doing arithmetic proofs,
+this is a good place to introduce equational reasoning via `calc`.
+:::
+
 :::dev BeforeNextRelease
 ```
 Readers might expect us to add eqn:H annotations to uses of

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -13,6 +13,41 @@ htmlSplit := .never
 file := some "Lists"
 %%%
 
+:::dev "Daniel Sainati (dsainati1)"
+[BCP: Old comment -- might be out of date?]
+Weird that this file contains the first `inductive` definition students have seen up to this point,
+but that definition is also actually a `structure`. Probably need to restructure this.
+
+Unsure if it's a good idea to actually use the built-in `List` definition here, since it's polymorphic,
+and we aren't introducing this idea until a later chapter. This also means we don't get the chance
+to show students how to actually produce an inductive definition if we're relying on the built-in ones.
+
+We probably need to actually take time to explain what a `@[simp]` annotation on a lemma
+means before we introduce it, and I don't think this chapter is the right place to do it anyway.
+This is probably a better fit for `Auto.lean`.
+
+Claude picked a bad definition for `nonzeroes`:
+```
+  match l with
+  | [] => []
+  | 0 :: t => nonzeros t
+  | h :: t => h :: nonzeros t
+```
+which makes many of the later proofs hard to do without the full automation of `simp`.
+I changed it, but it's worth pointing this out.
+:::
+
+:::dev "Konstantinos Kallas (angelhof)"
+The `Baz` "how many elements does this type have?" exercise (the last exercise
+in the chapter) is a *manual* exercise, and that's a poor fit: a student who
+doesn't realize an inductive definition needs a base case will simply fail it and
+only see why in the grader comment — and it's easy to wrongly think you have the
+right answer and move on without thinking. Better to either add a short section
+that explains this directly, or add a hint like the `one_true_baz` / `count_trues`
+scaffold ("try to write a value of type `Baz` for which the lemma holds"). Worth
+reworking for easier grading.
+:::
+
 :::instructors
 This file takes about 60 minutes to get through.
 Putting it together with Induction.lean makes a reasonable

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -14,7 +14,7 @@ file := some "Lists"
 %%%
 
 :::dev "Daniel Sainati (dsainati1)"
-[BCP: Old comment -- might be out of date?]
+\[BCP: Old comment -- might be out of date?\]
 Weird that this file contains the first `inductive` definition students have seen up to this point,
 but that definition is also actually a `structure`. Probably need to restructure this.
 

--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -8,6 +8,14 @@
  WORKINCLASSes in this chapter.  BCP 20: But conversely some more
  quizzes would be great! -/
 
+/- JC: Classical axioms are more pervasive in Lean and the section from Rocq
+   needs to be rewritten to acknowledge this and teach idiomatic style.
+   [BCP: Old comment -- might be out of date?]
+   -/
+
+/- CH: There's several style things to mention here like `classical` vs.
+   `open Classical`. [BCP: This one too?] -/
+
 -- HIDEFROMHTML
 import LF.Basics
 import LF.Induction

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -14,7 +14,7 @@ file := some "Poly"
 %%%
 
 :::dev "Daniel Sainati (dsainati1)"
-[BCP: Old comment -- might be out of date?]
+\[BCP: Old comment -- might be out of date?\]
 None of the comments at the start of the chapter motivating the polymorphic
 definition of lists make sense with the change to use `List Nat` in the previous chapter.
 

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -13,6 +13,20 @@ htmlSplit := .never
 file := some "Poly"
 %%%
 
+:::dev "Daniel Sainati (dsainati1)"
+[BCP: Old comment -- might be out of date?]
+None of the comments at the start of the chapter motivating the polymorphic
+definition of lists make sense with the change to use `List Nat` in the previous chapter.
+
+Using the built-in definition of `List.reverse` is dramatically more complicated
+than implementing our own reverse function, since it is implemented in terms of an auxiliary
+function.
+
+The associativity of `++` in Lean is different than Rocq. In Rocq the definition
+of `app_assoc` is `l ++ m ++ n = (l ++ m) ++ n`, but in Lean it's
+`l ++ m ++ n = l ++ (m ++ n)`.
+:::
+
 :::instructors
 To get through this plus Tactics.lean in two 80-minute
 lectures is a bit tight -- if that's your plan, don't dawdle on

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -13,6 +13,13 @@ htmlSplit := .never
 file := some "Tactics"
 %%%
 
+:::dev "Daniel Sainati (dsainati1)"
+[BCP: Old comment -- might be out of date?]
+There is a section here on unfolding definitions that should probably move earlier,
+to `Basics` or `Induction`, once those chapters are rewritten to not use arithmetic. This will
+also require changing the examples.
+:::
+
 :::instructors
 This material is a bit too much to cover in detail in
 one 80-minute lecture.  90-100 minutes is more reasonable, but that

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -14,7 +14,7 @@ file := some "Tactics"
 %%%
 
 :::dev "Daniel Sainati (dsainati1)"
-[BCP: Old comment -- might be out of date?]
+\[BCP: Old comment -- might be out of date?\]
 There is a section here on unfolding definitions that should probably move earlier,
 to `Basics` or `Induction`, once those chapters are rewritten to not use arithmetic. This will
 also require changing the examples.


### PR DESCRIPTION
Migrate most of the notes out of INPROGRESS.md into :::dev notes at the top of each chapter.

There are still a few things in INPROGRESS... can we either delete those as stale or move them somewhere else?


