### PR TITLE
Types: bnf grammar, and notation encoding behind :::details

### DIFF
--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -29,7 +29,7 @@ In this and later chapters, we are not very consistent about
 :::
 
 :::instructors
-This chapter is meaty, but quite short -- probably too short
+This chapter is meaty, but quite short — probably too short
    for a whole week of class (though long enough that it will probably spill
    into part of a second 80-minute lecture).  Some of the material from
    Types (maybe even the whole thing) can be included in the same week (and
@@ -83,11 +83,11 @@ value "all in one big step":
 2 + 2 + 3 * 4 ⇓ 16
 ```
 
-This style is simple and natural for many purposes -- indeed, Gilles Kahn,
+This style is simple and natural for many purposes — indeed, Gilles Kahn,
 who popularized it, called it _natural semantics_.  But there are some
 things it does not do well.  In particular, it does not give us a convenient
 way of talking about _concurrent_ programming languages, where the semantics
-of a program -- the essence of how it behaves -- includes not just which
+of a program — the essence of how it behaves — includes not just which
 input states get mapped to which output states, but also the intermediate
 states that it passes through along the way; this is crucial, since these
 states can also be observed by concurrently executing code.
@@ -100,12 +100,12 @@ write strange expressions like `2 + nil`, and our semantics for arithmetic
 expressions will then need to say something about how such expressions
 behave.  One possibility is to maintain the convention that every arithmetic
 expression evaluates to some number by choosing some way of viewing a list
-as a number -- e.g., by specifying that a list should be interpreted as `0`
+as a number — e.g., by specifying that a list should be interpreted as `0`
 when it occurs in a context expecting a number.  But this would be a bit of
 a hack.
 
 A much more natural approach is simply to say that the behavior of the
-expression `2 + nil` is _undefined_ -- i.e., it doesn't evaluate to any
+expression `2 + nil` is _undefined_ — i.e., it doesn't evaluate to any
 result at all.  And we can easily do this: we just have to formulate `aeval`
 and `beval` as inductive propositions rather than functions, so that we can
 make them partial functions instead of total ones.
@@ -118,8 +118,8 @@ infinite loop or because, at some point, the program tries to do an
 operation that makes no sense, such as adding a number to a list, so that
 none of the evaluation rules can be applied.
 
-These two outcomes -- nontermination vs. getting stuck in an erroneous
-configuration -- should not be confused.  In particular, we want to _allow_
+These two outcomes — nontermination vs. getting stuck in an erroneous
+configuration — should not be confused.  In particular, we want to _allow_
 the first (because permitting the possibility of infinite loops is the price
 we pay for the convenience of programming with general looping constructs)
 but _prevent_ the second (which is just wrong), for example by
@@ -179,7 +179,7 @@ Advantages of the small-step style include:
 ::::full
 To save space, we start with an incredibly simple language of just
 constants and addition.  (We use single-letter constructors `c` and `p`
--- for Constant and Plus -- for brevity.)  The same techniques scale up to
+— for Constant and Plus — for brevity.)  The same techniques scale up to
 richer languages.
 ::::
 
@@ -274,8 +274,8 @@ Things to notice:
 ::::
 
 :::terse
-Notice: each step reduces the _leftmost_ `p` node that is ready to go -- the first rule tells how
-to rewrite it, the second and third tell where to find it -- and constants do not step to anything.
+Notice: each step reduces the _leftmost_ `p` node that is ready to go — the first rule tells how
+to rewrite it, the second and third tell where to find it — and constants do not step to anything.
 :::
 
 Let's pause and check a couple of examples of reasoning with the step relation.
@@ -370,7 +370,7 @@ develops some of these ideas in a bit more detail; reviewing that chapter
 may be useful if the treatment here feels too terse.)
 
 A _binary relation_ on a type `X` is a family of propositions parameterized
-by two elements of `X` -- i.e., a proposition about pairs of elements of
+by two elements of `X` — i.e., a proposition about pairs of elements of
 `X`.
 ::::
 
@@ -391,7 +391,7 @@ def Relation (X : Type) := X → X → Prop
 :::full
 Our main examples of such relations in this chapter will be the
 single-step reduction relation, `⟶`, and its multi-step variant, `⟶*`,
-defined below, but there are many other examples -- e.g., the "equals,"
+defined below, but there are many other examples — e.g., the "equals,"
 "less than," "less than or equal to," and "is the square of" relations on
 numbers, and the "prefix of" relation on lists and strings.
 :::
@@ -457,7 +457,7 @@ It can be useful to think of the `⟶` relation as defining an _abstract
 machine_:
 
   - At any moment, the _state_ of the machine is a term.
-  - A _step_ of the machine is an atomic unit of computation -- here, a
+  - A _step_ of the machine is an atomic unit of computation — here, a
     single "add" operation.
   - The _halting states_ of the machine are ones where there is no more
     computation to be done.
@@ -675,9 +675,9 @@ theorem nf_same_as_value (t : Tm) : IsNormalForm Step t ↔ IsValue t :=
   ⟨nf_is_value t, value_is_nf t⟩
 ```
 
-Why is this interesting? Because `IsValue` is a _syntactic_ concept -- it is
-defined by looking at the way a term is written -- while `IsNormalForm` is a
-_semantic_ one -- it is defined by looking at how the term steps.
+Why is this interesting? Because `IsValue` is a _syntactic_ concept — it is
+defined by looking at the way a term is written — while `IsNormalForm` is a
+_semantic_ one — it is defined by looking at how the term steps.
 
 It is not obvious that these concepts should characterize the same set of terms!
 
@@ -863,7 +863,7 @@ end Temp3
 ::::full
 We've been working so far with the _single-step reduction_ relation `⟶`,
 which formalizes the individual steps of an abstract machine for executing
-programs.  We can use the same machine to reduce programs to completion --
+programs.  We can use the same machine to reduce programs to completion —
 to find out what final result they yield.  This can be formalized as
 follows:
 
@@ -940,7 +940,7 @@ example : (.p (.c 1) (.c 2)) ⟶* .c (1 + 2) := by
 ```
 
 ::::full
-Second, it _contains_ `R` -- single-step reductions are a particular case of
+Second, it _contains_ `R` — single-step reductions are a particular case of
 multi-step executions.  (It is this fact that justifies the word "closure"
 in "multi-step closure of `R`.")
 ::::
@@ -1045,7 +1045,7 @@ def IsNormalFormOf {X : Type} (R : Relation X) (t t' : X) : Prop :=
 
 :::full
 We have already seen that, for our language, single-step reduction is
-deterministic -- i.e., a given term can take a single step in at most one
+deterministic — i.e., a given term can take a single step in at most one
 way.  It follows that, if `t` can reach a normal form, then this normal form
 is unique.
 
@@ -1089,7 +1089,7 @@ theorem normal_forms_unique : Deterministic (IsNormalFormOf Step) := by
 :::full
 Indeed, something stronger is true for this language (though not for all the
 languages we will see): the reduction of _any_ term `t` will eventually
-reach a normal form in a finite number of steps -- i.e., `IsNormalFormOf` is
+reach a normal form in a finite number of steps — i.e., `IsNormalFormOf` is
 a _total_ function.  We say the `Step` relation is _normalizing_.  To prove
 it, we need a couple of congruence lemmas.
 :::
@@ -1123,7 +1123,7 @@ theorem multistep_congr_2 (v1 t2 t2' : Tm) (hv : IsValue v1) (h : t2 ⟶* t2') :
 ::::full
 With these lemmas in hand, the main proof is a straightforward induction.
 
-_Theorem_: The `Step` relation is normalizing -- i.e., for every `t` there
+_Theorem_: The `Step` relation is normalizing — i.e., for every `t` there
 exists some `t'` such that `t` reduces to `t'` and `t'` is a normal form.
 
 _Proof sketch_: By induction on terms.  There are two cases:
@@ -1220,7 +1220,7 @@ includes `⟶`).
 
 :::::exercise (rating := 3) (name := "multistep_of_eval_inf")
 Write a detailed informal version of the proof of `multistep_of_eval`.  (A
-paper exercise -- there is no Lean proof to fill in here.)
+paper exercise — there is no Lean proof to fill in here.)
 
 :::solution
 ```
@@ -1305,8 +1305,8 @@ I would have thought this is how to state and prove the theorem:
 theorem eval_of_multistep' (t : Tm) (n : Nat) (h : t ⟶* .c n) : t ⇓ n
 ```
 
-It's simpler to prove this version -- no reasoning about normal forms is
-needed -- and the statement is clearly the converse of `multistep_of_eval`,
+It's simpler to prove this version — no reasoning about normal forms is
+needed — and the statement is clearly the converse of `multistep_of_eval`,
 so we could get a corollary stating an equivalence:
 `t ⇓ n ↔ t ⟶* c n`.  And that seems to finish the subsection on a much
 stronger note.
@@ -1422,7 +1422,7 @@ scoped notation:40 a:41 " ⟶a " a':41 => AStep a a'
 ```
 
 ::::full
-Notice that `AStep` has exactly the shape `Aexp → Aexp → Prop` -- i.e., it is a
+Notice that `AStep` has exactly the shape `Aexp → Aexp → Prop` — i.e., it is a
 `Relation Aexp` in the sense of the _Relations_ section above. So the generic
 vocabulary from that section (`Deterministic`, `IsNormalForm`, the multi-step
 closure `Multi`, ...) applies to it directly.
@@ -1438,7 +1438,7 @@ example :
 ```
 
 :::::exercise (rating := 2) (name := "strong_progress_arith")
-Every arithmetic expression is either a value or can take a step -- the same
+Every arithmetic expression is either a value or can take a step — the same
 _strong progress_ property we proved for the toy language, now for the richer
 `Slang` arithmetic expressions.
 
@@ -1551,7 +1551,7 @@ inductive BStep : Bexp → Bexp → Prop where
 scoped notation:40 b:41 " ⟶b " b':41 => BStep b b'
 ```
 
-A boolean example -- the left comparison operand reduces first:
+A boolean example — the left comparison operand reduces first:
 
 ```lean
 example :
@@ -1622,7 +1622,7 @@ theorem bstep_deterministic : Deterministic BStep := by
 ::::full
 The relation `⟶a` above bakes in a _left-to-right_ evaluation order: the rule
 `plusRight` can fire only once the left operand is already a value (`IsAValue v1`).
-But nothing about the _meaning_ of `+` requires that order -- we could just as
+But nothing about the _meaning_ of `+` requires that order — we could just as
 well reduce the right operand first, or interleave the two.  Different orders
 are exactly what a concurrent or optimizing implementation might choose, so it
 is natural to ask whether the choice can affect the final answer.
@@ -1671,7 +1671,7 @@ theorem anstep_not_deterministic : ¬ Deterministic ANStep := by
 ::::full
 Remarkably, this nondeterminism does _not_ affect the final answer.  The key
 observation is that a single step never changes the big-step _value_ of an
-expression -- whichever operand we advance, `eval` is preserved.
+expression — whichever operand we advance, `eval` is preserved.
 ::::
 
 :::::exercise (rating := 2) (name := "anstep_preserves_eval")
@@ -1743,7 +1743,7 @@ theorem astep_anstep_agree (a : Aexp) (n1 n2 : Nat)
 
 ::::full
 So even though `⟶n` is genuinely nondeterministic, the value it eventually
-produces is completely determined -- and it is the same value the deterministic
+produces is completely determined — and it is the same value the deterministic
 machine (and the big-step evaluator) computes.  This _confluence to a unique
 result_ is exactly the property one wants when reordering or parallelizing the
 evaluation of pure expressions.
@@ -1808,7 +1808,7 @@ Prove the compiler correct: running the compiled program from the empty stack
 reduces, in some number of steps, to a stack holding exactly the value of the
 expression.
 
-_Hint:_ this will not go through by a direct induction -- the induction
+_Hint:_ this will not go through by a direct induction — the induction
 hypothesis is too weak.  Prove a more general statement first, about running
 `compile a` followed by _any_ leftover program `p`, starting from _any_ stack
 `stk`.  (Reassociating the `++`s with `List.append_assoc`, and chaining steps

--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -201,6 +201,13 @@ def evalF (t : Tm) : Nat :=
 Here is the same evaluator, written in exactly the same style, but formulated as an
 inductively defined relation. We use the notation `t ⇓ n` for "`t` evaluates to `n`."
 
+The `notation` command below is how that is declared: it introduces `⇓` as
+infix syntax for the `Eval` relation defined with it, with a precedence saying
+how tightly it binds.
+This is the lightweight way to name a relation; later chapters, where a whole
+object language needs a grammar rather than a single operator, reach for
+`declare_syntax_cat` instead.
+
 ```
                         -------                (const)
                         c n ⇓ n

--- a/TS/Types.lean
+++ b/TS/Types.lean
@@ -38,7 +38,7 @@ challenging.
 
 Spending an entire 80-minute class on this chapter feels about right.
 Going through the proofs of progress and preservation very carefully,
-at the board, was critical.  Doing the quizzes together is good -- a few
+at the board, was critical.  Doing the quizzes together is good — a few
 more quizzes would be better.
 
 For this lecture, I (BCP) find it useful to make a physical 1-page
@@ -68,7 +68,7 @@ might be wonderful additions to the TERSE notes.
 :::
 
 ::::full
-Our next major topic is _type systems_ -- static program analyses that
+Our next major topic is _type systems_ — static program analyses that
 classify expressions according to the "shapes" of their results.  We'll
 begin with a typed version of the simplest imaginable language, to
 introduce the basic ideas of types and typing rules and the fundamental
@@ -92,7 +92,7 @@ New topic: _type systems_
 To motivate the discussion of type systems, let's begin as usual with a
 tiny toy language. We want it to have the potential for programs to go
 wrong because of runtime type errors, so we endow it with two kinds of
-data -- numbers and booleans -- where not every operation is defined on
+data — numbers and booleans — where not every operation is defined on
 both types of data. For example, program terms like `5 + true` and
 `if 42 then 0 else 1` use undefined operator/data-type combinations.
 
@@ -142,7 +142,7 @@ inductive Tm where
 ::::full
 Writing terms as raw constructors (`.ite .fls .zero (.succ .zero)`) gets
 unreadable quickly.  We introduce a _concrete syntax_ so that a term can be
-written inside `<{ … }>` -- for example `<{ if false then 0 else succ 0 }>` --
+written inside `<{ … }>` — for example `<{ if false then 0 else succ 0 }>` —
 mirroring the informal grammar above.  A bare identifier is spliced as a Lean
 term (so a variable `t` is written just `t`); `~e` escapes an arbitrary Lean
 expression, and `( … )` groups.
@@ -151,7 +151,7 @@ You do not need to understand exactly how the declarations below work; every
 object language in this book is given its syntax the same way, so it is worth
 seeing the pattern once:
 
-- `declare_syntax_cat` adds a new non-terminal to Lean's grammar -- here `tm`,
+- `declare_syntax_cat` adds a new non-terminal to Lean's grammar — here `tm`,
   the terms of this chapter's language.
 - Each `syntax` directive declares one production of that non-terminal, with
   annotations fixing precedence, and the last one declares the `<{ … }>`
@@ -194,6 +194,31 @@ macro_rules
   | `(<{ ~$e }>)  => pure e
   | `(<{ if $c then $t else $e }>) => `(Tm.ite <{ $c }> <{ $t }> <{ $e }>)
 ```
+
+:::dev "mwhicks1" PotentialImprovement
+As observed by berberman, the precedences above are strict, so an argument position
+accepts only an atom or a parenthesized term.
+`succ succ 0`, `succ if true then 0 else 0`, and
+a chained `if … else if … else …` are all rejected; they have to be written
+`succ (succ 0)`, `succ (if true then 0 else 0)`, and
+`if … else (if … else …)`.
+
+This matches the Rocq original, whose notation levels are equally strict
+(`succ x` at level 90 with `x` at 80; `if` at level 90 with all three slots at
+80), and the SF text writes `succ (succ 0)` throughout. It does not match the
+informal BNF above, where every recursive position is an unrestricted `t`.
+
+A later pass could loosen the grammar to follow the BNF — put the argument of
+a unary operator and the three slots of `if` at level 50, the lowest level in
+this category. That change should come together with a delaborator that
+parenthesizes explicitly, since the parenthesizer derives parens from these
+same precedences: with the loose grammar it prints `iszero pred succ 0` and
+`if if true then true else false then 0 else 0`. Wrapping a compound argument
+(`succ`/`pred`/`iszero`/`if`) in parens in the argument position of a unary
+operator and in the condition of an `if`, but not in the branches, keeps the
+current output (`iszero (pred (succ 0))`) while letting `else if` chains print
+flat.
+:::
 
 ::::full
 A _delaborator_ closes the loop: it walks a `Tm` value and rebuilds the
@@ -240,8 +265,10 @@ partial def delabTmInner : DelabM (TSyntax `tm) := do
   (⟨·⟩) <$> annotateTermInfo ⟨stx.raw⟩
 
 open Lean PrettyPrinter Delaborator SubExpr in
-@[delab app.Tm.tru, delab app.Tm.fls, delab app.Tm.zero, delab app.Tm.succ,
-  delab app.Tm.pred, delab app.Tm.isZero, delab app.Tm.ite]
+-- The keys are the constants' full names: `Tm` lives in namespace `TM`, and the
+-- `delab` attribute does not resolve its argument against the current namespace.
+@[delab app.TM.Tm.tru, delab app.TM.Tm.fls, delab app.TM.Tm.zero, delab app.TM.Tm.succ,
+  delab app.TM.Tm.pred, delab app.TM.Tm.isZero, delab app.TM.Tm.ite]
 partial def delabTm : Delab := whenPPOption getPPNotation do
   guard <| match_expr ← getExpr with
     | Tm.tru => true | Tm.fls => true | Tm.zero => true
@@ -353,7 +380,7 @@ for determinism (this will be proved in an optional exercise below).
 
 ::::full
 Notice that the `Tm.Step` relation doesn't care about whether the
-expression being stepped makes global sense -- it just checks that the
+expression being stepped makes global sense — it just checks that the
 operation in the _next_ reduction step is being applied to the right
 kinds of operands.  For example, the term `succ true` cannot take a
 step, but the almost as obviously nonsensical term
@@ -573,7 +600,7 @@ succ (if true then true else true)
 (A) Yes    (B) No
 
 (Hint: Notice that the `Tm.Step` relation doesn't care about whether the
-expression being stepped makes global sense -- it just checks that the
+expression being stepped makes global sense — it just checks that the
 operation in the _next_ reduction step is being applied to the right
 kinds of operands.)
 ::::
@@ -598,7 +625,7 @@ live Lean. Not sure if we want to keep this.
 
 Suppose we define an alternate single-step relation, written `t ⇢ t'`,
 that _drops_ the `Tm.IsNValue` premise from the `predSucc` and `isZeroSucc`
-rules -- so `pred (succ t)` and `iszero (succ t)` may step even when `t` is
+rules — so `pred (succ t)` and `iszero (succ t)` may step even when `t` is
 not a numeric value.  (It is built with exactly the same notation
 setup as `Tm.Step`; note `predSucc`/`isZeroSucc` no longer take a premise.)
 
@@ -633,7 +660,7 @@ Some questions about this relation (answers inline):
     `pred (succ true)` is stuck for `Tm.Step` but steps under `⇢` (to
     `true`, by `predSucc`, now that the `Tm.IsNValue` premise is gone).
 
-  - Is every `⇢` normal form also a `Tm.Step` normal form?  Yes -- `Tm.Step`
+  - Is every `⇢` normal form also a `Tm.Step` normal form?  Yes — `Tm.Step`
     is a subrelation of `⇢`, so anything stuck for `⇢` is stuck for `Tm.Step`.
 
   - Is every value reachable by `Tm.Step` (in many steps) also reachable by
@@ -761,7 +788,7 @@ notation, inside a `section` with `set_option hygiene false` so the bare name
 `Tm.HasType` in the expansion resolves to the relation being defined; after the
 `section` we re-declare the same rules hygienically for real use.  Unlike `⟶`,
 the judgment builds on the custom `tm` syntactic category, so it must use
-`syntax`/`macro_rules` rather than `notation` -- which is why it still needs the
+`syntax`/`macro_rules` rather than `notation` — which is why it still needs the
 `app_unexpander` to print the judgment back.
 ::::
 
@@ -807,7 +834,7 @@ macro_rules
 
 -- Print `Tm.HasType`/`Ty` values back as `<{ ⊢ … ⦂ … }>` notation: `delabTy`
 open Lean PrettyPrinter Delaborator SubExpr in
-@[delab app.Ty.bool, delab app.Ty.nat]
+@[delab app.TM.Ty.bool, delab app.TM.Ty.nat]
 def delabTy : Delab := whenPPOption getPPNotation do
   match_expr ← getExpr with
   | Ty.bool => `($(mkIdent `Bool):ident)
@@ -831,7 +858,7 @@ example : <{ ⊢ if false then 0 else succ 0 ⦂ Nat }> :=
 ::::full
 It's important to realize that the typing relation is a _conservative_
 (or _static_) approximation: it does not consider what happens when the
-term is reduced -- in particular, it does not calculate the type of its
+term is reduced — in particular, it does not calculate the type of its
 normal form.
 ::::
 
@@ -884,14 +911,14 @@ theorem nat_canonical (t : Tm) (hT : <{ ⊢ t ⦂ Nat }>) (hv : Tm.IsValue t) : 
 
 The typing relation enjoys two critical properties.
 
-The first is that well-typed normal forms are not stuck -- or conversely,
+The first is that well-typed normal forms are not stuck — or conversely,
 if a term is well typed, then either it is a value or it can take at
 least one step.  We call this _progress_.
 
 :::::exercise (rating := 3) (name := "finish_progress")
 Complete the formal proof of the `progress` property.  (Make sure you
 understand the parts we've given of the informal proof in the following
-exercise before starting -- this will save you a lot of time.)
+exercise before starting — this will save you a lot of time.)
 
 ```lean
 theorem progress (t : Tm) (T : Ty) (hT : <{ ⊢ t ⦂ T }>) : Tm.IsValue t ∨ ∃ t', t ⟶ t' := by
@@ -939,7 +966,7 @@ theorem progress (t : Tm) (T : Ty) (hT : <{ ⊢ t ⦂ T }>) : Tm.IsValue t ∨ �
 What is the relation between the _progress_ property defined here and the
 _strong progress_ from the {ref "Smallstep"}[Smallstep] chapter?
 
-(A) No difference -- they mean the same thing
+(A) No difference — they mean the same thing
 
 (B) Progress implies strong progress
 
@@ -972,7 +999,7 @@ _Proof_: By induction on a derivation of `⊢ t ⦂ T`.
 
     - If `t1` is a value, then by the canonical forms lemmas and the fact
       that `⊢ t1 ⦂ Bool` we have that `t1` is a boolean value
-      (`Tm.IsBValue`) -- i.e., it is either `true` or `false`.  If `t1 = true`, then `t` steps to `t2` by
+      (`Tm.IsBValue`) — i.e., it is either `true` or `false`.  If `t1 = true`, then `t` steps to `t2` by
       `ifTrue`, while if `t1 = false`, then `t` steps to `t3` by
       `ifFalse`.  Either way, `t` can step, which is what we wanted to
       show.
@@ -1300,7 +1327,7 @@ All three remain true.
 
 :::::exercise (rating := 3) (name := "subject_expansion")
 Having seen the subject reduction property, one might wonder whether the
-opposite property -- subject _expansion_ -- also holds.  That is, is it
+opposite property — subject _expansion_ — also holds.  That is, is it
 always the case that, if `t ⟶ t'` and `⊢ t' ⦂ T`, then `⊢ t ⦂ T`?  If so,
 prove it.  If not, give a counter-example.
 
@@ -1466,7 +1493,7 @@ Preservation becomes false: `pred 0` has type `Bool` and steps to `0`,
 
 :::::exercise (rating := 3) (name := "more_variations")
 Make up some exercises of your own along the same lines as the ones
-above.  Try to find ways of selectively breaking properties -- i.e., ways
+above.  Try to find ways of selectively breaking properties — i.e., ways
 of changing the definitions that break just one of the properties and
 leave the others alone.
 :::::

--- a/TS/Types.lean
+++ b/TS/Types.lean
@@ -156,8 +156,8 @@ seeing the pattern once:
 - Each `syntax` directive declares one production of that non-terminal, with
   annotations fixing precedence, and the last one declares the `<{ … }>`
   brackets that let a `tm` appear where Lean expects a term.
-- `macro_rules` then translates each production into the corresponding
-  constructor of {name}`Tm`.
+- `macro_rules` then translates the resulting syntax forms into the
+  corresponding constructors of {name}`Tm`.
 ::::
 
 ```lean

--- a/TS/Types.lean
+++ b/TS/Types.lean
@@ -112,8 +112,14 @@ The language definition is completely routine.
 
 Here is the syntax of program terms, informally:
 
-```
-t ::= true | false | if t then t else t | 0 | succ t | pred t | iszero t
+```bnf
+t ::= "true"
+    | "false"
+    | "if" t "then" t "else" t
+    | "0"
+    | "succ" t
+    | "pred" t
+    | "iszero" t ;
 ```
 
 And here it is formally:
@@ -140,6 +146,18 @@ written inside `<{ … }>` -- for example `<{ if false then 0 else succ 0 }>` --
 mirroring the informal grammar above.  A bare identifier is spliced as a Lean
 term (so a variable `t` is written just `t`); `~e` escapes an arbitrary Lean
 expression, and `( … )` groups.
+
+You do not need to understand exactly how the declarations below work; every
+object language in this book is given its syntax the same way, so it is worth
+seeing the pattern once:
+
+- `declare_syntax_cat` adds a new non-terminal to Lean's grammar -- here `tm`,
+  the terms of this chapter's language.
+- Each `syntax` directive declares one production of that non-terminal, with
+  annotations fixing precedence, and the last one declares the `<{ … }>`
+  brackets that let a `tm` appear where Lean expects a term.
+- `macro_rules` then translates each production into the corresponding
+  constructor of {name}`Tm`.
 ::::
 
 ```lean
@@ -185,6 +203,7 @@ output print as `<{ … }>` rather than as a pile of constructors.  (Setting
 prints as `Bool` or `Nat`.
 ::::
 
+::::details (summary := "Notation encoding: printing terms back")
 ```lean
 open Lean PrettyPrinter Delaborator SubExpr Parenthesizer in
 /-- Re-inserts parentheses in `tm` output according to the grammar's precedences. -/
@@ -232,6 +251,7 @@ partial def delabTm : Delab := whenPPOption getPPNotation do
   | `(tm| ~$e) => pure e
   | e => `(<{ $e }>)
 ```
+::::
 
 ### Values
 


### PR DESCRIPTION
- The informal syntax becomes a ` ```bnf ` block, so terminals and non-terminals are distinguished in the book and the extracted `.lean` gets an aligned grammar rather than one long line.
- The `tm` syntax category and the delaborator move into `:::details`.  Both are encoding: a reader following the metatheory can skip them, and the prose above each block already says what they achieve.

Follows the pattern established in the Stlc chapter.