### PR TITLE
Basics: rework the last exercise

### DIFF
--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -279,7 +279,7 @@ ordinary Lean uses of `true`/`false`, and as non-reserved symbols they would
 clash with the bare-identifier form of `imp_aexp`.
 :::
 
-::::details (summary := "Notation encoding: boolean expressions")
+::::details "Notation encoding: boolean expressions"
 ```lean
 /-- Boolean expressions of Imp -/
 declare_syntax_cat imp_bexp
@@ -314,7 +314,7 @@ comparison); without the annotation the parser would descend into `imp_aexp`
 and then insist on a comparison operator.
 :::
 
-::::details (summary := "Notation encoding: boolean expressions, macro rules")
+::::details "Notation encoding: boolean expressions, macro rules"
 ```lean
 open Lean in
 macro_rules
@@ -401,7 +401,7 @@ mentioning an Imp expression is displayed in readable Imp syntax rather than as
 a pile of constructors.
 ::::
 
-::::details (summary := "Notation encoding: printing expressions back")
+::::details "Notation encoding: printing expressions back"
 ```lean
 namespace Imp.Delab
 open Lean PrettyPrinter Delaborator SubExpr Parenthesizer
@@ -504,7 +504,7 @@ The `whenPPOption getPPNotation` wrapper lets `set_option pp.notation false`
 switch this delaborator off, revealing the raw constructors (see the
 "Desugaring Notations" discussion, after the commands are introduced).
 
-::::details (summary := "Notation encoding: registering the delaborators")
+::::details "Notation encoding: registering the delaborators"
 ```lean
 @[delab app.Aexp.num, delab app.Aexp.id, delab app.Aexp.plus,
   delab app.Aexp.minus, delab app.Aexp.mult]
@@ -671,7 +671,7 @@ Concrete syntax for commands, in the style of the `ssft24` Imp `Stmt`
    with expressions, `~c` escapes back to an ordinary Lean term of type `Com`.
 :::
 
-::::details (summary := "Notation encoding: commands")
+::::details "Notation encoding: commands"
 ```lean
 /-- Imp commands -/
 declare_syntax_cat imp_com
@@ -686,7 +686,7 @@ declare_syntax_cat imp_com
    elsewhere in the file, and avoids reserving `skip` globally.
 :::
 
-::::details (summary := "Notation encoding: commands, macro rules")
+::::details "Notation encoding: commands, macro rules"
 ```lean
 /-- The command that does nothing (`skip;`) -/
 syntax ident ";" : imp_com
@@ -731,7 +731,7 @@ delaborators for the condition of an
 unrecognized subcommand with the `~` escape.
 ::::
 
-::::details (summary := "Notation encoding: printing commands back")
+::::details "Notation encoding: printing commands back"
 ```lean
 namespace Imp.Delab
 open Lean PrettyPrinter Delaborator SubExpr

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -2706,17 +2706,18 @@ Add grading attributes.
 Now that we have learned the basic features of Lean 4, let's close the chapter
 with an exercise that brings them together.
 
-One fascinating aspect of using a theorem prover like Lean is that we can do
-more than implement a system — we can also state precisely what we expect the
-system to behave and prove that our implementation satisfies those expectations.
+In a theorem prover like Lean, we can do
+more than just implement a system — we can also state precisely how we expect the
+system to behave and prove that our implementation satisfies that expectation.
 
-In this exercise, we will model part of an airport database.
-The airport stores one database entry for each traveler.
-An entry records where the traveler is in the airport process,
-together with information about their current bag.
+In this exercise, we will model part of a database
+storing information about travelers passing through an airport.
+The database contains one entry per traveler, recording
+information about where the traveler is in the airport process and the contents of their luggage.
 
-We will implement several operations on these entries and prove
-general properties about their behavior.
+We will implement several operations on these entries, state
+properties that describe how the database should
+behave, and prove that the implementation satisfies them.
 :::
 
 :::terse
@@ -2730,6 +2731,8 @@ namespace Airport
 ```
 
 :::full
+First, we describe the possible states of a bag.
+
 For simplicity, we assume that a bag either contains a battery, which causes
 it to fail inspection, or contains only ordinary items:
 :::
@@ -2745,7 +2748,7 @@ inductive BagContent : Type where
 ```
 
 :::full
-The screening status records whether the bag has not yet been inspected,
+A bag's screening status records whether the bag has not yet been inspected,
 has been cleared, or has been blocked:
 :::
 
@@ -2761,7 +2764,7 @@ inductive ScreeningStatus : Type where
 ```
 
 :::full
-A traveler can be in one of three stages:
+Next, we consider the possible stages of the airport process a traveler can inhabit:
 - they have not yet purchased a ticket;
 - they have a ticket but have not yet checked in;
 - they have checked in, in which case the
@@ -2811,12 +2814,15 @@ theorem buyTicket_checkedIn (bagContent : BagContent)
 attribute [irreducible] buyTicket
 ```
 
-Here is our first general property: buying a ticket twice has the same
-effect as buying it once.
-
 :::full
-N.B. An operation is called _idempotent_
-if performing it twice has the same effect as performing it once.
+An operation is called _idempotent_
+when performing it twice has the same effect as performing it once.
+The first property we will prove about our system is that
+purchasing a ticket is an idempotent operation.
+:::
+
+:::terse
+Here is our first general property: buying a ticket twice is idempotent.
 :::
 
 :::exercise (rating := 2) (name := "buy_ticket_idempotent")

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -2764,7 +2764,7 @@ inductive ScreeningStatus : Type where
 A traveler can be in one of three stages:
 - they have not yet purchased a ticket;
 - they have a ticket but have not yet checked in;
-- they have checked in,in which case the
+- they have checked in, in which case the
   database also stores the screening status of their bag.
 :::
 
@@ -2840,7 +2840,7 @@ theorem buyTicket_idempotent (t : Traveler) :
 ```
 :::
 
-A traveler can check in only after buying a ticket.
+A traveler can check in only after buying a ticket,
 and their bag is marked as needing inspection.
 Calling checkIn in any other state does nothing.
 

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1372,6 +1372,16 @@ inductive Nat : Type where
   | succ (n : Nat)
 ```
 
+The following lines make ordinary numerals such as 0, 1, and 2 work with our {name}`Nat` type.You can ignore the details for now.
+
+```lean
+def ofNat : _root_.Nat → Nat
+  | .zero => .zero
+  | .succ n => .succ (ofNat n)
+
+instance (n : _root_.Nat) : OfNat Nat n := ⟨ofNat n⟩
+```
+
 :::full
 We'll define some shorthands for numbers, putting them in the `Nat` namespace
 so we don't need to use `.` notation everywhere.
@@ -2685,358 +2695,330 @@ theorem and_eq_or (b c : Bool) : (b && c) = (b || c) → b = c := by
 :::
 ::::
 
-## Course Late Policies, Formalized
+## Airport Exercise
 
-:::dev
-This exercise needs to be changed. Per GitHub discussion:
-the way this exercise is currently structured is at odds with our definition
-of Nats (use of large digits that would be tedious to work with by rewriting).
-The definitions of grades and letters also do not lend themselves well to
-our discipline of defining and using rewrite rules for all our functions,
-as they would require a frustrating number of such rules. We should come up with
-a new exercise here of similar size and difficulty, but that works better with
-the new presentation style of this material.
-HG: Also, we should make sure that this reads OK in full/terse
-TODO
+:::dev "Yipeng Liu (berberman)" BeforeNextRelease
+Add grading attributes.
 :::
 
-::::full
-Suppose that a course has a grading policy based on late days,
-where a student's final letter grade is lowered if they submit too
-many homework assignments late.
-::::
+
+:::full
+Now that we have learned the basic features of Lean 4, let's close the chapter
+with an exercise that brings them together.
+
+One fascinating aspect of using a theorem prover like Lean is that we can do
+more than implement a system — we can also state precisely what we expect the
+system to behave and prove that our implementation satisfies those expectations.
+
+In this exercise, we will model part of an airport database.
+The airport stores one database entry for each traveler.
+An entry records where the traveler is in the airport process,
+together with information about their current bag.
+
+We will implement several operations on these entries and prove
+general properties about their behavior.
+:::
+
+:::terse
+We will model a simple airport system in Lean. Besides implementing
+its operations, we will state properties that describe how the system should
+behave and prove that the implementation satisfies them.
+:::
 
 ```lean
-namespace LateDays
-open scoped NatPlayground.Nat
-
--- Numeric literals (`9`, `17`, `21`) for our unary `Nat`.
-@[reducible] def ofNat : _root_.Nat → Nat
-  | .zero => .zero
-  | .succ n => .succ (ofNat n)
-
-instance (n : _root_.Nat) : OfNat Nat n := ⟨ofNat n⟩
+namespace Airport
 ```
 
-::::full
-First, we introduce a datatype for modeling the "letter" component
-of a grade.
-::::
+:::full
+For simplicity, we assume that a bag either contains a battery, which causes
+it to fail inspection, or contains only ordinary items:
+:::
+
+:::terse
+A bag is either ordinary or contains a battery:
+:::
 
 ```lean
-inductive Letter : Type where
-  | A | B | C | D | F
+inductive BagContent : Type where
+  | battery
+  | ordinary
 ```
 
-::::full
-Then we define the modifiers — a `natural` `A` is just a "plain"
-grade of `A`.
-::::
+:::full
+The screening status records whether the bag has not yet been inspected,
+has been cleared, or has been blocked:
+:::
+
+:::terse
+A bag can be unscreened, cleared, or blocked:
+:::
 
 ```lean
-inductive Modifier : Type where
-  | plus | natural | minus
+inductive ScreeningStatus : Type where
+  | notScreened
+  | cleared
+  | blocked
 ```
 
-::::full
-A full `Grade`, then, is just a `Letter` and a `Modifier`.
-In Lean, a combination of several values is called a _structure_.  The `structure`
-keyword is used to define a new structure type.
-::::
+:::full
+A traveler can be in one of three stages:
+- they have not yet purchased a ticket;
+- they have a ticket but have not yet checked in;
+- they have checked in,in which case the
+  database also stores the screening status of their bag.
+:::
+
+:::terse
+There are three stages a traveler can be in:
+:::
 
 ```lean
-structure Grade where
-  letter : Letter
-  modifier : Modifier
+inductive Traveler : Type where
+  | noTicket (bagContent : BagContent)
+  | ticketed (bagContent : BagContent)
+  | checkedIn (bagContent : BagContent) (screeningStatus : ScreeningStatus)
 ```
 
-::::full
-We will want to be able to say when one grade is "better" than
-another.  In other words, we need a way to compare two grades.  As
-with natural numbers, we could define `bool`-valued functions
-`grade_eqb`, `grade_ltb`, etc., and that would work fine.
-However, we can also define a slightly more informative type for
-comparing two values, as shown below.  This datatype has three
-constructors that can be used to indicate whether two values are
-"equal", "less than", or "greater than" one another.
-::::
+Buying a ticket changes a traveler with no ticket into a ticketed traveler.
+If the traveler already has a ticket or has already checked in, nothing changes.
+
+:::exercise (rating := 1) (name := "buy_ticket")
+Define `buyTicket`
+```lean
+def buyTicket (t : Traveler) : Traveler := solution!(
+  match t with
+  | .noTicket bagContent => .ticketed bagContent
+  | _ => t
+)
+example : buyTicket (.noTicket .ordinary) = .ticketed .ordinary := solution!(by rfl)
+example : buyTicket (.checkedIn .battery .blocked) = .checkedIn .battery .blocked := solution!(by rfl)
+```
+:::
+
+The simplification rules for {name}`buyTicket`:
 
 ```lean
-inductive Comparison : Type where
-  | eq   -- "equal"
-  | lt   -- "less than"
-  | gt   -- "greater than"
+theorem buyTicket_noTicket (bagContent : BagContent) :
+    buyTicket (.noTicket bagContent) = .ticketed bagContent := solution!(by rfl)
+
+theorem buyTicket_ticketed (bagContent : BagContent) :
+    buyTicket (.ticketed bagContent) = .ticketed bagContent := solution!(by rfl)
+
+theorem buyTicket_checkedIn (bagContent : BagContent)
+    (screeningStatus : ScreeningStatus) :
+    buyTicket (.checkedIn bagContent screeningStatus) = .checkedIn bagContent screeningStatus := solution!(by rfl)
+
+attribute [irreducible] buyTicket
 ```
 
-::::full
-Since we're in a namespace, we can open the relevant types to
-avoid having to write `Letter.A`, etc.
-::::
+Here is our first general property: buying a ticket twice has the same
+effect as buying it once.
 
+:::exercise (rating := 2) (name := "buy_ticket_idempotent")
 ```lean
-open Letter Modifier Comparison
-```
-
-::::full
-Using pattern matching, it is not difficult to define the
-comparison operation for two letters `l1` and `l2` (see below).
-This definition uses a feature of `match` patterns: we can match
-against _two_ values simultaneously by separating them and the
-corresponding patterns with comma `,`.
-This is simply a convenient abbreviation for nested pattern
-matching.
-::::
-
-```lean
-def letterComparison (l1 l2 : Letter) : Comparison :=
-  match l1, l2 with
-  | A, A => eq
-  | A, _ => gt
-  | B, A => lt
-  | B, B => eq
-  | B, _ => gt
-  | C, A => lt
-  | C, B => lt
-  | C, C => eq
-  | C, _ => gt
-  | D, F => gt
-  | D, D => eq
-  | D, _ => lt
-  | F, F => eq
-  | F, _ => lt
-
-example : letterComparison B A = lt := by rfl
-example : letterComparison D D = eq := by rfl
-example : letterComparison B F = gt := by rfl
-```
-
-::::exercise (rating := 1) (name := "letter_comparison")
-```lean
-theorem letterComparison_Eq : ∀ l : Letter,
-    letterComparison l l = eq := by
+theorem buyTicket_idempotent (t : Traveler) :
+    buyTicket (buyTicket t) = buyTicket t := by
   solution!
-    intro l; cases l <;> rfl
+    cases t with
+    | noTicket =>
+        rewrite [buyTicket_noTicket]
+        rewrite [buyTicket_ticketed]
+        rfl
+    | ticketed =>
+        rewrite [buyTicket_ticketed]
+        rewrite [buyTicket_ticketed]
+        rfl
+    | checkedIn =>
+        rewrite [buyTicket_checkedIn]
+        rewrite [buyTicket_checkedIn]
+        rfl
 ```
-
-:::gradeTheorem 1 LateDays.letterComparison_Eq
 :::
-::::
+
+A traveler can check in only after buying a ticket.
+and their bag is marked as needing inspection.
+Calling checkIn in any other state does nothing.
+
+:::exercise (rating := 1) (name := "check_in")
+
+Define `check_in`.
 
 ```lean
-def modifierComparison (m1 m2 : Modifier) : Comparison :=
-  match m1, m2 with
-  | plus, plus => eq
-  | plus, _ => gt
-  | natural, plus => lt
-  | natural, natural => eq
-  | natural, _ => gt
-  | minus, minus => eq
-  | minus, _ => lt
+def checkIn (t : Traveler) : Traveler := solution!(
+  match t with
+  | .ticketed bagContent => .checkedIn bagContent .notScreened
+  | _ => t
+)
+
+example : checkIn (.noTicket .ordinary) = .noTicket .ordinary := solution!(by rfl)
+example : checkIn (.ticketed .battery) = .checkedIn .battery .notScreened := solution!(by rfl)
+example : checkIn (.checkedIn .ordinary .cleared) = .checkedIn .ordinary .cleared := solution!(by rfl)
 ```
-
-::::exercise (rating := 2) (name := "grade_comparison")
-Here, we will need to access the fields of the `Grade` structure.
-The field names are `letter` and `modifier`, so for a grade `g`,
-we can write `g.letter` and `g.modifier` to access these fields.
-
-```lean
-def gradeComparison (g1 g2 : Grade) : Comparison
-  := solution!(match letterComparison g1.letter g2.letter with
-  | lt => lt
-  | eq => modifierComparison g1.modifier g2.modifier
-  | gt => gt)
-
-theorem gradeComparison_test1 : gradeComparison ⟨A, minus⟩ ⟨B, plus⟩ = gt := solution!(by rfl)
-theorem gradeComparison_test2 : gradeComparison ⟨A, minus⟩ ⟨A, plus⟩ = lt := solution!(by rfl)
-theorem gradeComparison_test3 : gradeComparison ⟨F, plus⟩ ⟨F, plus⟩ = eq := solution!(by rfl)
-theorem gradeComparison_test4 : gradeComparison ⟨B, minus⟩ ⟨C, plus⟩ = gt := solution!(by rfl)
-```
-
-:::gradeTheorem "0.5" gradeComparison_test1 gradeComparison_test2 gradeComparison_test3 gradeComparison_test4
 :::
-::::
+
+Again, we record one rewrite rule for each case:
 
 ```lean
-def lowerLetter (l : Letter) : Letter :=
-  match l with
-  | A => B
-  | B => C
-  | C => D
-  | D => F
-  | F => F  -- Can't go lower than F!
+theorem checkIn_noTicket (bagContent : BagContent) :
+    checkIn (.noTicket bagContent) = .noTicket bagContent := solution!(by rfl)
+
+theorem checkIn_ticketed (bagContent : BagContent) :
+    checkIn (.ticketed bagContent) = .checkedIn bagContent .notScreened := solution!(by rfl)
+
+theorem checkIn_checkedIn (bagContent : BagContent)
+    (screeningStatus : ScreeningStatus) :
+    checkIn (.checkedIn bagContent screeningStatus) = .checkedIn bagContent screeningStatus := solution!(by rfl)
+
+attribute [irreducible] checkIn
 ```
 
-::::full
-This theorem is not provable because of the edge case of `F`!
+Buying a ticket and then checking in always leaves the traveler checked in,
+regardless of whether they were already checked in.
 
-```
-theorem lowerLetter_lowers_bad : ∀ (l : Letter),
-  letterComparison (lowerLetter l) l = lt := by ...
-```
-::::
-
+:::exercise (rating := 1) (name := "buy_ticket_then_check_in")
 ```lean
-theorem lowerLetter_F_is_F : lowerLetter F = F := by rfl
-```
-
-::::exercise (rating := 2) (name := "lower_letter_lowers")
-```lean
-theorem lowerLetter_lowers : ∀ l : Letter,
-    letterComparison F l = lt →
-    letterComparison (lowerLetter l) l = lt := by
+theorem buyTicket_then_checkIn (bagContent : BagContent) :
+    checkIn (buyTicket (.noTicket bagContent)) = .checkedIn bagContent .notScreened := by
   solution!
-    intro l h
-    cases l with
-    | A => rfl
-    | B => rfl
-    | C => rfl
-    | D => rfl
-    | F => exact h
+    rewrite [buyTicket_noTicket]
+    rewrite [checkIn_ticketed]
+    rfl
 ```
-
-:::gradeTheorem 2 lowerLetter_lowers
 :::
-::::
 
-::::exercise (rating := 2) (name := "lower_grade")
-In addition to the dot notation for accessing structure fields, we can also
-use pattern matching to access these fields.
-For example, if `g` is a grade, then we can write
-`match g with ⟨l, m⟩ => ...` to access the letter and modifier components
-of `g` as `l` and `m`, respectively.
-Note: The angle brackets `⟨` and `⟩` are typed as `\<` and `\>`.
+Bag inspection happens only after check-in.
+An ordinary bag is cleared, while a bag containing a battery is blocked.
+If the traveler has not checked in, `inspectBag` does nothing.
+
+:::exercise (rating := 1) (name := "inspect_bag")
+Define `inspectBag`.
 
 ```lean
-def lowerGrade (g : Grade) : Grade
-  := solution!(match g with
-  | ⟨l, plus⟩ => ⟨l, natural⟩
-  | ⟨l, natural⟩ => ⟨l, minus⟩
-  | ⟨F, minus⟩ => ⟨F, minus⟩
-  | ⟨l, minus⟩ => ⟨lowerLetter l, plus⟩)
+def inspectBag (t : Traveler) : Traveler := solution!(
+  match t with
+  | .checkedIn .ordinary _ => .checkedIn .ordinary .cleared
+  | .checkedIn .battery _ => .checkedIn .battery .blocked
+  | _ => t
+)
 
-theorem lowerGrade_A_plus : lowerGrade ⟨A, plus⟩ = ⟨A, natural⟩ := solution!(by rfl)
-example : lowerGrade ⟨A, natural⟩ = ⟨A, minus⟩ := solution!(by rfl)
-example : lowerGrade ⟨A, minus⟩ = ⟨B, plus⟩ := solution!(by rfl)
-example : lowerGrade ⟨B, plus⟩ = ⟨B, natural⟩ := solution!(by rfl)
-example : lowerGrade ⟨F, natural⟩ = ⟨F, minus⟩ := solution!(by rfl)
-example : lowerGrade (lowerGrade ⟨B, minus⟩) = ⟨C, natural⟩ := solution!(by rfl)
-example : lowerGrade (lowerGrade (lowerGrade ⟨B, minus⟩)) = ⟨C, minus⟩ := solution!(by rfl)
-theorem lowerGrade_F_minus : lowerGrade ⟨F, minus⟩ = ⟨F, minus⟩ := solution!(by rfl)
+example : inspectBag (.ticketed .battery) = .ticketed .battery := solution!(by rfl)
+example : inspectBag (.checkedIn .ordinary .notScreened) = .checkedIn .ordinary .cleared := solution!(by rfl)
+example : inspectBag (.checkedIn .battery .notScreened) = .checkedIn .battery .blocked := solution!(by rfl)
 ```
-
-:::gradeTheorem "0.25" lowerGrade_A_plus lowerGrade_F_minus
 :::
-::::
 
-::::exercise (rating := 3) (name := "lower_grade_lowers")
-:::dev
-For our solution we use:
-
-- Working on multiple match cases with `| _ ... | _ => ...`;
-- Working on all remaining goals with `all_goals`.
-- These are not expected of students at this point.
-:::
+Again, we record one characterization lemma for each case.
 
 ```lean
-theorem lowerGrade_lowers : ∀ g : Grade,
-    gradeComparison ⟨F, minus⟩ g = lt →
-    gradeComparison (lowerGrade g) g = lt := by
+theorem inspectBag_noTicket (bagContent : BagContent) :
+    inspectBag (.noTicket bagContent) = .noTicket bagContent := solution!(by rfl)
+
+theorem inspectBag_ticketed (bagContent : BagContent) :
+    inspectBag (.ticketed bagContent) = .ticketed bagContent := solution!(by rfl)
+
+theorem inspectBag_ordinary (screeningStatus : ScreeningStatus) :
+    inspectBag (.checkedIn .ordinary screeningStatus) = .checkedIn .ordinary .cleared := solution!(by rfl)
+
+theorem inspectBag_battery (screeningStatus : ScreeningStatus) :
+    inspectBag (.checkedIn .battery screeningStatus) = .checkedIn .battery .blocked := solution!(by rfl)
+
+attribute [irreducible] inspectBag
+```
+
+:::exercise (rating := 2) (name := "inspect_bag_idempotent")
+Inspecting the same unchanged bag twice has the same effect as inspecting it once.
+
+```lean
+theorem inspectBag_idempotent (t : Traveler) : inspectBag (inspectBag t) = inspectBag t := by
   solution!
-    intro g h
-    match g with
-    | ⟨l, plus⟩ =>
-      rewrite [lowerGrade, gradeComparison]
-      rewrite [letterComparison_Eq]
-      rewrite [modifierComparison]
+    cases t with
+    | noTicket bagContent =>
+      rewrite [inspectBag_noTicket]
+      rewrite [inspectBag_noTicket]
       rfl
-    | ⟨l, natural⟩ =>
-      rewrite [lowerGrade, gradeComparison]
-      rewrite [letterComparison_Eq]
-      rewrite [modifierComparison]
+    | ticketed bagContent =>
+      rewrite [inspectBag_ticketed]
+      rewrite [inspectBag_ticketed]
       rfl
-      intro x
-      contradiction
-    | ⟨l, minus⟩ =>
-      cases l
-      case F => rewrite [lowerGrade_F_minus]; exact h
-      all_goals rfl
-```
-
-:::dev "Roger Burtonpatel (rogerburtonpatel)"
-in removing `dsimp` from these proofs, I found
-that you might need the `contradiction` tactic here instead,
-or some other reasoning that's not accomplishable
-with the tactics we've introduced so far. Can you make this
-proof work with only `rw`, `rfl`, `exact`, etc?
-
-Niklas Halonen (xhalo32): We need to teach how to prove a goal that looks like `natural ≠ minus` for example.
-One could write `injection x` for example:
-```lean
-example : natural ≠ minus := by
-  intro x
-  injection x
+    | checkedIn bagContent screeningStatus =>
+      cases bagContent with
+      | battery =>
+        rewrite [inspectBag_battery]
+        rewrite [inspectBag_battery]
+        rfl
+      | ordinary =>
+        rewrite [inspectBag_ordinary]
+        rewrite [inspectBag_ordinary]
+        rfl
 ```
 :::
 
-:::gradeTheorem 3 lowerGrade_lowers
+If the traveler replaces the bag after check in, the previous screening result no longer
+applies to the new bag.
+
+:::exercise (rating := 1) (name := "replace_bag")
+Define `replaceBag`.
+```lean
+def replaceBag (newContent : BagContent) (t : Traveler) : Traveler := solution!(
+  match t with
+  | .checkedIn _ _ => .checkedIn newContent .notScreened
+  | .ticketed _ => .ticketed newContent
+  | .noTicket _ => .noTicket newContent
+)
+
+example : replaceBag .battery (.ticketed .ordinary) = .ticketed .battery := solution!(by rfl)
+example : replaceBag .battery (.checkedIn .ordinary .cleared) = .checkedIn .battery .notScreened := solution!(by rfl)
+```
 :::
-::::
+
+As before, we record the behavior of each case as a rewrite rule.
 
 ```lean
-def applyLatePolicy (lateDays : NatPlayground.Nat) (g : Grade) : Grade :=
-  if Nat.ble lateDays  9 then g
-  else if Nat.ble lateDays 17 then lowerGrade g
-  else if Nat.ble lateDays 21 then lowerGrade (lowerGrade g)
-  else lowerGrade (lowerGrade (lowerGrade g))
+theorem replaceBag_noTicket (newContent oldContent : BagContent) :
+    replaceBag newContent (.noTicket oldContent) = .noTicket newContent := solution!(by rfl)
 
-theorem applyLatePolicy_unfold : ∀ (lateDays : NatPlayground.Nat) (g : Grade),
-    applyLatePolicy lateDays g
-    =
-    (if Nat.ble lateDays 9 then g
-     else if Nat.ble lateDays 17 then lowerGrade g
-     else if Nat.ble lateDays 21 then lowerGrade (lowerGrade g)
-     else lowerGrade (lowerGrade (lowerGrade g))) := by
-  intro _ _; rfl
+theorem replaceBag_ticketed (newContent oldContent : BagContent) :
+    replaceBag newContent (.ticketed oldContent) = .ticketed newContent := solution!(by rfl)
+
+theorem replaceBag_checkedIn (newContent oldContent : BagContent)
+    (screeningStatus : ScreeningStatus) :
+    replaceBag newContent (.checkedIn oldContent screeningStatus) =
+    .checkedIn newContent .notScreened := solution!(by rfl)
+
+attribute [irreducible] replaceBag
 ```
 
-::::exercise (rating := 2) (name := "no_penalty_for_mostly_on_time")
+:::full
+We know that replacing a bag after it has been inspected resets its
+screening status. In other words, {name}`inspectBag` and {name}`replaceBag` cannot in
+general be performed in either order.
+
+But are there cases in which the two operations do commute?
+
+Yes. If the traveler has not checked in, {name}`inspectBag` does nothing, so
+replacing and inspecting the bag can be performed in either order.
+:::
+
+:::terse
+{name}`inspectBag` and {name}`replaceBag` commute when the traveler has not checked in.
+:::
+
+:::exercise (rating := 2) (name := "inspect_replace_commute")
 ```lean
-theorem no_penalty_for_mostly_on_time : ∀ (lateDays : NatPlayground.Nat) (g : Grade),
-    (Nat.ble lateDays 9 = true) →
-    applyLatePolicy lateDays g = g := by
+theorem inspectBag_replaceBag_comm_ticketed
+    (oldContent newContent : BagContent)
+    (screeningStatus : ScreeningStatus) :
+    inspectBag (replaceBag newContent (.ticketed oldContent)) =
+    replaceBag newContent (inspectBag (.ticketed oldContent)) := by
   solution!
-    intro lateDays g h
-    rewrite [applyLatePolicy]
-    rewrite [h]; rfl
+    rewrite [replaceBag_ticketed]
+    rewrite [inspectBag_ticketed]
+    rewrite [inspectBag_ticketed]
+    rewrite [replaceBag_ticketed]
+    rfl
 ```
-
-:::gradeTheorem 2 no_penalty_for_mostly_on_time
 :::
-::::
-
-::::exercise (rating := 2) (name := "grade_lowered_once")
-```lean
-theorem grade_lowered_once : ∀ (lateDays : NatPlayground.Nat) (g : Grade),
-    (Nat.ble lateDays 9 = false) →
-    (Nat.ble lateDays 17 = true) →
-    applyLatePolicy lateDays g = lowerGrade g := by
-  solution!
-    intro lateDays g h9 h17
-    rewrite [applyLatePolicy]
-    rewrite [h9, h17]; rfl
-```
-
-:::gradeTheorem 2 grade_lowered_once
-:::
-::::
 
 ```lean
-end LateDays
+end Airport
 ```
-:::dev "Roger Burtonpatel (rogerburtonpatel)"
-If we are to have this exercise, we must either
-make the functions irreducible or teach about
-`rw` of a reducible definition.
-We also have to figure out how to make lowerGrade\_lowers
-go through without `dsimp` or `contradiction`. To discuss.
-:::

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -2510,10 +2510,10 @@ termination.
 ```lean +error
 def factorial_bad (n : Nat) : Nat :=
   if n == 0 then 1
-  else n * factorial_bad (n - 1)
+  else n * factorial_bad (pred n)
 ```
 
-This fails because Lean can't see that `n - 1` is structurally smaller.
+This fails because Lean can't see that `pred n` is structurally smaller.
 
 :::
 ::::
@@ -2782,7 +2782,7 @@ inductive Traveler : Type where
 Buying a ticket changes a traveler with no ticket into a ticketed traveler.
 If the traveler already has a ticket or has already checked in, nothing changes.
 
-:::exercise (rating := 1) (name := "buy_ticket")
+:::exercise (rating := 1) (name := "buyTicket")
 Define `buyTicket`
 ```lean
 def buyTicket (t : Traveler) : Traveler := solution!(
@@ -2814,6 +2814,11 @@ attribute [irreducible] buyTicket
 Here is our first general property: buying a ticket twice has the same
 effect as buying it once.
 
+:::full
+N.B. An operation is called _idempotent_
+if performing it twice has the same effect as performing it once.
+:::
+
 :::exercise (rating := 2) (name := "buy_ticket_idempotent")
 ```lean
 theorem buyTicket_idempotent (t : Traveler) :
@@ -2839,9 +2844,9 @@ A traveler can check in only after buying a ticket.
 and their bag is marked as needing inspection.
 Calling checkIn in any other state does nothing.
 
-:::exercise (rating := 1) (name := "check_in")
+:::exercise (rating := 1) (name := "checkIn")
 
-Define `check_in`.
+Define `checkIn`.
 
 ```lean
 def checkIn (t : Traveler) : Traveler := solution!(
@@ -2872,8 +2877,8 @@ theorem checkIn_checkedIn (bagContent : BagContent)
 attribute [irreducible] checkIn
 ```
 
-Buying a ticket and then checking in always leaves the traveler checked in,
-regardless of whether they were already checked in.
+A traveler who does not yet have a ticket can buy one and then check in.
+After doing so, the traveler is checked in and their bag needs to be screened.
 
 :::exercise (rating := 1) (name := "buy_ticket_then_check_in")
 ```lean
@@ -2890,7 +2895,7 @@ Bag inspection happens only after check-in.
 An ordinary bag is cleared, while a bag containing a battery is blocked.
 If the traveler has not checked in, `inspectBag` does nothing.
 
-:::exercise (rating := 1) (name := "inspect_bag")
+:::exercise (rating := 1) (name := "inspectBag")
 Define `inspectBag`.
 
 ```lean
@@ -2989,14 +2994,16 @@ attribute [irreducible] replaceBag
 ```
 
 :::full
-We know that replacing a bag after it has been inspected resets its
-screening status. In other words, {name}`inspectBag` and {name}`replaceBag` cannot in
-general be performed in either order.
+It is easy to see that replacing a bag after it has been inspected resets its screening status.
+In other words, {name}`inspectBag` and {name}`replaceBag` do not, in general, commute:
+the order in which the two operations are performed can affect the result.
 
-But are there cases in which the two operations do commute?
+But are there cases in which the two operations *do* commute?
 
-Yes. If the traveler has not checked in, {name}`inspectBag` does nothing, so
-replacing and inspecting the bag can be performed in either order.
+Yes. If the traveler has not checked in, {name}`inspectBag` has no effect.
+Therefore, whether we inspect the bag before or after replacing it makes no difference.
+In this case, {name}`inspectBag` and {name}`replaceBag` commute.
+
 :::
 
 :::terse
@@ -3005,9 +3012,19 @@ replacing and inspecting the bag can be performed in either order.
 
 :::exercise (rating := 2) (name := "inspect_replace_commute")
 ```lean
+theorem inspectBag_replaceBag_comm_noTicket
+    (oldContent newContent : BagContent) :
+    inspectBag (replaceBag newContent (.noTicket oldContent)) =
+    replaceBag newContent (inspectBag (.noTicket oldContent)) := by
+  solution!
+    rewrite [replaceBag_noTicket]
+    rewrite [inspectBag_noTicket]
+    rewrite [inspectBag_noTicket]
+    rewrite [replaceBag_noTicket]
+    rfl
+
 theorem inspectBag_replaceBag_comm_ticketed
-    (oldContent newContent : BagContent)
-    (screeningStatus : ScreeningStatus) :
+    (oldContent newContent : BagContent) :
     inspectBag (replaceBag newContent (.ticketed oldContent)) =
     replaceBag newContent (inspectBag (.ticketed oldContent)) := by
   solution!

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -2723,7 +2723,8 @@ with an exercise that brings them together.
 In this exercise, we will model part of a database
 storing information about travelers passing through an airport.
 The database contains one entry per traveler, recording
-information about where the traveler is in the airport process and the contents of their luggage.
+information about where the traveler is in the airport process and the contents of their
+current carry-on bag.
 
 We will implement several operations on these entries, state intended
 properties of the database's
@@ -2734,35 +2735,18 @@ behavior, and prove that the implementation satisfies them.
 namespace Airport
 ```
 
-:::dev "Benjamin Pierce (bcpierce00)"
-Remove all the `:::terse` blocks and promote `:::full` blocks to top level -- the whole section is `:::::full` now.
-:::
-
-:::full
-First, we describe the possible states of a bag.
-
-For simplicity, we assume that a bag either contains a battery, which causes
-it to fail inspection, or contains only ordinary items:
-:::
-
-:::terse
-A bag is either ordinary or contains a battery:
-:::
+For simplicity, a carry-on bag either contains a prohibited item,
+such as a liquid that exceeds the allowed limit,
+causing it to fail inspection, or contains only ordinary items.
 
 ```lean
 inductive BagContent : Type where
-  | battery
+  | prohibited
   | ordinary
 ```
 
-:::full
-A bag's screening status records whether the bag has not yet been inspected,
-has been cleared, or has been blocked:
-:::
-
-:::terse
-A bag can be unscreened, cleared, or blocked:
-:::
+After a traveler checks in, the database also records the result of
+the most recent security screening of their carry-on bag.
 
 ```lean
 inductive ScreeningStatus : Type where
@@ -2771,18 +2755,13 @@ inductive ScreeningStatus : Type where
   | blocked
 ```
 
-:::full
 Next, we define the possible stages of the airport process a traveler can inhabit:
 - they have not yet purchased a ticket;
 - they have a ticket but have not yet checked in;
 - they have checked in, in which case the
-  database also stores the screening status of their bag.
-:::
+  database also stores the screening status of their carry-on bag.
 
-:::terse
-There are three stages a traveler can be in:
-:::
-
+We can represent these possible database entries directly with an inductive type.
 ```lean
 inductive Traveler : Type where
   | noTicket  (bagContent : BagContent)
@@ -2801,7 +2780,7 @@ def buyTicket (t : Traveler) : Traveler := solution!(
   | _ => t
 )
 example : buyTicket (.noTicket .ordinary) = .ticketed .ordinary := solution!(by rfl)
-example : buyTicket (.checkedIn .battery .blocked) = .checkedIn .battery .blocked := solution!(by rfl)
+example : buyTicket (.checkedIn .prohibited .blocked) = .checkedIn .prohibited .blocked := solution!(by rfl)
 ```
 :::
 
@@ -2821,15 +2800,9 @@ theorem buyTicket_checkedIn (bagContent : BagContent)
 attribute [irreducible] buyTicket
 ```
 
-:::full
 The first property we will prove about our system is that
-purchasing a ticket is an idempotent operation
+purchasing a ticket is an _idempotent_ operation
 (i.e., performing it twice has the same effect as performing it once).
-:::
-
-:::terse
-Here is our first general property: buying a ticket twice is idempotent.
-:::
 
 :::exercise (rating := 2) (name := "buy_ticket_idempotent")
 ```lean
@@ -2852,9 +2825,9 @@ theorem buyTicket_idempotent (t : Traveler) :
 ```
 :::
 
-A traveler can check in only after buying a ticket,
-and their bag is then marked as needing inspection.
-Calling `checkIn` in any other state does nothing.
+A traveler can check in only after buying a ticket.
+Checking in records that their carry-on bag still needs to be inspected.
+Calling `checkIn` before buying a ticket or after already checking in does nothing.
 
 :::exercise (rating := 1) (name := "checkIn")
 
@@ -2866,7 +2839,7 @@ def checkIn (t : Traveler) : Traveler := solution!(
 )
 
 example : checkIn (.noTicket .ordinary) = .noTicket .ordinary := solution!(by rfl)
-example : checkIn (.ticketed .battery) = .checkedIn .battery .notScreened := solution!(by rfl)
+example : checkIn (.ticketed .prohibited) = .checkedIn .prohibited .notScreened := solution!(by rfl)
 example : checkIn (.checkedIn .ordinary .cleared) = .checkedIn .ordinary .cleared := solution!(by rfl)
 ```
 :::
@@ -2888,7 +2861,7 @@ attribute [irreducible] checkIn
 ```
 
 A traveler who does not yet have a ticket can buy one and then check in.
-After this, the traveler is checked in and their bag needs to be screened.
+After this, the traveler is checked in and their carry-on ba bag needs to be screened.
 
 :::exercise (rating := 1) (name := "buy_ticket_then_check_in")
 ```lean
@@ -2901,8 +2874,9 @@ theorem buyTicket_then_checkIn (bagContent : BagContent) :
 ```
 :::
 
-Bag inspection happens only after check-in.
-An ordinary bag is cleared, while a bag containing a battery is blocked.
+Carry-on inspection happens only after check-in.
+A bag containing only ordinary items is cleared,
+while a bag containing a prohibited item is blocked.
 If the traveler has not checked in, `inspectBag` does nothing.
 
 :::exercise (rating := 1) (name := "inspectBag")
@@ -2912,13 +2886,13 @@ Define `inspectBag`.
 def inspectBag (t : Traveler) : Traveler := solution!(
   match t with
   | .checkedIn .ordinary _ => .checkedIn .ordinary .cleared
-  | .checkedIn .battery _ => .checkedIn .battery .blocked
+  | .checkedIn .prohibited _ => .checkedIn .prohibited .blocked
   | _ => t
 )
 
-example : inspectBag (.ticketed .battery) = .ticketed .battery := solution!(by rfl)
+example : inspectBag (.ticketed .prohibited) = .ticketed .prohibited := solution!(by rfl)
 example : inspectBag (.checkedIn .ordinary .notScreened) = .checkedIn .ordinary .cleared := solution!(by rfl)
-example : inspectBag (.checkedIn .battery .notScreened) = .checkedIn .battery .blocked := solution!(by rfl)
+example : inspectBag (.checkedIn .prohibited .notScreened) = .checkedIn .prohibited .blocked := solution!(by rfl)
 ```
 :::
 
@@ -2934,14 +2908,14 @@ theorem inspectBag_ticketed (bagContent : BagContent) :
 theorem inspectBag_ordinary (screeningStatus : ScreeningStatus) :
     inspectBag (.checkedIn .ordinary screeningStatus) = .checkedIn .ordinary .cleared := solution!(by rfl)
 
-theorem inspectBag_battery (screeningStatus : ScreeningStatus) :
-    inspectBag (.checkedIn .battery screeningStatus) = .checkedIn .battery .blocked := solution!(by rfl)
+theorem inspectBag_prohibited (screeningStatus : ScreeningStatus) :
+    inspectBag (.checkedIn .prohibited screeningStatus) = .checkedIn .prohibited .blocked := solution!(by rfl)
 
 attribute [irreducible] inspectBag
 ```
 
 :::exercise (rating := 2) (name := "inspect_bag_idempotent")
-Show that tnspecting the same unchanged bag twice has the same effect as inspecting it once.
+Show that inspecting same unchanged carry-on bag twice has the same effect as inspecting it once.
 
 ```lean
 theorem inspectBag_idempotent (t : Traveler) : inspectBag (inspectBag t) = inspectBag t := by
@@ -2957,9 +2931,9 @@ theorem inspectBag_idempotent (t : Traveler) : inspectBag (inspectBag t) = inspe
       rfl
     | checkedIn bagContent screeningStatus =>
       cases bagContent with
-      | battery =>
-        rewrite [inspectBag_battery]
-        rewrite [inspectBag_battery]
+      | prohibited =>
+        rewrite [inspectBag_prohibited]
+        rewrite [inspectBag_prohibited]
         rfl
       | ordinary =>
         rewrite [inspectBag_ordinary]
@@ -2968,79 +2942,73 @@ theorem inspectBag_idempotent (t : Traveler) : inspectBag (inspectBag t) = inspe
 ```
 :::
 
-If the traveler replaces the bag after check in, the previous screening result no longer applies to the new bag.
+A traveler may leave the screened area and return with a different carry-on bag.
+Since the previous screening result applied to the old bag,
+a new carry-on must be screened again before the traveler can re-enter.
 
-:::exercise (rating := 1) (name := "replace_bag")
-Define `replaceBag`.
+:::exercise (rating := 1) (name := "changeBag")
+Define `changeBag`.
 ```lean
-def replaceBag (newContent : BagContent) (t : Traveler) : Traveler := solution!(
+def changeBag (newContent : BagContent) (t : Traveler) : Traveler := solution!(
   match t with
   | .checkedIn _ _ => .checkedIn newContent .notScreened
   | .ticketed _ => .ticketed newContent
   | .noTicket _ => .noTicket newContent
 )
 
-example : replaceBag .battery (.ticketed .ordinary) = .ticketed .battery := solution!(by rfl)
-example : replaceBag .battery (.checkedIn .ordinary .cleared) = .checkedIn .battery .notScreened := solution!(by rfl)
+example : changeBag .prohibited (.ticketed .ordinary) = .ticketed .prohibited := solution!(by rfl)
+example : changeBag .prohibited (.checkedIn .ordinary .cleared) = .checkedIn .prohibited .notScreened := solution!(by rfl)
 ```
 :::
 
 As before, we record the behavior of each case as a rewrite rule.
 
 ```lean
-theorem replaceBag_noTicket (newContent oldContent : BagContent) :
-    replaceBag newContent (.noTicket oldContent) = .noTicket newContent := solution!(by rfl)
+theorem changeBag_noTicket (newContent oldContent : BagContent) :
+    changeBag newContent (.noTicket oldContent) = .noTicket newContent := solution!(by rfl)
 
-theorem replaceBag_ticketed (newContent oldContent : BagContent) :
-    replaceBag newContent (.ticketed oldContent) = .ticketed newContent := solution!(by rfl)
+theorem changeBag_ticketed (newContent oldContent : BagContent) :
+    changeBag newContent (.ticketed oldContent) = .ticketed newContent := solution!(by rfl)
 
-theorem replaceBag_checkedIn (newContent oldContent : BagContent)
+theorem changeBag_checkedIn (newContent oldContent : BagContent)
     (screeningStatus : ScreeningStatus) :
-    replaceBag newContent (.checkedIn oldContent screeningStatus) =
+    changeBag newContent (.checkedIn oldContent screeningStatus) =
     .checkedIn newContent .notScreened := solution!(by rfl)
 
-attribute [irreducible] replaceBag
+attribute [irreducible] changeBag
 ```
 
-:::full
 It is easy to see that replacing a bag after it has been inspected resets its screening status.
-In other words, {name}`inspectBag` and {name}`replaceBag` do not, in general, commute:
+In other words, {name}`inspectBag` and {name}`changeBag` do not, in general, commute:
 the order in which the two operations are performed can affect the result.
 
-But are there cases in which the two operations _do_ commute?
+However, if the traveler has not checked in, {name}`inspectBag` does nothing,
+so changing and inspecting the carry-on can be performed in either order.
+There are two such cases: the traveler may not yet have a ticket,
+or may have a ticket but not yet be checked in.
 
-Yes. If the traveler has not checked in, {name}`inspectBag` has no effect.
-Therefore, whether we inspect the bag before or after replacing it makes no difference.
-In this case, {name}`inspectBag` and {name}`replaceBag` commute.
-
-:::
-
-:::terse
-{name}`inspectBag` and {name}`replaceBag` commute when the traveler has not checked in.
-:::
-
-:::exercise (rating := 2) (name := "inspect_replace_commute")
+:::exercise (rating := 2) (name := "inspect_changeBag_commute")
 ```lean
-theorem inspectBag_replaceBag_comm_noTicket
+theorem inspectBag_changeBag_comm_noTicket
     (oldContent newContent : BagContent) :
-    inspectBag (replaceBag newContent (.noTicket oldContent)) =
-    replaceBag newContent (inspectBag (.noTicket oldContent)) := by
+    inspectBag (changeBag newContent (.noTicket oldContent)) =
+    changeBag newContent (inspectBag (.noTicket oldContent)) := by
   solution!
-    rewrite [replaceBag_noTicket]
+    rewrite [changeBag_noTicket]
     rewrite [inspectBag_noTicket]
     rewrite [inspectBag_noTicket]
-    rewrite [replaceBag_noTicket]
+    rewrite [changeBag_noTicket]
     rfl
 
-theorem inspectBag_replaceBag_comm_ticketed
+theorem inspectBag_changeBag_comm_ticketed
     (oldContent newContent : BagContent) :
-    inspectBag (replaceBag newContent (.ticketed oldContent)) =
-    replaceBag newContent (inspectBag (.ticketed oldContent)) := by
+    inspectBag (changeBag newContent (.ticketed oldContent)) =
+    changeBag newContent (inspectBag (.ticketed oldContent)) := by
   solution!
-    rewrite [replaceBag_ticketed]
+    rewrite [changeBag_ticketed]
     rewrite [inspectBag_ticketed]
     rewrite [inspectBag_ticketed]
-    rewrite [replaceBag_ticketed]
+    rewrite [changeBag_ticketed]
     rfl
 ```
 :::

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -488,6 +488,9 @@ _close_ (solve) the current goal, finishing its proof.
 
 Let's walk through the example above with this terminology in mind.
 ::::
+:::dev "Benjamin Pierce (bcpierce00)"
+The typesetting here is bad -- most of the text has to come out of the inline comments...
+:::
 
 ::::terse
 And now let's see it in a bit more detail:
@@ -1378,8 +1381,8 @@ whenever this is sensible in context.
 
 The technical details of how this is done are not important for present purposes,
 so we won't spend time explaining them here.
-Instead, we'll mark them with "You can skip this" comments in `.lean` files and
-hide them behind a button in the HTML presentation.
+Instead, we'll mark them with `THESE DETAILS CAN BE SKIPPED` comments in `.lean` files and
+hide them in a collapsed text segment in the HTML presentation. Click on the triangle in the HTML if you want to have a look.
 
 :::details "Library Nat to SFL Nat coercion"
 ```lean

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1372,8 +1372,16 @@ inductive Nat : Type where
   | succ (n : Nat)
 ```
 
-The following lines make ordinary numerals such as 0, 1, and 2 work with our {name}`Nat` type.You can ignore the details for now.
+With a little Lean magic, we can also arrange that
+ordinary numerals such as 0, 1, and 2 will be interpreted as values of our new {name}`Nat` type
+whenever this is sensible in context.
 
+The technical details of how this is done are not important for present purposes,
+so we won't spend time explaining them here.
+Instead, we'll mark them with "You can skip this" comments in `.lean` files and
+hide them behind a button in the HTML presentation.
+
+:::details "Library Nat to SFL Nat coercion"
 ```lean
 def ofNat : _root_.Nat → Nat
   | .zero => .zero
@@ -1381,6 +1389,7 @@ def ofNat : _root_.Nat → Nat
 
 instance (n : _root_.Nat) : OfNat Nat n := ⟨ofNat n⟩
 ```
+:::
 
 :::full
 We'll define some shorthands for numbers, putting them in the `Nat` namespace
@@ -2697,38 +2706,34 @@ theorem and_eq_or (b c : Bool) : (b && c) = (b || c) → b = c := by
 
 ## Airport Exercise
 
+:::suppressPreviousHeaderWhenTerse
+:::
+
+:::::full
 :::dev "Yipeng Liu (berberman)" BeforeNextRelease
 Add grading attributes.
 :::
 
-
-:::full
-Now that we have learned the basic features of Lean 4, let's close the chapter
+Now that we have learned some basic features of Lean, let's close the chapter
 with an exercise that brings them together.
-
-In a theorem prover like Lean, we can do
-more than just implement a system — we can also state precisely how we expect the
-system to behave and prove that our implementation satisfies that expectation.
 
 In this exercise, we will model part of a database
 storing information about travelers passing through an airport.
 The database contains one entry per traveler, recording
 information about where the traveler is in the airport process and the contents of their luggage.
 
-We will implement several operations on these entries, state
-properties that describe how the database should
-behave, and prove that the implementation satisfies them.
-:::
+We will implement several operations on these entries, state intended
+properties of the database's
+behavior, and prove that the implementation satisfies them.
 
-:::terse
-We will model a simple airport system in Lean. Besides implementing
-its operations, we will state properties that describe how the system should
-behave and prove that the implementation satisfies them.
-:::
 
 ```lean
 namespace Airport
 ```
+
+:::dev "Benjamin Pierce (bcpierce00)"
+Remove all the `:::terse` blocks and promote `:::full` blocks to top level -- the whole section is `:::::full` now.
+:::
 
 :::full
 First, we describe the possible states of a bag.
@@ -2764,7 +2769,7 @@ inductive ScreeningStatus : Type where
 ```
 
 :::full
-Next, we consider the possible stages of the airport process a traveler can inhabit:
+Next, we define the possible stages of the airport process a traveler can inhabit:
 - they have not yet purchased a ticket;
 - they have a ticket but have not yet checked in;
 - they have checked in, in which case the
@@ -2777,8 +2782,8 @@ There are three stages a traveler can be in:
 
 ```lean
 inductive Traveler : Type where
-  | noTicket (bagContent : BagContent)
-  | ticketed (bagContent : BagContent)
+  | noTicket  (bagContent : BagContent)
+  | ticketed  (bagContent : BagContent)
   | checkedIn (bagContent : BagContent) (screeningStatus : ScreeningStatus)
 ```
 
@@ -2786,7 +2791,6 @@ Buying a ticket changes a traveler with no ticket into a ticketed traveler.
 If the traveler already has a ticket or has already checked in, nothing changes.
 
 :::exercise (rating := 1) (name := "buyTicket")
-Define `buyTicket`
 ```lean
 def buyTicket (t : Traveler) : Traveler := solution!(
   match t with
@@ -2798,7 +2802,7 @@ example : buyTicket (.checkedIn .battery .blocked) = .checkedIn .battery .blocke
 ```
 :::
 
-The simplification rules for {name}`buyTicket`:
+Here are the simplification rules for {name}`buyTicket`:
 
 ```lean
 theorem buyTicket_noTicket (bagContent : BagContent) :
@@ -2815,10 +2819,9 @@ attribute [irreducible] buyTicket
 ```
 
 :::full
-An operation is called _idempotent_
-when performing it twice has the same effect as performing it once.
 The first property we will prove about our system is that
-purchasing a ticket is an idempotent operation.
+purchasing a ticket is an idempotent operation
+(i.e., performing it twice has the same effect as performing it once).
 :::
 
 :::terse
@@ -2847,12 +2850,10 @@ theorem buyTicket_idempotent (t : Traveler) :
 :::
 
 A traveler can check in only after buying a ticket,
-and their bag is marked as needing inspection.
-Calling checkIn in any other state does nothing.
+and their bag is then marked as needing inspection.
+Calling `checkIn` in any other state does nothing.
 
 :::exercise (rating := 1) (name := "checkIn")
-
-Define `checkIn`.
 
 ```lean
 def checkIn (t : Traveler) : Traveler := solution!(
@@ -2884,7 +2885,7 @@ attribute [irreducible] checkIn
 ```
 
 A traveler who does not yet have a ticket can buy one and then check in.
-After doing so, the traveler is checked in and their bag needs to be screened.
+After this, the traveler is checked in and their bag needs to be screened.
 
 :::exercise (rating := 1) (name := "buy_ticket_then_check_in")
 ```lean
@@ -2937,7 +2938,7 @@ attribute [irreducible] inspectBag
 ```
 
 :::exercise (rating := 2) (name := "inspect_bag_idempotent")
-Inspecting the same unchanged bag twice has the same effect as inspecting it once.
+Show that tnspecting the same unchanged bag twice has the same effect as inspecting it once.
 
 ```lean
 theorem inspectBag_idempotent (t : Traveler) : inspectBag (inspectBag t) = inspectBag t := by
@@ -2964,8 +2965,7 @@ theorem inspectBag_idempotent (t : Traveler) : inspectBag (inspectBag t) = inspe
 ```
 :::
 
-If the traveler replaces the bag after check in, the previous screening result no longer
-applies to the new bag.
+If the traveler replaces the bag after check in, the previous screening result no longer applies to the new bag.
 
 :::exercise (rating := 1) (name := "replace_bag")
 Define `replaceBag`.
@@ -3004,7 +3004,7 @@ It is easy to see that replacing a bag after it has been inspected resets its sc
 In other words, {name}`inspectBag` and {name}`replaceBag` do not, in general, commute:
 the order in which the two operations are performed can affect the result.
 
-But are there cases in which the two operations *do* commute?
+But are there cases in which the two operations _do_ commute?
 
 Yes. If the traveler has not checked in, {name}`inspectBag` has no effect.
 Therefore, whether we inspect the bag before or after replacing it makes no difference.
@@ -3045,3 +3045,4 @@ theorem inspectBag_replaceBag_comm_ticketed
 ```lean
 end Airport
 ```
+:::::

--- a/SFLMeta/Details.lean
+++ b/SFLMeta/Details.lean
@@ -8,15 +8,16 @@ namespace SFLMeta
 
 /-! ## `:::details` directive
 
-A collapsible disclosure block: the `summary` argument is shown by default
-as a one-line teaser; the contents are revealed only when the reader expands
-the block. Useful for tucking away encoding details (macro plumbing, helper
-notation) that aren't part of the main narrative.
+A collapsible disclosure block: the optional positional `summary` string is
+shown by default as a one-line teaser; the contents are revealed only when the
+reader expands the block. When omitted, the summary defaults to `"Details"`.
+Useful for tucking away encoding details (macro plumbing, helper notation) that
+aren't part of the main narrative.
 
 Author syntax:
 
 ````markdown
-:::details (summary := "Lean encoding")
+:::details "Lean encoding"
 The macros below set up the `<{ … }>` notation for STLC terms.
 
 ```lean
@@ -32,15 +33,16 @@ concern, not part of the source. -/
 
 /-- Configuration for `:::details`. -/
 structure DetailsConfig where
-  /-- The clickable teaser shown when the block is collapsed. -/
-  summary : String
+  /-- The clickable teaser shown when the block is collapsed. Defaults to
+  `"Details"` when omitted. -/
+  summary : Option String
 deriving Repr
 
 section
 variable [Monad m] [MonadError m]
 
 def DetailsConfig.parse : ArgParse m DetailsConfig :=
-  DetailsConfig.mk <$> .named `summary .string false
+  DetailsConfig.mk <$> ((some <$> .positional `summary .string) <|> pure none)
 
 instance : FromArgs DetailsConfig m := ⟨DetailsConfig.parse⟩
 
@@ -106,14 +108,14 @@ details.sf-details[open] {
 "##
   ]
 
-/-- A `:::details(summary := "…")` directive wraps its contents in a
-collapsible disclosure block. -/
+/-- A `:::details "…"` directive wraps its contents in a collapsible
+disclosure block. The summary string is optional (defaults to `"Details"`). -/
 @[directive]
 def details : DirectiveExpanderOf DetailsConfig
   | cfg, contents => do
     let blocks ← contents.mapM elabBlock
     ``(Verso.Doc.Block.other
-        (SFLMeta.Block.details $(quote cfg.summary))
+        (SFLMeta.Block.details $(quote (cfg.summary.getD "Details")))
         #[$blocks,*])
 
 end SFLMeta

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -789,14 +789,14 @@ This directive is always written as a self-closing empty block.
 :::
 ```
 
-#### `:::details (summary := <string>)`
+#### `:::details "<summary>"`
 
 _Rendered in all variants._
 
 In the HTML, this is rendered as a collapsible `<details>` element
-with the given `<summary>` text.
+with the given `<summary>` text, or "Details" when it is omitted.
 In the extracted Lean, this is rendered preceded by a
-`-- THESE DETAILS CAN BE SKIPPED: <summary>_` comment and succeeded by a
+`-- THESE DETAILS CAN BE SKIPPED: <summary>` comment and followed by a
 `-- END DETAILS` comment.
 Good for encoding details, macro plumbing, or helper notation that is correct
 but not central to the main narrative.

--- a/STYLE-WRITING.md
+++ b/STYLE-WRITING.md
@@ -207,6 +207,10 @@ We use American English spelling.
 For general matters of grammar, punctuation, and usage, we follow
 the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/).
 
+Except in the Preface, we use just "Lean", not "Lean 4".
+
+We generally use _italics_ for emphasis, not **boldface**.
+
 ### Informal Proofs
 
 We use informal proofs sparingly, as explanations and exercises when

--- a/TS/Stlc.lean
+++ b/TS/Stlc.lean
@@ -395,7 +395,7 @@ If anything ever changes here, make sure to do the same
 adjustment in all the other grammars for Stlc-like languages...
 :::
 
-::::details (summary := "Notation encoding: types")
+::::details "Notation encoding: types"
 The `stlcTy` grammar covers `Bool`, arrows (written `→` or `->`, associating to
 the right), parentheses, and `~e`.  A bare identifier other than `Bool` is
 spliced in as a Lean term, so a local `T` — or any Lean expression of type
@@ -433,7 +433,7 @@ We'll write types inside of `<{ ... }>` brackets:
 #check <{ (Bool -> Bool) -> Bool }>
 ```
 
-::::details (summary := "Notation encoding: terms")
+::::details "Notation encoding: terms"
 Terms are built from variables, application (associating to the left),
 abstraction, the two boolean constants, and conditionals.  A binding
 occurrence — the `x` in `λ x : T . t` — has a small grammar of its own,
@@ -492,7 +492,7 @@ macro_rules (kind := tmBracket)
 ```
 ::::
 
-::::details (summary := "Notation encoding: printing it back")
+::::details "Notation encoding: printing it back"
 A _delaborator_ runs the grammar backwards: it rebuilds the concrete syntax
 from a {name}`Ty` or {name}`Tm` value, so that types and terms appearing in
 goals and in `#check` output print as `<{ λ x : Bool . x }>` rather than as a
@@ -940,7 +940,7 @@ variable with this name", because naming a variable is what a bare identifier
 already does, and a bare identifier is a literal rather than a splice.
 ::::
 
-::::details (summary := "Notation encoding: substitution")
+::::details "Notation encoding: substitution"
 One more line registers substitutions with the printer, so that a goal
 mentioning one reads as `[x := s] t` rather than as a `subst` application.
 
@@ -1619,7 +1619,7 @@ with the turnstile and colon of the {ref "Types"}[Types] chapter:
 `<{ Γ ⊢ t ⦂ T }>`.
 ::::
 
-::::details (summary := "Notation encoding: contexts and judgments")
+::::details "Notation encoding: contexts and judgments"
 Contexts get a grammar of their own, `stlcCtx`.  The *meaning* is the map update
 we already have — `x ↦ T ; Γ` expands to exactly the `Typeclasses` chapter's
 partial-map update on `Γ` — but its surface syntax has to be our own, because
@@ -1681,7 +1681,7 @@ inductive HasType : Context → Tm → Ty → Prop where
       <{ ~Γ ⊢ if ~t₁ then ~t₂ else ~t₃ ⦂ ~T₁ }>
 ```
 
-::::details (summary := "Notation encoding: the judgment, for real")
+::::details "Notation encoding: the judgment, for real"
 Closing the `section` retires the hygiene-free rule; the same rule is then
 declared again, hygienically, for every later use.
 
@@ -1694,7 +1694,7 @@ macro_rules (kind := judgeBracket)
 ```
 ::::
 
-::::details (summary := "Notation encoding: printing judgments back")
+::::details "Notation encoding: printing judgments back"
 As with terms, a judgment prints back in its own notation, so that a goal reads
 as `<{ x ↦ Bool ; ∅ ⊢ x ⦂ Bool }>` rather than as a `HasType` applied to a chain
 of map updates.

--- a/TS/Types.lean
+++ b/TS/Types.lean
@@ -228,7 +228,7 @@ output print as `<{ … }>` rather than as a pile of constructors.  (Setting
 prints as `Bool` or `Nat`.
 ::::
 
-::::details (summary := "Notation encoding: printing terms back")
+::::details "Notation encoding: printing terms back"
 ```lean
 open Lean PrettyPrinter Delaborator SubExpr Parenthesizer in
 /-- Re-inserts parentheses in `tm` output according to the grammar's precedences. -/


### PR DESCRIPTION
The previous exercise was a bit of awkward with large numeric literals and  techniques we haven't introduced yet such as `Ne`, `dsimp`, `<;>`, etc.

This PR replaces it with a simpler exercise -- students define and test a small set of airport operations, write characterization lemmas, and then use those lemmas in larger proofs. I have tried making one about practicing more on structures, but it turned out to be awkward because the claims couldn't be stated nicely -- they would need the proofs to use `dsimp`/`contradiction` for operating equational hypotheses and structure projections.

I used gpt-5.6 to revise the wording.