### PR TITLE
Lists: clean up stale names and proof examples

### DIFF
--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -13,17 +13,6 @@ htmlSplit := .never
 file := some "Lists"
 %%%
 
-:::dev "Konstantinos Kallas (angelhof)"
-The `Baz` "how many elements does this type have?" exercise (the last exercise
-in the chapter) is a *manual* exercise, and that's a poor fit: a student who
-doesn't realize an inductive definition needs a base case will simply fail it and
-only see why in the grader comment — and it's easy to wrongly think you have the
-right answer and move on without thinking. Better to either add a short section
-that explains this directly, or add a hint like the `one_true_baz` / `count_trues`
-scaffold ("try to write a value of type `Baz` for which the lemma holds"). Worth
-reworking for easier grading.
-:::
-
 :::instructors
 This file takes about 60 minutes to get through.
 Putting it together with Induction.lean makes a reasonable
@@ -423,10 +412,6 @@ example : [1, 2, 3] ++ [4, 5] = [1, 2, 3, 4, 5] := by rfl
 example : [] ++ [4, 5] = [4, 5] := by rfl
 example : [1, 2, 3] ++ [] = [1, 2, 3] := by rfl
 ```
-
-:::dev "One An (meluge)" NOW
-Experiment: introduce `BEq.refl` here, at the point where the `BEq` class is named.
-:::
 
 :::slidebreak
 :::
@@ -949,7 +934,7 @@ theorem included_cons_nonmember {v : Nat} {l₁ l₂ : NatList} (h : member v l�
 ```lean
 example : included [1] [2, 1] = true := by
   rw [included_cons_member]
-  · apply included_nil
+  · exact included_nil
   · rw [member_cons_diff rfl]
     rw [member_cons_same rfl]
 
@@ -1101,7 +1086,7 @@ For comparison, here is an informal proof of the same theorem.
 :::
 
 :::dev "Benjamin Pierce (bcpierce00)"
-What's the best Lean markup for a displayed equation? The markup below is going to get squished into a paragraph with all the rest by default, but IMO it would look better as a separate display. Also: Are we going to consistently write Qed at the end of proofs? We should agree on a convention.
+Are we going to consistently write Qed at the end of proofs? We should agree on a convention.
 :::
 
 _Theorem_: For all lists `l1`, `l2`, and `l3`,
@@ -1118,7 +1103,7 @@ _Proof_: By induction on `l1`.
 ([] ++ l2) ++ l3 = [] ++ (l2 ++ l3),
 ```
 
-  which follows directly from the definition of `app`.
+  which follows directly from the definition of `append`.
 
 - Next, suppose `l1 = n :: l1'`, with
 
@@ -1132,7 +1117,7 @@ _Proof_: By induction on `l1`.
 ((n :: l1') ++ l2) ++ l3 = (n :: l1') ++ (l2 ++ l3).
 ```
 
-By the definition of `app`, this follows from
+By the definition of `append`, this follows from
 
 ```display
 n :: ((l1' ++ l2) ++ l3) = n :: (l1' ++ (l2 ++ l3)),
@@ -1265,7 +1250,7 @@ theorem length_append_succ {l : NatList} {n : Nat} :
   induction l with
   | nil =>
     rw [reverse_nil, nil_append, length_cons, length_nil]
-  | cons n l' ih =>
+  | cons m l' ih =>
     rw [reverse_cons]
     -- `ih` not applicable
 ```
@@ -1273,10 +1258,10 @@ theorem length_append_succ {l : NatList} {n : Nat} :
 ```leanOutput st3
 unsolved goals
 case cons
-n✝ n : Nat
+n m : Nat
 l' : NatList
-ih : (l'.reverse ++ [n✝]).length = l'.reverse.length + 1
-⊢ (l'.reverse ++ [n] ++ [n✝]).length = (l'.reverse ++ [n]).length + 1
+ih : (l'.reverse ++ [n]).length = l'.reverse.length + 1
+⊢ (l'.reverse ++ [m] ++ [n]).length = (l'.reverse ++ [m]).length + 1
 ```
 
 ::::full
@@ -1569,7 +1554,7 @@ theorem append_assoc4 {l1 l2 l3 l4 : NatList} :
 An exercise about your implementation of {name}`nonZeros`:
 
 ```lean
-theorem nonZeros_app (l1 l2 : NatList) :
+theorem nonZeros_append (l1 l2 : NatList) :
     nonZeros (l1 ++ l2) = (nonZeros l1) ++ (nonZeros l2) := by
   solution!
     induction l1 with
@@ -1582,7 +1567,7 @@ theorem nonZeros_app (l1 l2 : NatList) :
         rw [cons_append, nonZeros_cons_nonZero, nonZeros_cons_nonZero, ih, cons_append]
 ```
 
-:::gradeTheorem 1 nonZeros_app
+:::gradeTheorem 1 nonZeros_append
 :::
 :::::
 
@@ -1626,7 +1611,7 @@ theorem beq_refl {l : NatList} :
     induction l with
     | nil => rw [beq_nil]
     | cons n l' ih =>
-      rw [beq_cons_same BEq.rfl]
+      rw [beq_cons_same (BEq.refl n)]
       exact ih
 ```
 
@@ -1757,9 +1742,9 @@ theorem remove_does_not_increase_count (l : NatList) :
 ```
 :::::
 
-:::::exercise (rating := 3) (name := "count_app") (manual := true)
-Write down an interesting theorem `count_app` about lists
-involving the functions `count` and `app`, and prove it.
+:::::exercise (rating := 3) (name := "count_append") (manual := true)
+Write down an interesting theorem `count_append` about lists
+involving the functions `count` and `append`, and prove it.
 (You may find that the difficulty of the proof depends on how you defined `count`!)
 
 :::dev "Andrew Tolmach (AndrewTolmach)" PotentialImprovement


### PR DESCRIPTION
While reading through Lists, I noticed a few stale names and proof examples. This updates the remaining `app` references to `append`, fixes the displayed induction state, uses `BEq.refl` consistently, and removes notes that have already been addressed.

AI use: I used a bit of GPT while reviewing these fixes.