### PR TITLE
LF: introduce bif before first use

### DIFF
--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -558,6 +558,10 @@ theorem test_nonZeros : nonZeros [0, 1, 0] = [1] := by
 :::gradeTheorem "0.5" test_nonZeros
 :::
 
+The next definition uses `bif`, Lean's conditional for Boolean tests.
+The expression `bif b then x else y` evaluates to `x` when `b` is
+`true` and to `y` when `b` is `false`.
+
 ```lean
 def oddMembers (l : NatList) : NatList := solution!(
   match l with

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -560,7 +560,7 @@ theorem test_nonZeros : nonZeros [0, 1, 0] = [1] := by
 
 The next definition uses `bif`, Lean's conditional for Boolean tests.
 The expression `bif b then x else y` evaluates to `x` when `b` is
-`true` and to `y` when `b` is `false`.
+{name}`true` and to `y` when `b` is {name}`false`.
 
 ```lean
 def oddMembers (l : NatList) : NatList := solution!(


### PR DESCRIPTION
## Summary

I ran into `bif` for the first time in the `oddMembers` exercise and realized the syntax had not been introduced. This adds a short explanation immediately before that definition, including what happens for `true` and `false`.

Closes #205.