### PR TITLE
Qualified import with `open` and parentheses for handling `||` precedence

### DIFF
--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -457,7 +457,7 @@ Now that we've defined some basic functions on booleans, let's see how to
 _prove_ some simple properties of those functions. Here is a simple rule
 about `&&`:
 
-- `MyBool.true && b = b`
+- `(MyBool.true && b) = b`
 
 This is an example of a _proposition_, a logical _claim_ that we can try to prove.
 It says that `MyBool.true && b` is equal to `b` for every `MyBool` `b`.
@@ -2604,14 +2604,14 @@ theorem and_eq_or : ∀ b c : Bool, (b && c) = (b || c) → b = c := by
     cases c
     case true =>
       /-
-        h : true && c = true || c, i.e., h : c = true
+        h : (true && c) = true || c, i.e., h : c = true
       -/
       rewrite [Bool.and_true, Bool.or_true] at h
       rewrite [h]
       rfl
     case false =>
       /-
-        h : false && c = false || c, i.e., h : false = c
+        h : (false && c) = false || c, i.e., h : false = c
       -/
       rewrite [Bool.and_false, Bool.or_false] at h
       rewrite [h]

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1021,7 +1021,7 @@ open MyNamespace
 ```
 
 If we only want to bring _some_, rather than all, of the definitions
-of a namespace into the current scope, we can use the `export` command:
+of a namespace into the current scope, we can use the `open (...)` form:
 
 ```lean
 namespace MyOtherNamespace
@@ -1029,13 +1029,13 @@ def myHiddenDef : Bool := Bool.true
 def myVisibleDef : Bool := Bool.false
 end MyOtherNamespace
 
-export MyOtherNamespace (myVisibleDef)
+open MyOtherNamespace (myVisibleDef)
 
 -- `myVisibleDef` is now usable without qualification:
 #check myVisibleDef -- Bool
 ```
 
-But `myHiddenDef`, which we did not `export`, still needs its full name;
+But `myHiddenDef`, which we did not `open`, still needs its full name;
 using it unqualified is an error:
 
 ```lean +error
@@ -1045,13 +1045,13 @@ using it unqualified is an error:
 ::::full
 In fact, this is what exactly what Lean does with the standard `Bool` type by default.
 Since it is such an important
-part of many proofs and programs, Lean implicitly `export`s many of `Bool`s functions and
+part of many proofs and programs, Lean implicitly `open`s many of `Bool`s functions and
 constructors. Accordingly, we can use constructors like `true` and `false` and functions
 like `not` without qualifying them with `Bool.`.
 ::::
 
 ::::terse
-Names from the `Bool` `namespace` are `export`ed and thus available without qualification.
+Names from the `Bool` `namespace` are `open`ed and thus available without qualification.
 ::::
 
 ```lean

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -1126,7 +1126,7 @@ theorem andb_false (b : Bool) :
     | true  => rw [Bool.true_and]
 
 theorem all3_spec (b c : Bool) :
-    (b && c) || ((!b) || (!c)) = true := by
+    ((b && c) || ((!b) || (!c))) = true := by
   solution!
     cases b with
     | true => cases c with


### PR DESCRIPTION
The PR bundles two minor fixes.

- Basics.lean uses `export` for qualified imports even though `open` already has the qualified import form. The PR replaces all mentioning of `export` in Basics.lean with `open (...)`.
- In Lean, `||` has lower precedence than `=`. One of the exercises has the form `a || b = true` and it becomes `a || decide (b = true)`, where Lean auto-inserts `decide` to convert the `b = true` `Prop` into `bool`. There might be more instances of this problem, so it could be useful to ask Claude to hunt for similar issues
