### PR TITLE
Add a :::test directive for checks that run but aren't published

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,14 @@ build and passed through as a labelled comment in the generated `.lean` files
 `PotentialImprovement` notes are dropped from every build. The other annotation
 directives (`instructors`/`hide`/`grade`/`solution`) are noops (bodies dropped
 from every build); the tag name reserves each for a future build that treats it
-differently.
+differently.  "Dropped from every build" means dropped *at elaboration*: Lean
+code inside `::::hide` is inert text that is never checked — right for the
+parked, aspirational code the LF chapters' hide blocks hold, but the opposite of
+what a live check wants.  For content that must elaborate (and so can fail the
+build) while appearing in no build product — a run of `#check`s guarding a
+chapter's own notation, say — use `:::test` (`SFLMeta/Test.lean`), whose body is
+elaborated but rendered nowhere and saved nowhere.  Contrast `:::ignore`, which
+elaborates *and* renders, and is dropped only from the extracted `.lean`.
 
 Two related directives are **not** noops. `:::gradeTheorem <pts> "<name>"` is
 the structured successor to a `:::grade` block wrapping a `GRADE_THEOREM <pts>:

--- a/SFLMeta.lean
+++ b/SFLMeta.lean
@@ -15,6 +15,7 @@ import SFLMeta.Save
 import SFLMeta.SlideBreak
 import SFLMeta.Solution
 import SFLMeta.Terse
+import SFLMeta.Test
 import SFLMeta.Theme
 
 namespace SFLMeta

--- a/SFLMeta/Save.lean
+++ b/SFLMeta/Save.lean
@@ -6,6 +6,7 @@ import SFLMeta.Ignore
 import SFLMeta.Exercise
 import SFLMeta.Quiz
 import SFLMeta.Terse
+import SFLMeta.Test
 import SFLMeta.SlideBreak
 import SFLMeta.Details
 import Std.Data.HashMap
@@ -795,6 +796,9 @@ partial def walkBlock (width : Nat) (file : String) (b : Verso.Doc.Block Manual)
   | .other which contents =>
     let name := which.name
     if name == ``Block.ignore then
+      return buf
+    if name == ``Block.test then
+      -- Elaborated when the book is built, but part of no build product.
       return buf
     if name == ``Verso.Genre.Manual.Block.diagram then
       return buf

--- a/SFLMeta/Test.lean
+++ b/SFLMeta/Test.lean
@@ -1,0 +1,46 @@
+import VersoManual
+
+open Lean Elab
+open Verso ArgParse Doc Elab Genre.Manual
+
+namespace SFLMeta
+
+/-!
+`Block.test` wraps content that must *elaborate* when the book is built but that
+appears in no build product: nothing is rendered in HTML or TeX, and the saver
+emits nothing into the generated `.lean` files.
+
+It is the home for regression checks on a chapter's own machinery — a run of
+`#check`s confirming that a notation still parses the way the chapter claims,
+say.  Those checks are worth keeping and worth running, but they are not part of
+the exposition, and a reader working through the extracted `.lean` should never
+meet them.
+
+Contrast the neighbouring directives, none of which does this job:
+
+* `:::ignore` elaborates and renders, and is dropped only from the extracted
+  `.lean` — so its content is still in the book.
+* `::::hide` drops its body at *elaboration* (like `:::dev` and
+  `:::instructors`), so Lean code inside it is inert text that is never checked.
+  That is the right treatment for the parked, aspirational code those blocks
+  hold across the LF chapters, but it is the opposite of what a live check
+  needs.
+
+Because the body really is elaborated, a ` ```lean ` block inside `:::test` runs
+for real: it can fail the build, which is the point. -/
+block_extension Block.test where
+  data := Json.null
+  traverse _ _ _ := pure none
+  toHtml := some fun _ _ _ _ _ => pure .empty
+  toTeX  := some fun _ _ _ _ _ => pure .empty
+
+/--
+A `:::test` directive: Lean content that is checked when the book is built but
+that reaches neither the HTML book nor the generated `.lean` files. -/
+@[directive]
+def test : DirectiveExpanderOf Unit
+  | (), contents => do
+    let blocks ← contents.mapM elabBlock
+    ``(Verso.Doc.Block.other SFLMeta.Block.test #[$blocks,*])
+
+end SFLMeta


### PR DESCRIPTION
New verso directive `::::test` for Lean checks that run but aren't published. Motivation:

`::::hide` drops its body at *elaboration*, so Lean code inside it is inert text that is never checked. A `:::test` body is elaborated for real (so it can fail the build) but renders nothing in HTML/TeX and is skipped by the saver, so it reaches neither the published book nor the extracted `.lean` projects. Contrast `:::ignore`, which elaborates *and* renders, and is dropped only from the extracted `.lean`, not the HTML.

All of this (non user facing) code was authored by Claude.