### PR TITLE
LF: fix a few Induction inconsistencies

### DIFF
--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -95,8 +95,9 @@ Troubleshooting:
    in the dependency tree.
 ::::
 
-We reopen the namespace from the previous chapter to keep the definitions
-and theorems introduced in this chapter local to this file, so they don't clash with the standard library.
+We reopen the namespace from the previous chapter to group this chapter's
+definitions and theorems with the custom natural-number development and keep
+their names distinct from the standard library.
 
 ```lean
 namespace NatPlayground.Nat
@@ -115,6 +116,10 @@ We should try to figure out a nicer way to format these
 To prove the following theorem, which tactics will we need besides
 {tactic}`rfl`?
 
+```display
+theorem review₁ : (true || false) = true
+```
+
 (A) none
 
 (B) {tactic}`rewrite`
@@ -124,10 +129,6 @@ To prove the following theorem, which tactics will we need besides
 (D) both {tactic}`rewrite` and {tactic}`cases`
 
 (E) can't be done with the tactics we've seen.
-
-```display
-theorem review₁ : (true || false) = true
-```
 
 :::quizSolution
 ```lean
@@ -259,7 +260,7 @@ theorem succ_eq_add_one : ∀ n : Nat, succ n = n + one := by
 ::::
 
 
-## Proof by Induction
+# Proof by Induction
 
 ::::full
 We defined `add` to recurse on its _second_ argument:
@@ -930,11 +931,11 @@ course this is no accident: Lean has been designed so that its
 `induction` tactic generates the same sub-goals, in the same
 order, as the bullet points that a mathematician would usually
 write.  But there are significant differences of detail: the
-formal proof is much more explicit in some ways (e.g., the use of
-`rfl`) but much less explicit in others (in particular, the "proof
-state" at any given point in the Lean proof is completely implicit,
-whereas the informal proof reminds the reader several times where
-things stand).
+formal proof is much more explicit in some ways (e.g., the sequence
+of rewrites) but much less explicit in others (in particular, the
+"proof state" at any given point in the Lean proof is completely
+implicit, whereas the informal proof reminds the reader several
+times where things stand).
 ::::::
 
 :::::exercise (rating := 2) (name := "add_comm_informal") (level := Advanced) (manual := true)
@@ -1215,7 +1216,7 @@ to write the cases explicitly. We'll discuss some other tactic combinators
 much later in this book.
 ::::
 
-## Nat to Bin and Back to Nat
+# Nat to Bin and Back to Nat
 
 ```lean
 namespace NatToBin
@@ -1348,7 +1349,7 @@ theorem nat_bin_nat (n : Nat) :
 :::
 :::::
 
-## Bin to Nat and Back to Bin (Advanced)
+# Bin to Nat and Back to Bin (Advanced)
 
 The opposite direction — starting with a {name}`Bin`, converting to {name}`Nat`,
 then converting back to {name}`Bin` — turns out to be problematic. That


### PR DESCRIPTION
I noticed a few small inconsistencies while reading through Induction, so I grouped the straightforward fixes here.

- Restore three major sections to the top level, matching the Rocq chapter structure.
- Show the first review theorem before its answer choices.
- Clarify what reopening `NatPlayground.Nat` does.
- Update the formal/informal proof comparison so it describes the proof actually shown.

I left the developer notes alone since they seem to need separate pedagogical or tooling decisions.

Testing:
- `lake build LF.Induction`
- `make`
- Checked the generated student HTML for the quiz order and section hierarchy.

AI use: I used Codex to inspect the chapter, make the edits, and run the checks. The resulting diff and rendered HTML were rechecked against the current Lean source and the Rocq chapter.