### PR TITLE
More verso commands for enhanced rendering

### DIFF
--- a/SFLMeta/Bnf.lean
+++ b/SFLMeta/Bnf.lean
@@ -19,12 +19,21 @@ inductive BnfToken where
   | lit (literal : String)
 deriving Repr, Inhabited, BEq, ToJson, FromJson
 
+/-- One alternative of a production: a sequence of tokens, plus an optional gloss
+naming the form it describes (SF's right-hand `(application)` column). -/
+structure BnfAlt where
+  /-- The tokens of the alternative, in source order. -/
+  tokens : Array BnfToken
+  /-- The gloss, without its surrounding parentheses. -/
+  note : Option String := none
+deriving Repr, Inhabited, BEq, ToJson, FromJson
+
 /-- A single BNF production: `lhs ::= alts[0] | alts[1] | ...`. -/
 structure BnfProduction where
   /-- The non-terminal being defined. -/
   lhs : String
-  /-- The right-hand-side alternatives, each a sequence of tokens. -/
-  alts : Array (Array BnfToken)
+  /-- The right-hand-side alternatives. -/
+  alts : Array BnfAlt
 deriving Repr, Inhabited, BEq, ToJson, FromJson
 
 /-- A BNF grammar: a sequence of productions in source order. -/
@@ -39,7 +48,11 @@ namespace Bnf
 
 A `bnf%` term and a ` ```bnf ` code block share the same grammar. Productions end
 with `;`; alternatives within a production are separated by `|`; a token is either
-an identifier (metavariable) or a string literal (terminal). -/
+an identifier (metavariable) or a string literal (terminal). An alternative may
+end with a parenthesized string, `("application")`, which becomes a gloss in a
+right-hand column rather than part of the grammar. The gloss is written as a
+string literal so that it can be arbitrary prose without colliding with the
+token syntax. -/
 
 /-- A token of the BNF surface syntax. -/
 declare_syntax_cat bnfTok
@@ -50,8 +63,9 @@ syntax str : bnfTok
 
 /-- One alternative of a BNF production. -/
 declare_syntax_cat bnfAlt
-/-- An alternative is a non-empty sequence of tokens. -/
-syntax bnfTok+ : bnfAlt
+/-- An alternative is a non-empty sequence of tokens, optionally followed by a
+parenthesized gloss. -/
+syntax bnfTok+ ("(" str ")")? : bnfAlt
 
 /-- A single production. -/
 declare_syntax_cat bnfProd
@@ -86,11 +100,14 @@ def tokToTerm (stx : TSyntax `bnfTok) : MacroM (TSyntax `term) :=
     `(SFLMeta.BnfToken.lit $s)
   | _ => Macro.throwUnsupported
 
-/-- Translate a parsed `bnfAlt` to term syntax producing an `Array BnfToken`. -/
+/-- Translate a parsed `bnfAlt` to term syntax producing a `BnfAlt`. -/
 def altToTerm (stx : TSyntax `bnfAlt) : MacroM (TSyntax `term) := do
-  let `(bnfAlt| $toks:bnfTok*) := stx | Macro.throwUnsupported
+  let `(bnfAlt| $toks:bnfTok* $[($note:str)]?) := stx | Macro.throwUnsupported
   let tokTerms ← toks.mapM tokToTerm
-  `(#[$tokTerms,*])
+  let noteTerm ← match note with
+    | some s => `(some $s)
+    | none   => `(none)
+  `(({ tokens := #[$tokTerms,*], note := $noteTerm } : SFLMeta.BnfAlt))
 
 /-- Translate a parsed `bnfProd` to term syntax producing a `BnfProduction`. -/
 def prodToTerm (stx : TSyntax `bnfProd) : MacroM (TSyntax `term) := do
@@ -121,10 +138,11 @@ def tokOfSyntax (stx : TSyntax `bnfTok) : Except String BnfToken :=
   | `(bnfTok| $s:str)   => .ok (.lit s.getString)
   | _ => .error s!"unrecognized bnfTok"
 
-/-- Translate a parsed `bnfAlt` to an `Array BnfToken`. -/
-def altOfSyntax (stx : TSyntax `bnfAlt) : Except String (Array BnfToken) := do
-  let `(bnfAlt| $toks:bnfTok*) := stx | .error "expected bnfAlt"
-  toks.mapM tokOfSyntax
+/-- Translate a parsed `bnfAlt` to a `BnfAlt`. -/
+def altOfSyntax (stx : TSyntax `bnfAlt) : Except String BnfAlt := do
+  let `(bnfAlt| $toks:bnfTok* $[($note:str)]?) := stx | .error "expected bnfAlt"
+  let tokens ← toks.mapM tokOfSyntax
+  pure { tokens, note := note.map (·.getString) }
 
 /-- Translate a parsed `bnfProd` to a `BnfProduction`. -/
 def prodOfSyntax (stx : TSyntax `bnfProd) : Except String BnfProduction := do
@@ -160,15 +178,17 @@ def tokToHtml : BnfToken → Html
   | .meta    s => {{ <span class="bnf-mv">{{s}}</span> }}
   | .lit     s => {{ <span class="bnf-kw">{{s}}</span> }}
 
-/-- Render a single alternative (sequence of tokens) as inline HTML. -/
-def altToHtml (alt : Array BnfToken) : Html :=
-  Html.seq <| alt.foldl (init := #[]) fun acc t =>
+/-- Render a single alternative (sequence of tokens) as inline HTML.  The gloss, if
+any, is rendered separately by `toHtmlImpl` into its own column. -/
+def altToHtml (alt : BnfAlt) : Html :=
+  Html.seq <| alt.tokens.foldl (init := #[]) fun acc t =>
     if acc.isEmpty then #[tokToHtml t]
     else acc.push (Html.text false " ") |>.push (tokToHtml t)
 
 /-- Render a full BNF grammar as a structured HTML table. The LHS of each production is
 rendered with the same `.bnf-nt` styling as a non-terminal reference on the RHS so that the
-same name looks the same wherever it appears. -/
+same name looks the same wherever it appears.  A fourth column carries the alternatives'
+glosses; it is present but empty for a grammar that has none. -/
 def toHtmlImpl (b : BNF) : Html :=
   let rows : Array Html := b.productions.flatMap fun p =>
     p.alts.mapIdx fun i alt =>
@@ -176,10 +196,15 @@ def toHtmlImpl (b : BNF) : Html :=
         if i = 0 then {{ <td class="bnf-lhs"><span class="bnf-nt">{{p.lhs}}</span></td> }}
         else {{ <td class="bnf-lhs">{{" "}}</td> }}
       let sep : String := if i = 0 then "::=" else "|"
+      let noteCell : Html :=
+        match alt.note with
+        | some n => {{ <td class="bnf-note">{{"(" ++ n ++ ")"}}</td> }}
+        | none   => {{ <td class="bnf-note">{{" "}}</td> }}
       {{ <tr>
            {{lhsCell}}
            <td class="bnf-sep">{{sep}}</td>
            <td class="bnf-alt">{{altToHtml alt}}</td>
+           {{noteCell}}
          </tr> }}
   {{ <table class="bnf">{{Html.seq rows}}</table> }}
 
@@ -191,13 +216,15 @@ def tokToTeX : BnfToken → Verso.Output.TeX
   | .meta    s => .raw s!"\\mathit\{{s}}"
   | .lit     s => .raw s!"\\textsf\{{s}}"
 
-/-- Render an alternative as a TeX fragment, with `~` separators between tokens. -/
-def altToTeX (alt : Array BnfToken) : Verso.Output.TeX :=
-  Verso.Output.TeX.seq <| alt.foldl (init := #[]) fun acc t =>
+/-- Render an alternative as a TeX fragment, with `~` separators between tokens.  The
+gloss, if any, is rendered separately by `toTeXImpl` into its own column. -/
+def altToTeX (alt : BnfAlt) : Verso.Output.TeX :=
+  Verso.Output.TeX.seq <| alt.tokens.foldl (init := #[]) fun acc t =>
     if acc.isEmpty then #[tokToTeX t]
     else acc.push (.raw "~") |>.push (tokToTeX t)
 
-/-- Render a full BNF grammar as a LaTeX `tabular` environment. -/
+/-- Render a full BNF grammar as a LaTeX `tabular` environment.  The fourth column
+carries the alternatives' glosses, and stays empty for a grammar that has none. -/
 def toTeXImpl (b : BNF) : Verso.Output.TeX :=
   let rows : Array Verso.Output.TeX := b.productions.flatMap fun p =>
     p.alts.mapIdx fun i alt =>
@@ -205,8 +232,13 @@ def toTeXImpl (b : BNF) : Verso.Output.TeX :=
         if i = 0 then .raw s!"\\mathit\{{p.lhs}}" else .empty
       let sep : Verso.Output.TeX :=
         if i = 0 then .raw "::=" else .raw "$\\mid$"
-      .seq #[lhsCell, .raw " & ", sep, .raw " & ", altToTeX alt, .raw " \\\\\n"]
-  .seq #[.raw "\\begin{tabular}{lll}\n", .seq rows, .raw "\\end{tabular}\n"]
+      let noteCell : Verso.Output.TeX :=
+        match alt.note with
+        | some n => .raw s!"\\textit\{({n})}"
+        | none   => .empty
+      .seq #[lhsCell, .raw " & ", sep, .raw " & ", altToTeX alt, .raw " & ", noteCell,
+             .raw " \\\\\n"]
+  .seq #[.raw "\\begin{tabular}{llll}\n", .seq rows, .raw "\\end{tabular}\n"]
 
 end Bnf
 
@@ -263,6 +295,15 @@ table.bnf .bnf-mv  {
   text-underline-offset: 0.18em;
 }
 table.bnf .bnf-kw  { font-weight: 600; font-family: var(--verso-code-font-family, monospace); }
+/* The gloss column: set in the body font, muted, and pushed away from the
+   grammar so it reads as an annotation rather than as part of the syntax. */
+table.bnf td.bnf-note {
+  padding-left: 2.5em;
+  text-align: left;
+  font-family: inherit;
+  font-style: italic;
+  opacity: 0.65;
+}
 "##
   ]
 

--- a/SFLMeta/Bnf.lean
+++ b/SFLMeta/Bnf.lean
@@ -208,6 +208,37 @@ def toHtmlImpl (b : BNF) : Html :=
          </tr> }}
   {{ <table class="bnf">{{Html.seq rows}}</table> }}
 
+/-! ## Plain-text rendering
+
+The extracted `.lean` files have no styling to distinguish a terminal from a
+non-terminal, so a grammar is rendered there as SF's original aligned display:
+tokens separated by spaces, quotes dropped, glosses lined up in a right-hand
+column. -/
+
+/-- Render a single token as plain text. -/
+def tokToText : BnfToken → String
+  | .nonterm s => s
+  | .meta    s => s
+  | .lit     s => s
+
+/-- Render an alternative as plain text: its tokens, space-separated. -/
+def altToText (alt : BnfAlt) : String :=
+  String.intercalate " " (alt.tokens.toList.map tokToText)
+
+/-- Render a full BNF grammar as an aligned plain-text display.  The gloss
+column is aligned across the whole grammar, not per production. -/
+def toTextImpl (b : BNF) : String :=
+  let rows : Array (String × Option String) := b.productions.flatMap fun p =>
+    p.alts.mapIdx fun i alt =>
+      let lhs := if i = 0 then p.lhs else String.ofList (List.replicate p.lhs.length ' ')
+      let sep := if i = 0 then "::=" else "  |"
+      (lhs ++ " " ++ sep ++ " " ++ altToText alt, alt.note)
+  let width := rows.foldl (init := 0) fun w (l, _) => max w l.length
+  String.intercalate "\n" (rows.toList.map fun (l, note) =>
+    match note with
+    | some n => l ++ String.ofList (List.replicate (width + 4 - l.length) ' ') ++ "(" ++ n ++ ")"
+    | none   => l)
+
 /-! ## TeX rendering -/
 
 /-- Render a single token as a TeX fragment. -/

--- a/SFLMeta/Save.lean
+++ b/SFLMeta/Save.lean
@@ -935,8 +935,11 @@ partial def walkBlock (width : Nat) (file : String) (b : Verso.Doc.Block Manual)
     -- only reached for a list arriving outside that batching.
     return appendBoth buf file (asModuleDoc (blockToText width b))
   | .dl dis =>
+    -- A description list: the term of each item is content too, so emit it
+    -- before walking that item's description blocks.
     let mut buf := buf
     for di in dis do
+      buf := appendBoth buf file (asModuleDoc (inlinesToText di.term))
       buf := walkBlocks width file di.desc buf
     return buf
 

--- a/SFLMeta/Save.lean
+++ b/SFLMeta/Save.lean
@@ -285,10 +285,17 @@ private def devNoteComment (label body : String) : String :=
 private def mergeAdjacentModuleDocs (s : String) : String :=
   s.replace "\n-/\n\n/-!\n" "\n\n"
 
-/-- Decode a `Block.bnf` payload and return its original source string. -/
+/-- Decode a `Block.bnf` payload and render the grammar as an aligned plain-text
+display (`Bnf.toTextImpl`), which is what an extracted `.lean` file wants: the
+authoring source spells terminals as string literals and metavariables with a
+leading underscore, and neither is meant to be read.  Falls back to the original
+source if the payload cannot be decoded. -/
 private def decodeBnfSource? (data : Json) : Option String :=
   match data with
-  | .arr #[_, .str src] => some src
+  | .arr #[.str jsonStr, .str src] =>
+    match Json.parse jsonStr >>= fromJson? with
+    | .ok (b : BNF) => some (Bnf.toTextImpl b)
+    | .error _      => some src
   | _ => none
 
 /-- Decode a `Block.exercise` payload `(rating, name, level, manual)`, tolerating


### PR DESCRIPTION
Extended the `bnf` directive to allow an optional fourth column, as a production label. Also adjusted typesetting so that rendering markup intended for HTML only, distinguishing terminals from nonterminals, is stripped in the generated lean for cleaner plain-text. Finally, tweaked so that a description list's terms are emitted into the extracted `.lean`; useful for lists of examples (in prep for STLC).

All code written by Claude, human reviewed; no user-facing content.