### PR TITLE
Slang: the informal grammar becomes a bnf block

### DIFF
--- a/TS/Slang.lean
+++ b/TS/Slang.lean
@@ -93,19 +93,18 @@ trees -- the process that, for example, would translate the string
 For comparison, here's a conventional BNF (Backus-Naur Form) grammar
 defining the same abstract syntax:
 
-```
-  a := nat
-      | a + a
-      | a − a
-      | a * a
-
-  b := bool
-      | a = a
-      | a ≠ a
-      | a ≤ a
-      | a > a
-      | ¬ b
-      | b ∧ b
+```bnf
+a ::= nat
+    | a "+" a
+    | a "−" a
+    | a "*" a ;
+b ::= bool
+    | a "=" a
+    | a "≠" a
+    | a "≤" a
+    | a ">" a
+    | "¬" b
+    | b "∧" b ;
 ```
 
 Compared to the Lean version above...


### PR DESCRIPTION
The chapter introduces this display as "a conventional BNF grammar", so it may as well be one: the ` ```bnf ` block renders terminals and non-terminals distinctly in the book and comes out as an aligned plain-text grammar in the extracted `.lean`.

Also corrects `:=` to `::=` — BNF defines a non-terminal, it does not assign to one, and the chapter's own prose calls the notation BNF.

Shared file: this chapter is `{include}`d by both the HL and TS volumes.