### PR TITLE
to_verso/CLAUDE.md should emit :::gradeTheorem name as a bare identifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,12 +143,16 @@ the build) while appearing in no build product, wrap a ` ```lean -show ` block
 in `:::ignore`: `-show` keeps it out of the rendered book, `:::ignore` keeps it
 out of the extracted `.lean`.  Neither flag alone does both.
 
-Two related directives are **not** noops. `:::gradeTheorem <pts> "<name>"` is
+Two related directives are **not** noops. `:::gradeTheorem <pts> <name>...` is
 the structured successor to a `:::grade` block wrapping a `GRADE_THEOREM <pts>:
 <name>` spec — `to_verso` emits it for every `GRADE_THEOREM` marker (points bare
 for integers, quoted for fractions like `"0.5"`); other `GRADE_` specs
-(`GRADE_MANUAL`) keep the older `:::grade` body form. It renders nothing for now
-but records `(points, name)` for later autograding (`SFLMeta/Grade.lean`).
+(`GRADE_MANUAL`) keep the older `:::grade` body form. The theorem name is a
+**bare identifier** (not a quoted string), and the directive accepts *one or
+more* of them (`:::gradeTheorem "0.25" nand_test1 nand_test2`); each is resolved
+as a real Lean constant (`.inlineLeanResolvedName`), so a quoted name no longer
+parses. It renders nothing for now but records `(points, names)` for later
+autograding (`SFLMeta/Grade.lean`).
 `:::quizSolution` is the uniform quiz-answer block (superseding the old
 quiz-answer conventions `:::answer` and a bare-`(X)` `:::instructors`): in the
 HTML book it renders as a click-to-reveal disclosure button, and it is *elided

--- a/scripts/to_verso.py
+++ b/scripts/to_verso.py
@@ -1800,8 +1800,11 @@ class Renderer:
     def _on_grade(self, text):
         # -- GRADE_THEOREM / GRADE_MANUAL grading directives.  A `GRADE_THEOREM
         # <pts>: <name>` spec becomes the structured `:::gradeTheorem <pts>
-        # "<name>"` directive (point value and theorem name as arguments, empty
-        # body).  Any other spec — `GRADE_MANUAL <pts>: <name>` and the like —
+        # <name>` directive (point value and theorem name as arguments, empty
+        # body).  The name is emitted as a bare identifier: the directive
+        # resolves it as a real Lean constant (`.inlineLeanResolvedName`), so a
+        # quoted string no longer parses.  Any other spec — `GRADE_MANUAL <pts>:
+        # <name>` and the like —
         # keeps the older `:::grade` form carrying the spec as body text (a
         # backtick span, since the spec's underscored names would trip Verso's
         # emphasis parser as bare prose; a spec a span can't hold falls back to
@@ -1818,7 +1821,7 @@ class Renderer:
             # token, and quoting preserves the exact value as a string).
             pts = m.group(1)
             pts_arg = pts if pts.isdigit() else '"%s"' % pts
-            self._append(':::gradeTheorem %s "%s"\n:::\n\n'
+            self._append(':::gradeTheorem %s %s\n:::\n\n'
                          % (pts_arg, m.group(2)))
             return
         body = ('`' + text + '`' if '`' not in text and '\n' not in text


### PR DESCRIPTION
Main (#183) changed the :::gradeTheorem directive to resolve its theorem name(s) as real Lean constants (many1 .inlineLeanResolvedName) instead of carrying a single quoted string, so the old `:::gradeTheorem <pts> "<name>"` form no longer parses.

- to_verso.py: emit the name bare (`:::gradeTheorem 1 foo`) instead of quoted. Points logic is unchanged (bare int, quoted fraction), already matching main.
- CLAUDE.md: document the bare-identifier form and that the directive accepts one or more names.