### PR TITLE
Rework `sf_expect_failure` and `sf_experiment` syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -634,10 +634,10 @@ generated projects:
 |---|---|---|
 |`` ```lean ``|shown|normal (executable) code|
 |`` ```lean -show``|hidden|normal code|
-|`` ```lean +error``|shown as expected failure|wrapped in `sf_expect_failure ... end`|
-|`` ```lean +error -show``(rare)|hidden|wrapped in `sf_expect_failure ... end`|
-|`` ```lean -keep``|shown|wrapped in `sf_experiment ... end`|
-|`` ```lean -keep -show`` (rare)|hidden|wrapped in `sf_experiment ... end`|
+|`` ```lean +error``|shown as expected failure|wrapped in an indented `sf_expect_failure` block|
+|`` ```lean +error -show``(rare)|hidden|wrapped in an indented `sf_expect_failure` block|
+|`` ```lean -keep``|shown|wrapped in an indented `sf_experiment` block|
+|`` ```lean -keep -show`` (rare)|hidden|wrapped in an indented `sf_experiment` block|
 
 Do not put definitions needed later in `-keep` or `+error` blocks as they will not become
 executable declarations in the generated projects, though they still get rendered in the book. 

--- a/LF/UsingLean.lean
+++ b/LF/UsingLean.lean
@@ -600,18 +600,7 @@ Let's look at an example using `induction`.
 ::::full
 For example, suppose we start with the following incomplete proof:
 
-```lean
-/--
-error: unsolved goals
-case zero
-⊢ eqb 0 0 = true
-
-case succ
-n✝ : Nat
-a✝ : eqb n✝ n✝ = true
-⊢ eqb (n✝ + 1) (n✝ + 1) = true
--/
-#guard_msgs(error) in
+```lean -keep +error
 theorem foo (n : Nat) : eqb n n := by
   induction n
 ```
@@ -623,8 +612,6 @@ If you choose this action,
 Lean adds an explicit branch for each constructor:
 
 ```lean
-/-- warning: declaration uses `sorry` -/
-#guard_msgs in
 example (n : Nat) : eqb n n := by
   induction n with
   | zero => sorry
@@ -653,32 +640,14 @@ inaccessible names available again.
 The same trick also works for `match` expressions.
 For example, suppose we start with
 
-```
+```lean -keep +error
 def isZero (n : Nat) : Bool :=
   match n
 ```
 
-:::dev
-HIDE:
-@berberman: Incomplete `match` term would cause parse errors which `#guard_msgs` can't suppress.
-Use code block in docstring for now.
-:::
-
 Lean can generate the missing branches:
 
-```lean
-/--
-error: don't know how to synthesize placeholder
-context:
-n✝ n : Nat
-⊢ Bool
----
-error: don't know how to synthesize placeholder
-context:
-n : Nat
-⊢ Bool
--/
-#guard_msgs in
+```lean -keep +error
 def isZero (n : Nat) : Bool :=
   match n with
   | 0 => _

--- a/SFLMeta/SFLCompat.lean
+++ b/SFLMeta/SFLCompat.lean
@@ -67,7 +67,7 @@ private def rawIndentedLineFn : ParserFn := atomicFn <|
     (checkColGeFn "indented command sequence" >> rawLineFn))
 
 private def rawCommandBlockFn : ParserFn :=
-  rawFn (rawLineFn >> manyFn rawIndentedLineFn)
+  rawFn (rawLineFn >> manyFn rawIndentedLineFn) (trailingWs := true)
 
 private def rawCommandBlock : Parser := { fn := rawCommandBlockFn }
 

--- a/SFLMeta/SFLCompat.lean
+++ b/SFLMeta/SFLCompat.lean
@@ -4,15 +4,15 @@ public meta import Lean.Elab.BuiltinCommand
 
 namespace SLFCommand
 
-meta section
+open Lean Elab Command
 
-open Lean Elab Command Parser
+meta section
 
 -- Copied from `SubVerso.Compat` to avoid making generated projects depend on verso.
 -- We want to have info state and messages available right after the elaboration,
 -- so we need to disable `Elab.async` which would let diagnostics produced asynchronously
 -- through spanshot tasks.
-def commandWithoutAsync (act : CommandElabM Unit) : CommandElabM Unit := do
+private def commandWithoutAsync (act : CommandElabM Unit) : CommandElabM Unit := do
   match (← get).scopes with
   | [] => act
   | h :: t =>
@@ -37,20 +37,88 @@ private def withRestoringState (keepMsgs : Bool) (m : CommandElabM Unit) : Comma
       infoState := state.infoState
       messages := if keepMsgs then state.messages else savedState.messages }
 
-private def runCmds (cmds : TSyntaxArray `command) : CommandElabM Unit := do
-  for cmd in cmds do
+namespace IndentedCommands
+
+/-! # Block Commands Parser
+  Parse an indented command block. Commands are separated by new lines.
+  Since we want to capture parsing errors in `sf_expect_failure`,
+  we can't use Lean command parser directly in our command's syntax,
+  because any parsing error occurred would fail `sf_expect_failure` itself.
+  One possible solution is to first parse the whole indented body as raw syntax,
+  and then run Lean's command parser followed by command elaboration.
+-/
+
+open Parser
+
+private def rawLineEndFn : ParserFn :=
+  eoiFn <|> satisfyFn (· == '\n') "line break"
+
+/-- Consumes everything until the next newline and then consumes the newline itself. -/
+private def rawLineFn : ParserFn :=
+  takeUntilFn (· == '\n') >> rawLineEndFn
+
+/- For each line after the first body line, consumes leading whitespaces.
+  If it's blank, consumes the newline; otherwise consumes the line
+  requiring the indentation.
+-/
+private def rawIndentedLineFn : ParserFn := atomicFn <|
+  takeWhileFn (· == ' ') >>
+  (satisfyFn (· == '\n') "line break" <|>
+    (checkColGeFn "indented command sequence" >> rawLineFn))
+
+private def rawCommandBlockFn : ParserFn :=
+  rawFn (rawLineFn >> manyFn rawIndentedLineFn)
+
+private def rawCommandBlock : Parser := { fn := rawCommandBlockFn }
+
+@[combinator_parenthesizer rawCommandBlock]
+private def rawCommandBlock.parenthesizer := PrettyPrinter.Parenthesizer.visitToken
+
+@[combinator_formatter rawCommandBlock]
+private def rawCommandBlock.formatter := PrettyPrinter.Formatter.visitAtom Name.anonymous
+
+private partial def runRawCmdsAux
+    (ictx : InputContext) (pstate : ModuleParserState) : CommandElabM Unit := do
+  let state ← get
+  let scope := state.scopes.head!
+  let pctx :=  {
+      env := state.env
+      options := scope.opts
+      currNamespace := scope.currNamespace
+      openDecls := scope.openDecls : ParserModuleContext
+    }
+  let (cmd, pstate, messages) := parseCommand ictx pctx pstate state.messages
+  modify fun state => { state with messages }
+  unless cmd.isOfKind ``Command.eoi do
     elabCommand cmd
     runLinters cmd
+    unless isTerminalCommand cmd do
+      runRawCmdsAux ictx pstate
 
-private def runSandboxedCmds (ref : Syntax)
-    (expectError : Bool)
-    (keepMsgs : Bool)
-    (cmds : TSyntaxArray `command) : CommandElabM Unit :=
-  commandWithoutAsync <| withRestoringState keepMsgs do
-    if expectError then
-      withRef ref <| failIfSucceeds <| runCmds cmds
-    else
-      runCmds cmds
+/- Recovers the source info and elaborates the commands -/
+private def runRawCmds (body : Syntax) : CommandElabM Unit := do
+  let some source := body.getSubstring? (withLeading := false) (withTrailing := false)
+    | throwErrorAt body "command sequence has no source range"
+  let fileName ← getFileName
+  let fileMap ← getFileMap
+  -- Recall that `rawIndentedLineFn` may consume whitespaces after the newline.
+  -- Here we move the ending back to the last non-whitespace character to produce
+  -- correctly positioned diagnostics.
+  let stopPos := source.trimRight.stopPos
+  if h : stopPos ≤ fileMap.source.rawEndPos then
+    let ictx := InputContext.mk fileMap.source fileName
+      (fileMap := fileMap) (endPos := stopPos) (endPos_valid := h)
+    runRawCmdsAux ictx { pos := source.startPos, recovering := false, hasLeading := false }
+  else
+    throwErrorAt body "invalid command-sequence source range"
+
+end IndentedCommands
+
+end
+
+public meta section
+
+open Parser IndentedCommands
 
 /--
 Elaborates the enclosed commands and reports their diagnostics,
@@ -59,26 +127,17 @@ but discards their effects afterwards.
 Example:
 ```lean
 sf_experiment
-
   def hidden : Nat := 1
   #check hidden
-
-end
 -- `hidden` is not available here.
 ```
 -/
-public def experimentTk := leading_parser
+def experimentTk := leading_parser
   "sf_experiment"
 
-/--
-  Closes `sf_experiment`.
--/
-public def experimentEndTk := leading_parser
-  "end"
-
-@[command_parser] public def experimentCmd := leading_parser
-  experimentTk >> many1 (ppLine >> notSymbol "end" >> commandParser) >>
-  ppDedent (ppLine >> experimentEndTk)
+@[command_parser] def experimentCmd := leading_parser
+  experimentTk >> checkLinebreakBefore "indented command sequence" >>
+    checkColGt "indented command sequence" >> withPosition rawCommandBlock
 
 /--
 Succeeds only if the enclosed commands fail.
@@ -88,47 +147,106 @@ Example:
 ```lean
 sf_expect_failure
   example : 1 = 2 := rfl
-end
 ```
 -/
-public def expectFailureTk := leading_parser
+def expectFailureTk := leading_parser
   "sf_expect_failure"
 
 /-
   Like `sf_expect_failure` but reports the diagnostics.
 -/
-public def expectFailureInfoTk := leading_parser
+def expectFailureInfoTk := leading_parser
   "sf_expect_failure?"
 
-/--
-  Closes `sf_expect_failure`.
--/
-public def expectFailureEndTk := leading_parser
-  "end"
+@[command_parser] def expectFailureCmd := leading_parser
+  expectFailureTk >> checkLinebreakBefore "indented command sequence" >>
+    checkColGt "indented command sequence" >> withPosition rawCommandBlock
 
-@[command_parser] public def expectFailureCmd := leading_parser
-  expectFailureTk >> many1 (ppLine >> notSymbol "end" >> commandParser) >>
-  ppDedent (ppLine >> expectFailureEndTk)
-
-@[command_parser] public def expectFailureInfoCmd := leading_parser
-  expectFailureInfoTk >> many1 (ppLine >> notSymbol "end" >> commandParser) >>
-  ppDedent (ppLine >> expectFailureEndTk)
+@[command_parser] def expectFailureInfoCmd := leading_parser
+  expectFailureInfoTk >> checkLinebreakBefore "indented command sequence" >>
+    checkColGt "indented command sequence" >> withPosition rawCommandBlock
 
 @[command_elab experimentCmd]
-public def elabExperimentCmd : CommandElab := fun stx => do
-  match stx with
-    | `(command| sf_experiment%$tk $cmds:command* end) =>
-      runSandboxedCmds tk false true cmds
-    | _ => throwUnsupportedSyntax
+def elabExperimentCmd : CommandElab := fun stx => do
+  let body := stx.getArgs.back!
+  commandWithoutAsync <| withRestoringState true do
+    runRawCmds body
 
 @[command_elab expectFailureCmd, command_elab expectFailureInfoCmd]
-public def elabExpectFailureCmd : CommandElab := fun stx => do
-  let (tk, keepMsgs, cmds) ← match stx with
-    | `(command| sf_expect_failure%$tk $cmds:command* end) => pure (tk, false, cmds)
-    | `(command| sf_expect_failure?%$tk $cmds:command* end) => pure (tk, true, cmds)
-    | _ => throwUnsupportedSyntax
-  runSandboxedCmds tk true keepMsgs cmds
+def elabExpectFailureCmd : CommandElab := fun stx => do
+  let keepMsgs := stx.isOfKind ``expectFailureInfoCmd
+  unless keepMsgs || stx.isOfKind ``expectFailureCmd do
+    throwUnsupportedSyntax
+  let tk := stx[0]
+  let body := stx.getArgs.back!
+  commandWithoutAsync <| withRestoringState keepMsgs do
+    withRef tk <| failIfSucceeds <| runRawCmds body
 
 end
+
+namespace Tests
+
+/--
+@ +3:11...+4:8
+info: unexpected token '#check'; expected 'with'
+---
+@ +3:4...9
+info: Missing cases:
+_
+---
+@ +4:2...8
+info: 1 : Nat
+-/
+#guard_msgs (positions := true) in
+sf_expect_failure?
+  def f (n : Nat) : Nat :=
+    match n
+  #check 1
+
+/-- info: Nat : Type -/
+#guard_msgs in
+#check Nat
+
+/--
+info: SLFCommand.Tests.x : Nat
+---
+info: 3
+-/
+#guard_msgs in
+sf_experiment
+  def x : Nat := 1
+  #check x
+  def f : Nat → Nat
+    | 0 => 0
+    | n + 1 => n + 2
+  #eval f 2
+
+/-- error: Unknown identifier `x` -/
+#guard_msgs in
+#check x
+
+/--
+error: Type mismatch
+  "qwq"
+has type
+  String
+but is expected to have type
+  Nat
+-/
+#guard_msgs in
+sf_experiment
+  def y : Nat := "qwq"
+
+/-- info: invalid 'import' command, it must be used in the beginning of the file -/
+#guard_msgs in
+sf_expect_failure?
+  import Lean
+
+/-- warning: using 'exit' to interrupt Lean -/
+#guard_msgs in
+sf_experiment
+  #exit
+
+end Tests
 
 end SLFCommand

--- a/SFLMeta/Save.lean
+++ b/SFLMeta/Save.lean
@@ -298,9 +298,9 @@ private def decodeExercise? (data : Json) : Option (Nat × String × Option Stri
   | .arr #[.num _, .str _, _, _] | .arr #[.num _, .str _] => some (decodeExerciseData data)
   | _ => none
 
-private def wrap (startText endText body : String) : String :=
+private def wrapIndented (startText body : String) : String :=
   let body := body.trimAscii.toString.splitOn "\n" |>.map ("  " ++ ·) |> String.intercalate "\n"
-  startText ++ "\n\n" ++ body ++ "\n\n" ++ endText ++ "\n\n"
+  startText ++ "\n" ++ body ++ "\n\n"
 
 /-! ## Block extension that carries pre-computed teacher and student source -/
 
@@ -350,8 +350,8 @@ def decode? (data : Json) : Option Data :=
 
 /--
   * persistent, non-error blocks become executable Lean;
-  * non-persistent blocks (`-keep`) become `sf_experiment ... end`;
-  * expected-error blocks (`+error`) become `sf_expect_failure ... end`
+  * non-persistent blocks (`-keep`) become indented `sf_experiment` blocks;
+  * expected-error blocks (`+error`) become indented `sf_expect_failure` blocks
 -/
 private def Data.extractionMode (saved : Data) : ExtractionMode :=
   let {persistent, expectedError} := saved.config
@@ -812,14 +812,14 @@ partial def walkBlock (width : Nat) (file : String) (b : Verso.Doc.Block Manual)
             (saved.terse.trimAscii.toString ++ "\n\n")
         | .experiment =>
           return appendVariants buf file
-            (wrap "sf_experiment" "end" saved.teacher)
-            (wrap "sf_experiment" "end" saved.student)
-            (wrap "sf_experiment" "end" saved.terse)
+            (wrapIndented "sf_experiment" saved.teacher)
+            (wrapIndented "sf_experiment" saved.student)
+            (wrapIndented "sf_experiment" saved.terse)
         | .expectFailure =>
           return appendVariants buf file
-            (wrap "sf_expect_failure" "end" saved.teacher)
-            (wrap "sf_expect_failure" "end" saved.student)
-            (wrap "sf_expect_failure" "end" saved.terse)
+            (wrapIndented "sf_expect_failure" saved.teacher)
+            (wrapIndented "sf_expect_failure" saved.student)
+            (wrapIndented "sf_expect_failure" saved.terse)
       return buf
     if name == ``Block.importBlock then
       -- Cross-chapter `import` lines shown to the reader.  The extracted


### PR DESCRIPTION
This PR fixes https://github.com/plclub/sf-in-lean/pull/62#issuecomment-4963493625 and let both commands require indented body and let `end` no longer be the delimiter. Particularly, the following incomplete parsing error can be captured:

```lean
sf_expect_failure?
  def f (n : Nat) : Nat :=
    match n
  #check 1 
```

It also updates the project extraction logic to use this new syntax and remove the newline which it would produce after the command. Finally, it replaces some `guard_msgs` in UsingLean with `lean +error` code block, leveraging this new feature.  