### PR TITLE
Get ready for alpha testers

### DIFF
--- a/ALPHATESTERS.md
+++ b/ALPHATESTERS.md
@@ -1,0 +1,19 @@
+# SF-in-Lean: Instructions for Alpha-Testers
+
+- clone the [repo](https://github.com/plclub/sf-in-lean)
+- type `make student` in the top-level directory
+- open _out/lf/student/html-multi/index.html
+- follow the installation instructions in the `Preface` to install VSCode and Lean if necessary
+- start reading!
+
+If you see clear improvements (typos, obvious clarifications, etc.), please feel free to just make them directly to the `.lean` files in the `LF`, `HL`, or `TS` subdirectories
+
+If you have more substantive remarks, please add them to the source code in the form of `dev` comments, like this:
+```
+    :::dev "Your Real Name (@your_github_handle)"
+    ... Your suggestions ...
+    :::
+```    
+Make a github PR for each chapter as you finish reading it.  
+
+We are actively working on all chapters, so if you're reading a chapter over a long period, make sure to pull changes often.

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,18 @@ $(eval $(call VOLUME_template,ts))
 
 # ── Top-level targets ─────────────────────────────────────────────────────────
 
-.PHONY: all serve clean ensure-build-symlink style-check style-checklist
+.PHONY: all student solutions terse grading serve clean ensure-build-symlink style-check style-checklist
 
 all: lf hl ts
+
+# Build a single variant across every volume.
+student: lf-student hl-student ts-student
+
+solutions: lf-solutions hl-solutions ts-solutions
+
+terse: lf-terse hl-terse ts-terse
+
+grading: lf-grading hl-grading ts-grading
 
 # Mechanical conformance checks for STYLE.md (auto checks fail the run; assisted
 # ones are advisory). `style-checklist` prints the audit checklist for the

--- a/README.md
+++ b/README.md
@@ -3,36 +3,32 @@
 This repository contains the work-in-progress sources for [Software
 Foundations](https://softwarefoundations.cis.upenn.edu/) in Lean.
 
-## Status
+## Status and how to contribute
 
-SF-in-Lean is _not_ ready for ordinary readers yet.  We'll make a
-posting on the Lean Zulip when we've got something suitable for public
-consumption. We aim to have a complete and polished draft of most
+SF-in-Lean _is_ ready for adventurous alpha-testers.  See ALPHATESTERS.md for more.
+
+The SF-in-Lean team is also looking for contributors who have the time and interest to make a more significant commitment.  If you are interested in joining us, please email [Benjamin Pierce](bcpierce@cis.upenn.edu).
+
+SF-in-Lean is _not_ ready for ordinary readers yet. We aim to have a 
+complete and polished draft of most
 chapters of _Logical Foundations_ and _Programming Language
-Foundations_ in time for Fall 2026 courses. 
-
-If you would like to be notified when chapters are ready for
-alpha-testing, please email [Benjamin
-Pierce](mailto:bcpierce@cis.upenn.edu).
-
-We are also not set up yet to consider PRs from outside the
-translation team.  If you are interested in joining the team, please
-email Benjamin Pierce and we can discuss.
+Foundations_ in time for Fall 2026 courses. We'll make a
+posting on the Lean Zulip when appropriate.
 
 ## Quick start: building and viewing the book
 
 To build everything and preview the HTML locally:
 
     make serve
+    open http://localhost:8000
 
-then visit <http://localhost:8000>.  (This builds all volumes in all
-three variants — student / solutions / terse — into `_out/`, then
-serves that directory on port 8000.)
+(This builds all volumes in all three variants — student / solutions / terse —
+into `_out/`, then serves that directory on port 8000.)
 
 To rebuild just one volume, use its make target and then serve `_out/`:
 
     make lf          # or: hl, ts
-    make lf-student  # just one variant: -student, -solutions, -terse
+    make lf-student  # or lf-solutions, lf-terse, etc.
     python3 -m http.server 8000 -d _out/
 
 The HTML for a given volume and variant lands in
@@ -51,6 +47,7 @@ For everything else — repo layout, conventions, PR workflow — see
 
 This project is licensed under the Apache License, Version 2.0. See the
 [LICENSE](LICENSE) and [NOTICE](NOTICE) files for details. 
+
 Any contribution you intentionally submit for inclusion in this
 work shall be licensed under the same terms, with no additional terms or
 conditions.

--- a/SFLMeta/Comment.lean
+++ b/SFLMeta/Comment.lean
@@ -1,5 +1,6 @@
 import VersoManual
 import SFLMeta.Bnf
+import SFLMeta.Variant
 import SFLMeta.Ignore
 import SFLMeta.Exercise
 import SFLMeta.Details
@@ -126,15 +127,27 @@ def devNoteLabel (author urgency : Option String) (year : Option Nat)
   else s!"{heading} ({String.intercalate ", " fields})"
 
 /-! `Block.devcomment` carries the note body as its children and records its
-author/urgency metadata in `data`. A note whose urgency passes `devNoteShown`
-(`NOW`, `BeforeNextRelease`, or none) is rendered: brightly highlighted in the
-HTML book, and passed through as a labelled comment in generated `.lean` files
-by `SFLMeta.Save.Extract.walkBlock`. `PotentialImprovement` notes render
-nothing. -/
+author/urgency metadata in `data`. Most dev notes are developer-facing, so in
+the *student* variant only `NOW`-urgency notes survive traversal (both the HTML
+book and the extracted `.lean` operate on the per-variant traversed tree); the
+rest are dropped. All notes survive traversal in the solutions, terse, and
+grading variants. Among the surviving blocks, a note is rendered only when its
+urgency passes `devNoteShown` (`NOW`, `BeforeNextRelease`, or none): brightly
+highlighted in the HTML book, and passed through as a labelled comment in
+generated `.lean` files by `SFLMeta.Save.Extract.walkBlock`.
+`PotentialImprovement` notes render nothing. -/
 block_extension Block.devcomment (author : Option String)
     (urgency : Option String) (year : Option Nat) where
   data := Json.arr #[toJson author, toJson urgency, toJson year]
-  traverse _ _ _ := pure none
+  traverse _ data _ := do
+    if (← getCurrVariant).isStudent then
+      -- In the student build, keep only `NOW`-urgency dev notes; drop the rest.
+      let isNow := match decodeDevData? data with
+        | some (_, urgency, _) => urgency == some "NOW"
+        | none => false
+      return if isNow then none else some (.concat #[])
+    else
+      return none
   toHtml :=
     open Verso.Output.Html in
     some fun _ goB _ data contents => do


### PR DESCRIPTION
At the team meeting this week, we agreed on the desirability of increasing the pool of readers / alpha-testers for SFL.  With this in mind, I've added an ALPHATESTERS.md at the top level, changed the README to point to it, and removed all non-NOW :::dev comments from the student version so that they don't bother most readers.
