### PR TITLE
Hoare: start going through proofs

### DIFF
--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -558,17 +558,6 @@ A raw Lean assertion can also be written directly inside {{ }}.
 ```
 :::
 
-:::dev "Claude"
-Delaborators for this grammar are defined in the _Printing Assertions_ section below (after
-assertion substitution, the last notation they need to recognize).  They
-cover the base chapter's forms -- triples, `->>`, substitution, and lifted
-`Prop`s; not covered are the extension modules' shadowed triples (each
-module defines its own `Com` and `ValidHoareTriple`) and the `bassertion`
-coercion, which fall back to raw display.  An assertion applied to a state
-(after `intro st`) also prints raw -- the same thing that happens in the
-Rocq development as soon as `simpl` unfolds the notation.
-:::
-
 ```lean
 namespace Assertion
 
@@ -740,6 +729,133 @@ fun st => st[Z] * st[Z] ≤ st[X] ∧ ¬st[Z].succ * st[Z].succ ≤ st[X]
 end ExamplePrettyAssertions
 ```
 
+## Printing Assertions
+%%%
+tag := "assn-delaborators"
+%%%
+
+::::full
+As in the {ref "imp-delaborators"}[Imp chapter], the assertion notation
+above is _input_ only: Lean reads `{{ X ≤ 5 }}` but still prints the
+underlying function, as `#print assertion8` just showed.  The delaborators
+below close the loop for plain assertions: a state lambda whose body Lean
+can rebuild is printed back in `{{ … }}` notation, and an assertion Lean
+cannot rebuild falls back to the raw `fun st => …` form, which is exactly
+this notation's escape syntax, so what you see is always valid input.  Each
+time a new notation involving assertions appears below (implication, Hoare
+triples, substitution), a small delaborator defined next to it will extend
+this printing to cover it.  As before, there is no need to understand the
+details.
+::::
+
+::::details "Notation encoding: printing assertions back"
+```lean
+namespace Assertion.Delab
+open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
+
+/-- Rebuild the surface form of an assertion body, undoing the state
+threading the `assn` elaborator performs: `st[X]` prints as `X`,
+`Aexp.eval st a` as `a`, `Bexp.eval st b = true` as `b`, an applied
+assertion `P st` as `P`, and a subterm that does not mention the state
+prints as itself. -/
+partial def delabBody (stId : FVarId) : DelabM Term := do
+  let e ← getExpr
+  if !e.containsFVar stId then
+    delab
+  else
+    match_expr e with
+    | MyGetElem.getElem _ _ _ _ st _ =>
+      guard (st == .fvar stId)
+      withNaryArg 5 delab
+    | Aexp.eval st _ =>
+      guard (st == .fvar stId)
+      withAppArg delab
+    | HAdd.hAdd _ _ _ _ _ _ =>
+      `($(← withNaryArg 4 (delabBody stId)) + $(← withNaryArg 5 (delabBody stId)))
+    | HSub.hSub _ _ _ _ _ _ =>
+      `($(← withNaryArg 4 (delabBody stId)) - $(← withNaryArg 5 (delabBody stId)))
+    | HMul.hMul _ _ _ _ _ _ =>
+      `($(← withNaryArg 4 (delabBody stId)) * $(← withNaryArg 5 (delabBody stId)))
+    | Eq _ l r =>
+      -- `Bexp.eval st b = true` is the threaded form of a bare boolean `b`
+      if r.isConstOf ``Bool.true && l.isAppOfArity ``Bexp.eval 2
+          && l.appFn!.appArg! == .fvar stId then
+        withNaryArg 1 <| withAppArg delab
+      else
+        `($(← withNaryArg 1 (delabBody stId)) = $(← withNaryArg 2 (delabBody stId)))
+    | Ne _ _ _ =>
+      `($(← withNaryArg 1 (delabBody stId)) ≠ $(← withNaryArg 2 (delabBody stId)))
+    | LE.le _ _ _ _ =>
+      `($(← withNaryArg 2 (delabBody stId)) ≤ $(← withNaryArg 3 (delabBody stId)))
+    | LT.lt _ _ _ _ =>
+      `($(← withNaryArg 2 (delabBody stId)) < $(← withNaryArg 3 (delabBody stId)))
+    | GE.ge _ _ _ _ =>
+      `($(← withNaryArg 2 (delabBody stId)) ≥ $(← withNaryArg 3 (delabBody stId)))
+    | GT.gt _ _ _ _ =>
+      `($(← withNaryArg 2 (delabBody stId)) > $(← withNaryArg 3 (delabBody stId)))
+    | And _ _ =>
+      `($(← withNaryArg 0 (delabBody stId)) ∧ $(← withNaryArg 1 (delabBody stId)))
+    | Or _ _ =>
+      `($(← withNaryArg 0 (delabBody stId)) ∨ $(← withNaryArg 1 (delabBody stId)))
+    | Iff _ _ =>
+      `($(← withNaryArg 0 (delabBody stId)) ↔ $(← withNaryArg 1 (delabBody stId)))
+    | Not _ =>
+      `(¬ $(← withAppArg (delabBody stId)))
+    | _ =>
+      if e.isArrow then
+        `($(← withBindingDomain (delabBody stId)) →
+          $(← withBindingBody `h (delabBody stId)))
+      else if let .app f v := e then
+        -- an applied assertion `P st` (or an applied escape lambda)
+        guard (v == .fvar stId)
+        guard !(f.containsFVar stId)
+        withAppFn delab
+      else
+        failure
+
+/-- Print an `Assertion`-valued term as it appears inside `{{ … }}`: a
+state lambda is un-threaded; a term the printer cannot rebuild falls back
+to the raw lambda, which is exactly this notation's escape form. -/
+partial def delabAssn : DelabM Term := do
+  if (← getExpr).isLambda then
+    (withBindingBody' `st (pure ·.fvarId!) fun stId => delabBody stId)
+      <|> Delaborator.delab
+  else
+    delab
+
+/-- Print an assertion-position argument: a state lambda gets the
+`{{ … }}` notation; any other term (a named assertion, a substitution)
+already reads well bare. -/
+def delabAssnArg (i : Nat) : DelabM Term := do
+  if (← withNaryArg i getExpr).isLambda then
+    `({{ $(← withNaryArg i delabAssn) }})
+  else
+    withNaryArg i Delaborator.delab
+
+/-- Print a bare assertion lambda in `{{ … }}` notation.  Keyed on lambdas
+at large, so the guards bail out cheaply unless the binder is a `State`
+and the body is a proposition the printer can rebuild. -/
+@[delab lam]
+def delabAssertion : Delab := whenPPOption getPPNotation do
+  let e ← getExpr
+  guard <| e.isLambda && e.bindingDomain!.isConstOf ``_root_.State
+  let P ← withBindingBody' `st (pure ·.fvarId!) fun stId => do
+    guard (← Meta.inferType (← getExpr)).isProp
+    delabBody stId
+  `({{ $P }})
+
+end Assertion.Delab
+```
+::::
+
+:::ignore
+```lean -show
+/-- info: {{X = 3 ∨ X ≤ Y}} : State → Prop -/
+#guard_msgs in
+#check {{ X = 3 ∨ X ≤ Y }}
+```
+:::
+
 ## Assertion Implication
 
 Given two assertions `P` and `Q`, we say that `P` _implies_ `Q`,
@@ -769,6 +885,50 @@ notation:26 P:27 " <<->> " Q:27 => AssertImplies P Q ∧ AssertImplies Q P
 theorem assertIff_def {P Q : Assertion} : P <<->> Q ↔ AssertImplies P Q ∧ AssertImplies Q P
     := by rfl
 ```
+
+::::full
+The matching delaborators print implications and equivalences between
+assertions back in `->>` and `<<->>` notation.
+::::
+
+::::details "Notation encoding: printing implications back"
+```lean
+namespace Assertion.Delab
+open Lean PrettyPrinter Delaborator SubExpr
+
+@[delab app.AssertImplies]
+def delabAssertImplies : Delab := whenPPOption getPPNotation do
+  guard <| (← getExpr).isAppOfArity ``AssertImplies 2
+  `($(← delabAssnArg 0) ->> $(← delabAssnArg 1))
+
+/-- `<<->>` abbreviates a conjunction of two `AssertImplies`, so its
+delaborator is keyed on `∧` and bails out unless the two conjuncts mirror
+each other. -/
+@[delab app.And]
+def delabAssertIff : Delab := whenPPOption getPPNotation do
+  let e ← getExpr
+  guard <| e.isAppOfArity ``And 2
+  let l := e.appFn!.appArg!
+  let r := e.appArg!
+  guard <| l.isAppOfArity ``AssertImplies 2 && r.isAppOfArity ``AssertImplies 2
+  guard <| l.appFn!.appArg! == r.appArg! && l.appArg! == r.appFn!.appArg!
+  `($(← withNaryArg 0 <| delabAssnArg 0) <<->> $(← withNaryArg 0 <| delabAssnArg 1))
+
+end Assertion.Delab
+```
+::::
+
+:::ignore
+```lean -show
+/-- info: {{X < 4}} ->> {{X < 5}} : Prop -/
+#guard_msgs in
+#check ({{ X < 4 }} ->> {{ X < 5 }})
+
+/-- info: {{X < 4}} <<->> {{X < 5}} : Prop -/
+#guard_msgs in
+#check ({{ X < 4 }} <<->> {{ X < 5 }})
+```
+:::
 
 # Hoare Triples, Informally
 
@@ -1062,6 +1222,32 @@ open scoped ValidHoareTriple
 #check ({{ True }} X := 0 {{ False }})
 ```
 ::::
+
+::::details "Notation encoding: printing triples back"
+```lean
+namespace Assertion.Delab
+open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
+
+/-- Print a `ValidHoareTriple` back in `{{ P }} c {{ Q }}` notation. -/
+@[delab app.ValidHoareTriple]
+def delabTriple : Delab := whenPPOption getPPNotation do
+  guard <| (← getExpr).isAppOfArity ``ValidHoareTriple 3
+  let P ← withNaryArg 0 delabAssn
+  let c ← withNaryArg 1 delabComInner
+  let Q ← withNaryArg 2 delabAssn
+  `({{ $P }} $c:imp_com {{ $Q }})
+
+end Assertion.Delab
+```
+::::
+
+:::ignore
+```lean -show
+/-- info: {{X ≤ 5}} X := X + 1 {{X ≤ 7}} : Prop -/
+#guard_msgs in
+#check {{ X ≤ 5 }} X := X + 1 {{ X ≤ 7 }}
+```
+:::
 
 :::::exercise (rating := 1) (name := "hoare_post_true")
 Prove that if `Q` holds in every state, then any triple with `Q`
@@ -1393,18 +1579,24 @@ Currently in triples we need to write `{{ {{ X < 5 }} [X ↦ X + 1] }}` which lo
 ```lean
 namespace Assertion
 
-/-- Assertion substitution: `P [X ↦ a]` -/
+/-- Assertion substitution, written inside the braces: `{{ (P) [X ↦ a] }}`.
+The substituted assertion is re-read with the same notation, so Imp
+variables in it mean state lookups as usual; a named assertion is passed
+through directly. -/
 scoped syntax:max term:arg " [" ident " ↦ " imp_aexp "]" : term
 
 macro_rules
-  | `($P [$x ↦ $a:imp_aexp]) => `(Assertion.subst $x (aexp { $a }) $P)
+  | `(assn($st; $P [$x ↦ $a:imp_aexp])) =>
+    match P with
+    | `($_:ident) => ``(Assertion.subst $x (aexp { $a }) $P $st)
+    | _ => ``(Assertion.subst $x (aexp { $a }) {{ $P }} $st)
 
 theorem subst_def {x : Ident} {a : Aexp} {P : Assertion} :
-    P [x ↦ ~a] = fun (st : State) => P (x →ₜ a.eval st ; st) := by rfl
+    Assertion.subst x a P = fun (st : State) => P (x →ₜ a.eval st ; st) := by rfl
 
 @[simp]
 theorem subst_apply {x : Ident} {a : Aexp} {P : Assertion} {st : State} :
-    P [x ↦ ~a] st ↔ P (x →ₜ a.eval st ; st) := by rfl
+    Assertion.subst x a P st ↔ P (x →ₜ a.eval st ; st) := by rfl
 
 end Assertion
 ```
@@ -1417,9 +1609,30 @@ P [ X ↦ a ]
 
 ```lean
 #check (fun st => Assertion.subst X (aexp { 2 * X }) ({{ X ≤ 10 }}) st)
-#check {{ X ≤ 10 }} [X ↦ 2 * X]
-#check (∀ st, {{ X ≤ 10 }} [X ↦ 2 * X] st)
+#check {{ (X ≤ 10) [X ↦ 2 * X] }}
+#check (∀ st, ({{ (X ≤ 10) [X ↦ 2 * X] }}) st)
 ```
+
+::::details "Notation encoding: printing substitutions back"
+```lean
+namespace Assertion.Delab
+open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
+
+/-- Print an `Assertion.subst` back in `P [x ↦ a]` notation. -/
+@[delab app.Assertion.subst]
+def delabSub : Delab := whenPPOption getPPNotation do
+  guard <| (← getExpr).isAppOfArity ``Assertion.subst 3
+  let `($x:ident) ← withNaryArg 0 delab | failure
+  let a ← withNaryArg 1 delabAexpInner
+  let P ← withNaryArg 2 delabAssn
+  if (← withNaryArg 2 getExpr).isLambda then
+    `({{ $P }} [$x:ident ↦ $a:imp_aexp])
+  else
+    `($P [$x:ident ↦ $a:imp_aexp])
+
+end Assertion.Delab
+```
+::::
 
 That is, `P [X ↦ a]` stands for an assertion -- let's call it
 `P'` -- that behaves just like `P` except that, wherever `P` looks up
@@ -1497,7 +1710,7 @@ We can demonstrate formally that we have captured intuitive meaning of
 ```lean
 namespace ExampleAssertionSub
 example :
-    {{ (X ≤ 5) }} [X ↦ 3] <<->> {{ 3 ≤ 5 }} := by
+    {{ (X ≤ 5) [X ↦ 3] }} <<->> {{ 3 ≤ 5 }} := by
   rw [assertIff_def]
   rw [assertImplies_def]
   constructor
@@ -1507,7 +1720,7 @@ example :
     simp
 
 example :
-    {{ (X ≤ 5) }} [X ↦ X + 1] <<->> {{ (X + 1) ≤ 5 }} := by
+    {{ (X ≤ 5) [X ↦ X + 1] }} <<->> {{ (X + 1) ≤ 5 }} := by
   rw [assertIff_def]
   constructor
   · rw [assertImplies_def]
@@ -1521,158 +1734,6 @@ end ExampleAssertionSub
 ```
 
 Most of the `simp` calls rely on {name}`Assertion.subst_apply`, {name}`TotalMap.update_eq` plus some `Aexp` characterizing lemmas like {name}`Aexp.eval_num`.
-
-## Printing Assertions
-%%%
-tag := "assn-delaborators"
-%%%
-
-:::dev "Niklas Halonen (xhalo32)" NOW
-To One:
-1. Add delaborator for plain assertions, also for `<<->>`
-2. Move the delab stuff near where the syntax is first introduced for assertions and then add small delaborators when new syntax like triples are introduced.
-:::
-
-::::full
-As in the {ref "imp-delaborators"}[Imp chapter], the assertion notations
-above are _input_ only: Lean reads `{{ X ≤ 5 }}` but still prints the
-underlying function.  The delaborators below close the loop for the common
-cases: Hoare triples, `->>` implications, and assertion substitutions are
-printed back in their concrete notation, and an assertion Lean cannot
-rebuild falls back to the raw `fun st => …` form -- which is exactly this
-notation's escape syntax, so what you see is always valid input.  As
-before, there is no need to understand the details, and everything can be
-switched off with `set_option pp.notation false`.
-::::
-
-::::details "Notation encoding: printing assertions back"
-```lean
-namespace Assertion.Delab
-open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
-
-/-- Rebuild the surface form of an assertion body, undoing the state
-threading the `assn` elaborator performs: `st[X]` prints as `X`,
-`Aexp.eval st a` as `a`, `Bexp.eval st b = true` as `b`, an applied
-assertion `P st` as `P`, and a subterm that does not mention the state
-prints as itself. -/
-partial def delabBody (stId : FVarId) : DelabM Term := do
-  let e ← getExpr
-  if !e.containsFVar stId then
-    delab
-  else
-    match_expr e with
-    | MyGetElem.getElem _ _ _ _ st _ =>
-      guard (st == .fvar stId)
-      withNaryArg 5 delab
-    | Aexp.eval st _ =>
-      guard (st == .fvar stId)
-      withAppArg delab
-    | HAdd.hAdd _ _ _ _ _ _ =>
-      `($(← withNaryArg 4 (delabBody stId)) + $(← withNaryArg 5 (delabBody stId)))
-    | HSub.hSub _ _ _ _ _ _ =>
-      `($(← withNaryArg 4 (delabBody stId)) - $(← withNaryArg 5 (delabBody stId)))
-    | HMul.hMul _ _ _ _ _ _ =>
-      `($(← withNaryArg 4 (delabBody stId)) * $(← withNaryArg 5 (delabBody stId)))
-    | Eq _ l r =>
-      -- `Bexp.eval st b = true` is the threaded form of a bare boolean `b`
-      if r.isConstOf ``Bool.true && l.isAppOfArity ``Bexp.eval 2
-          && l.appFn!.appArg! == .fvar stId then
-        withNaryArg 1 <| withAppArg delab
-      else
-        `($(← withNaryArg 1 (delabBody stId)) = $(← withNaryArg 2 (delabBody stId)))
-    | Ne _ _ _ =>
-      `($(← withNaryArg 1 (delabBody stId)) ≠ $(← withNaryArg 2 (delabBody stId)))
-    | LE.le _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) ≤ $(← withNaryArg 3 (delabBody stId)))
-    | LT.lt _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) < $(← withNaryArg 3 (delabBody stId)))
-    | GE.ge _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) ≥ $(← withNaryArg 3 (delabBody stId)))
-    | GT.gt _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) > $(← withNaryArg 3 (delabBody stId)))
-    | And _ _ =>
-      `($(← withNaryArg 0 (delabBody stId)) ∧ $(← withNaryArg 1 (delabBody stId)))
-    | Or _ _ =>
-      `($(← withNaryArg 0 (delabBody stId)) ∨ $(← withNaryArg 1 (delabBody stId)))
-    | Iff _ _ =>
-      `($(← withNaryArg 0 (delabBody stId)) ↔ $(← withNaryArg 1 (delabBody stId)))
-    | Not _ =>
-      `(¬ $(← withAppArg (delabBody stId)))
-    | _ =>
-      if e.isArrow then
-        `($(← withBindingDomain (delabBody stId)) →
-          $(← withBindingBody `h (delabBody stId)))
-      else if let .app f v := e then
-        -- an applied assertion `P st` (or an applied escape lambda)
-        guard (v == .fvar stId)
-        guard !(f.containsFVar stId)
-        withAppFn delab
-      else
-        failure
-
-/-- Print an `Assertion`-valued term as it appears inside `{{ … }}`: a
-state lambda is un-threaded; a term the printer cannot rebuild falls back
-to the raw lambda, which is exactly this notation's escape form. -/
-partial def delabAssn : DelabM Term := do
-  if (← getExpr).isLambda then
-    (withBindingBody' `st (pure ·.fvarId!) fun stId => delabBody stId)
-      <|> Delaborator.delab
-  else
-    delab
-
-@[delab app.ValidHoareTriple]
-def delabTriple : Delab := whenPPOption getPPNotation do
-  guard <| (← getExpr).isAppOfArity ``ValidHoareTriple 3
-  let P ← withNaryArg 0 delabAssn
-  let c ← withNaryArg 1 delabComInner
-  let Q ← withNaryArg 2 delabAssn
-  `({{ $P }} $c:imp_com {{ $Q }})
-
-/-- Print an assertion-position argument: a state lambda gets the
-`{{ … }}` notation; any other term (a named assertion, a substitution)
-already reads well bare. -/
-def delabAssnArg (i : Nat) : DelabM Term := do
-  if (← withNaryArg i getExpr).isLambda then
-    `({{ $(← withNaryArg i delabAssn) }})
-  else
-    withNaryArg i Delaborator.delab
-
-@[delab app.AssertImplies]
-def delabAssertImplies : Delab := whenPPOption getPPNotation do
-  guard <| (← getExpr).isAppOfArity ``AssertImplies 2
-  `($(← delabAssnArg 0) ->> $(← delabAssnArg 1))
-
-@[delab app.Assertion.subst]
-def delabSub : Delab := whenPPOption getPPNotation do
-  guard <| (← getExpr).isAppOfArity ``Assertion.subst 3
-  let `($x:ident) ← withNaryArg 0 delab | failure
-  let a ← withNaryArg 1 delabAexpInner
-  let P ← withNaryArg 2 delabAssn
-  if (← withNaryArg 2 getExpr).isLambda then
-    `({{ $P }} [$x:ident ↦ $a:imp_aexp])
-  else
-    `($P [$x:ident ↦ $a:imp_aexp])
-
-end Assertion.Delab
-```
-::::
-
-:::ignore
-```lean -show
-/-- info: {{X ≤ 5}} X := X + 1 {{X ≤ 7}} : Prop -/
-#guard_msgs in
-#check {{ X ≤ 5 }} X := X + 1 {{ X ≤ 7 }}
-
-/-- info: {{X < 4}} ->> {{X < 5}} : Prop -/
-#guard_msgs in
-#check ({{ X < 4 }} ->> {{ X < 5 }})
-
-/-- info: {{X ≤ 10}} [X ↦ 2 * X] : Assertion -/
-#guard_msgs in
-#check {{ X ≤ 10 }} [X ↦ 2 * X]
-```
-:::
-
 :::slidebreak
 :::
 
@@ -1709,7 +1770,7 @@ Here's a first formal proof of a Hoare triple using this rule.
 
 ```lean
 theorem assertion_sub_example :
-    {{ {{ X < 5 }} [X ↦ X + 1] }}
+    {{ (X < 5) [X ↦ X + 1] }}
       X := X + 1
     {{ X < 5 }} := by
   exact hoare_asgn
@@ -1745,7 +1806,7 @@ theorem hoare_asgn_examples1 :
         X := 2 * X
       {{ X ≤ 10 }} := by
   solution!
-    exists {{ X ≤ 10 }} [X ↦ 2 * X]
+    exists ({{ (X ≤ 10) [X ↦ 2 * X] }})
     exact hoare_asgn
 ```
 :::::
@@ -1758,7 +1819,7 @@ theorem hoare_asgn_examples2 :
         X := 3
       {{ 0 ≤ X ∧ X ≤ 5 }} := by
   solution!
-    exists {{ 0 ≤ X ∧ X ≤ 5 }} [X ↦ 3]
+    exists ({{ (0 ≤ X ∧ X ≤ 5) [X ↦ 3] }})
     exact hoare_asgn
 ```
 :::::
@@ -2136,7 +2197,7 @@ tried it in class.
 theorem hoare_asgn_example1 :
     {{True}} X := 1 {{X = 1}} := by
   workinclass!
-    apply hoare_consequence_pre (P' := {{X = 1}} [X ↦ 1])
+    apply hoare_consequence_pre (P' := {{ (X = 1) [X ↦ 1] }})
     · exact hoare_asgn
     · rw [assertImplies_def]
       intro st _
@@ -2167,7 +2228,7 @@ theorem assertion_sub_example2 :
       X := X + 1
     {{X < 5}} := by
   workinclass!
-    apply hoare_consequence_pre (P' := {{X < 5}} [X ↦ X + 1])
+    apply hoare_consequence_pre (P' := {{ (X < 5) [X ↦ X + 1] }})
     · exact hoare_asgn
     · rw [assertImplies_def]
       intro st h
@@ -2315,7 +2376,7 @@ theorem hoare_asgn_example1' :
     {{True}} X := 1 {{X = 1}} := by
   apply hoare_consequence_pre -- not specifying `(P' := ...)` leaves a "hole" `?P'`
   · -- The goal is `{{?P'}} X := 1 {{X = 1}}`
-    exact hoare_asgn -- Assigns `?P'` to `{{X = 1}} [X ↦ 1]` (automatically closing the `case P'`)
+    exact hoare_asgn -- Assigns `?P'` to `{{ (X = 1) [X ↦ 1] }}` (automatically closing the `case P'`)
   · rw [assertImplies_def]
     intro st _
     simp

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -1565,17 +1565,6 @@ Introduce a notation typeclass for this (e.g. HasSubst)
 A lot of the substitutions use `[x ↦ ~a]`. Could we have syntax support for `[x ↦ a]`. A naive approach that adds `" [" ident " ↦ " term "]" ` leads to ambiguity.
 :::
 
-:::dev "Niklas Halonen (xhalo32)" NOW
-We need to add an unexpander for the substitution notation which is another argument for HasSubst typeclass.
-:::
-
-:::dev "Niklas Halonen (xhalo32)"
-Is it possible to move the substitution syntax inside the braces like in the original Rocq material?
-I.e. `{{ (X ≤ 10) [X ↦ 2 * X] }}` vs. `{{ X ≤ 10 }} [X ↦ 2 * X]`
-
-Currently in triples we need to write `{{ {{ X < 5 }} [X ↦ X + 1] }}` which looks ugly.
-:::
-
 ```lean
 namespace Assertion
 
@@ -1618,21 +1607,37 @@ P [ X ↦ a ]
 namespace Assertion.Delab
 open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
 
-/-- Print an `Assertion.subst` back in `P [x ↦ a]` notation. -/
+/-- Print an `Assertion.subst` back in `P [x ↦ a]` notation.  Emits the
+bare inside-the-braces form: the generic application case of `delabBody`
+picks it up inside an assertion body, and the enclosing printer supplies
+the single pair of braces. -/
 @[delab app.Assertion.subst]
 def delabSub : Delab := whenPPOption getPPNotation do
   guard <| (← getExpr).isAppOfArity ``Assertion.subst 3
   let `($x:ident) ← withNaryArg 0 delab | failure
   let a ← withNaryArg 1 delabAexpInner
-  let P ← withNaryArg 2 delabAssn
   if (← withNaryArg 2 getExpr).isLambda then
-    `({{ $P }} [$x:ident ↦ $a:imp_aexp])
+    `(($(← withNaryArg 2 delabAssn)) [$x:ident ↦ $a:imp_aexp])
   else
-    `($P [$x:ident ↦ $a:imp_aexp])
+    match ← withNaryArg 2 delab with
+    | `($P:ident) => `($P:ident [$x:ident ↦ $a:imp_aexp])
+    | P => `(($P) [$x:ident ↦ $a:imp_aexp])
 
 end Assertion.Delab
 ```
 ::::
+
+:::ignore
+```lean -show
+/-- info: {{(X ≤ 10) [X ↦ 2 * X]}} : State → Prop -/
+#guard_msgs in
+#check {{ (X ≤ 10) [X ↦ 2 * X] }}
+
+/-- info: (X ≤ 10) [X ↦ 2 * X] : Assertion -/
+#guard_msgs in
+#check (Assertion.subst X (aexp { 2 * X }) {{ X ≤ 10 }})
+```
+:::
 
 That is, `P [X ↦ a]` stands for an assertion -- let's call it
 `P'` -- that behaves just like `P` except that, wherever `P` looks up
@@ -1747,10 +1752,6 @@ give the precise proof rule for assignment:
 
 We can prove formally that this rule is indeed valid.
 
-:::dev "Niklas Halonen (xhalo32)" NOW
-The delaboration for `x := ~a` seems to be broken now that I made sequencing use semicolons.
-:::
-
 ```lean
 theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
     {{ Q [x ↦ ~a] }} x := ~a {{ Q }} := by
@@ -1762,6 +1763,16 @@ theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
     rw [Assertion.subst_def] at hQ
     exact hQ
 ```
+
+:::ignore
+```lean -show
+/--
+info: @hoare_asgn : ∀ {Q : Assertion} {x : Ident} {a : Aexp}, {{Q [x ↦ ~a]}} x := ~a {{Q}}
+-/
+#guard_msgs in
+#check @hoare_asgn
+```
+:::
 
 :::slidebreak
 :::
@@ -2270,18 +2281,15 @@ Many of the proofs we have done so far with Hoare triples can be
 streamlined using the automation techniques that we introduced in
 the _Automation_ chapter of _Logical Foundations_.
 
-:::dev "Niklas Halonen (xhalo32)" NOW
-The following paragraph is outdated.
-We already have characterizing lemmas like `validHoareTriple_def`, but rarely do we need to use them with `simp`.
-:::
-
-Recall that the `simp` tactic can be told to unfold definitions as
-part of its simplifications.  The definitions we keep needing to
-unfold in this chapter are `ValidHoareTriple`, `AssertImplies`,
-`Assertion.sub`, the lifting functions `Assertion.ofProp`,
-`Aexp'.ofNat`, and `Aexp'.ofAexp`, and the total-map operations.
-We'll pass these to `simp` explicitly below (and shortly package the
-recipe up as a tactic of our own).
+Recall that `simp` rewrites with any lemmas we pass it.  The
+definitions whose meaning we keep needing to expose in this chapter --
+`ValidHoareTriple`, `AssertImplies`, and `Assertion.subst` -- each
+come with a characterizing lemma (`validHoareTriple_def`,
+`assertImplies_def`, `Assertion.subst_def`) restating the definition
+as an equation.  Passing these lemmas to `simp` replaces the defined
+notions by their meanings wherever they appear.  We'll do that
+explicitly below (and shortly package the recipe up as a tactic of
+our own).
 
 :::dev "Claude"
 The Rocq source here registers `Hint Unfold assert_implies assertion_sub
@@ -2289,7 +2297,7 @@ t_update : core` for `auto`.  That only widens `auto`'s search (unlike the
 `Arguments /.` commands, it does not affect `simpl`), so its Lean
 counterpart is the `assertion_auto` tactic's simp list below -- not global
 `@[simp]` lemmas as for the notation wrappers, whose folded names carry no
-meaning in goals the way `->>` and `Assertion.sub` do.
+meaning in goals the way `->>` and `Assertion.subst` do.
 :::
 
 :::dev "Niklas Halonen (xhalo32)" NOW

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -3053,7 +3053,7 @@ inductive Com.EvalR : Com → State → State → Prop where
       EvalR (imp {if1 (~b) {~c} }) st st
 -- END SOLUTION
 
-instance : HasEval Com State where
+instance : HasEval Com State State where
   Eval := Com.EvalR
 
 @[app_unexpander Com.EvalR]
@@ -3969,7 +3969,7 @@ inductive Com.EvalR : Com → State → State → Prop where
       EvalR (imp {repeat {~c} until (~b) }) st st''
 -- END SOLUTION
 
-instance : HasEval Com State where
+instance : HasEval Com State State where
   Eval := Com.EvalR
 
 @[app_unexpander Com.EvalR]
@@ -4040,7 +4040,7 @@ as it goes, but it isn't going to lead to a nice rule for decorated
 programs, when we get to that, because it uses c twice, perhaps in
 different ways! -/
 
-theorem hoare_repeat (P Q : Assertion) (b : Bexp) (c : Com)
+theorem hoare_repeat {P Q : Assertion} {b : Bexp} {c : Com}
     (h1 : {{ P }} ~c {{ Q }}) (h2 : {{ Q ∧ ¬ b }} ~c {{ Q }}) :
     {{ P }} repeat { ~c } until (~b) {{ Q ∧ b }} := by
   rw [validHoareTriple_def] at h1 h2 ⊢
@@ -4054,7 +4054,7 @@ theorem hoare_repeat (P Q : Assertion) (b : Bexp) (c : Com)
   | repeatLoop s0 s0' s0'' b0 c0 hc hb hloop ih1 ih2 =>
     injection heq with hceq hbeq
     subst hceq hbeq
-    apply ih2 _ h2 _ rfl
+    apply ih2 h2 _ rfl
     constructor
     · exact h1 hc hpre
     · simp [hb]
@@ -4386,113 +4386,94 @@ inductive Com : Type where
   | whileDo : Bexp → Com → Com
   | havoc : Ident → Com
 
-/-- Himp commands: Imp commands plus `havoc` -/
-declare_syntax_cat himp_com
 /-- Havoc: set a variable to a nondeterministically chosen number
 (`havoc x;`).  As with `skip`, the word `havoc` is not reserved: the
 production accepts any identifier and the macro below rejects
 everything except `havoc`. -/
-syntax ident ident ";" : himp_com
-```
-
-:::instructors
-Copy of template com
-:::
-
-```lean
-/-- The command that does nothing (`skip;`) -/
-syntax ident ";" : himp_com
-/-- Sequencing: one command after another -/
-syntax himp_com ppDedent(ppLine himp_com) : himp_com
-/-- Assignment -/
-syntax ident " := " imp_aexp ";" : himp_com
-/-- Conditional -/
-syntax "if " "(" imp_bexp ")" ppHardSpace "{" ppLine himp_com ppDedent(ppLine "}" ppHardSpace "else" ppHardSpace "{") ppLine himp_com ppDedent(ppLine "}") : himp_com
-/-- Loop -/
-syntax "while " "(" imp_bexp ")" ppHardSpace "{" ppLine himp_com ppDedent(ppLine "}") : himp_com
-/-- Escape to Lean -/
-syntax:max "~" term:max : himp_com
-
-/-- Include a Himp command in Lean code -/
-syntax:min "imph" ppHardSpace "{" ppLine himp_com ppDedent(ppLine "}") : term
+scoped syntax ident ident : imp_com
 
 open Lean in
-macro_rules
-  | `(imph { $x:ident ; }) =>
+scoped macro_rules
+  | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
     else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
-  | `(imph { $c1 $c2 }) =>
-    `(Com.seq (imph {$c1}) (imph {$c2}))
-  | `(imph { $x:ident := $a; }) =>
+  | `(imp { $c1; $c2 }) =>
+    `(Com.seq (imp {$c1}) (imp {$c2}))
+  | `(imp { $x:ident := $a }) =>
     `(Com.asgn $x (aexp {$a}))
-  | `(imph { if ($b) {$c1} else {$c2} }) =>
-    `(Com.cond (bexp {$b}) (imph {$c1}) (imph {$c2}))
-  | `(imph { while ($b) {$c} }) =>
-    `(Com.whileDo (bexp {$b}) (imph {$c}))
-  | `(imph { $h:ident $x:ident ; }) =>
+  | `(imp { if ($b) {$c1} else {$c2} }) =>
+    `(Com.cond (bexp {$b}) (imp {$c1}) (imp {$c2}))
+  | `(imp { while ($b) {$c} }) =>
+    `(Com.whileDo (bexp {$b}) (imp {$c}))
+  | `(imp { $h:ident $x:ident }) =>
     if h.getId == `havoc then `(Com.havoc $x)
     else Macro.throwErrorAt h s!"expected 'havoc', got '{h.getId}'"
-  | `(imph { ~$c }) =>
+  | `(imp { ~$c }) =>
     pure c
 
 inductive Com.EvalR : Com → State → State → Prop where
   | skip (st : State) :
-      EvalR (imph {skip;}) st st
+      EvalR (imp {skip}) st st
   | asgn (st : State) (a : Aexp) (n : Nat) (x : Ident) (h : a.eval st = n) :
-      EvalR (imph {x := ~a;}) st (x →ₜ n ; st)
+      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
   | seq (c1 c2 : Com) (st st' st'' : State)
       (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
-      EvalR (imph {~c1 ~c2}) st st''
+      EvalR (imp {~c1; ~c2}) st st''
   | ifTrue (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
-      EvalR (imph {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
   | ifFalse (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = false)
       (hc : EvalR c2 st st') :
-      EvalR (imph {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
   | whileFalse (b : Bexp) (st : State) (c : Com) (hb : b.eval st = false) :
-      EvalR (imph {while (~b) {~c} }) st st
+      EvalR (imp {while (~b) {~c} }) st st
   | whileTrue (st st' st'' : State) (b : Bexp) (c : Com)
       (hb : b.eval st = true) (hc : EvalR c st st')
-      (hloop : EvalR (imph {while (~b) {~c} }) st' st'') :
-      EvalR (imph {while (~b) {~c} }) st st''
+      (hloop : EvalR (imp {while (~b) {~c} }) st' st'') :
+      EvalR (imp {while (~b) {~c} }) st st''
   | havoc (st : State) (x : Ident) (n : Nat) :
-      EvalR (imph {havoc x;}) st (x →ₜ n ; st)
+      EvalR (imp {havoc x}) st (x →ₜ n ; st)
 
-scoped notation:40 (priority := high) st0:41 " =[ " c " ]=> " st1:41 =>
-  Com.EvalR c st0 st1
-scoped syntax:40 (priority := high) term:41 " =[ " himp_com " ]=> " term:41 : term
-scoped macro_rules
-  | `($st0 =[ $c:himp_com ]=> $st1) => `($st0 =[ imph { $c } ]=> $st1)
+instance : HasEval Com State State where
+  Eval := Com.EvalR
+
+@[app_unexpander Com.EvalR]
+def Com.unexpandEvalR : Lean.PrettyPrinter.Unexpander
+  | `($_ $c $st0 $st1) => ``($st0 =[ ~$c ]=> $st1)
+  | _ => throw ()
 ```
 
 The definition of Hoare triples is exactly as before.
 
 ```lean
-def ValidHoareTriple (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
-  ∀ st st', (st =[ c ]=> st') → P st → Q st'
+def ValidHoareTriple
+    (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
+  ∀ {st st' : State},
+    (st =[ c ]=> st') →
+    P st →
+    Q st'
 
-namespace ValidHoareTriple
+instance : HasTriple Com where
+  Triple := ValidHoareTriple
 
-/-- Hoare triple over Himp commands -/
-scoped syntax:lead "{{" term "}} " himp_com:lead " {{" term "}}" : term
+theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
+    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
+      P st →
+      Q st' := by rfl
 
-macro_rules
-  | `({{ $P }} $c:himp_com {{ $Q }}) =>
-      `(ValidHoareTriple ({{ $P }}) (imph { $c }) ({{ $Q }}))
-
-end ValidHoareTriple
-
-open scoped ValidHoareTriple
+attribute [irreducible] ValidHoareTriple
 ```
 
 And the precondition consequence rule is exactly as before.
 
 ```lean
-theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
+theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
-  exact hhoare st st' heval (himp st hpre)
+  apply_rules
 ```
 
 :::::exercise (rating := 3) (name := "hoare_havoc") (level := Advanced)
@@ -4507,15 +4488,19 @@ Complete the Hoare rule for `havoc` commands below by defining
 
 ```lean
 def havoc_pre (x : Ident) (Q : Assertion) (st : State) : Prop :=
-  solution!(∀ (n : Nat), Assertion.sub x (.num n) Q st)
+  solution!(∀ (n : Nat), ({{ Q [x ↦ ~(.num n)] }}) st)
 
-theorem hoare_havoc (Q : Assertion) (x : Ident) :
-    {{ fun st => havoc_pre x Q st }} havoc x; {{ Q }} := by
+theorem hoare_havoc {Q : Assertion} {x : Ident} :
+    {{ fun st => havoc_pre x Q st }} havoc x {{ Q }} := by
   solution!
-    rw [validHoareTriple_def] havoc_pre
+    rw [validHoareTriple_def]
     intro st st' heval hpre
+    rw [havoc_pre] at hpre
     inversion heval with
-    | havoc n => apply hpre
+    | havoc n =>
+      specialize hpre n
+      simp only [Assertion.subst_apply, Aexp.eval_num] at hpre
+      exact hpre
 ```
 :::::
 
@@ -4551,19 +4536,18 @@ optional.
 :::
 
 ```lean
-theorem havoc_post (P : Assertion) (x : Ident) :
-    {{ P }} havoc x;
-    {{ fun st => ∃ (n : Nat), ({{ P [x ↦ ~(Aexp.num n)] }}) st }} := by
+theorem havoc_post {P : Assertion} {x : Ident} :
+    {{ P }}
+    havoc x
+    {{ fun st => ∃ (n : Nat), ({{ P [x ↦ ~(.num n)] }}) st }} := by
   apply hoare_consequence_pre
   · apply hoare_havoc
-  ·
-    solution!
-      unfold havoc_pre AssertImplies Assertion.sub
-      intro st hP n
+  · solution!
+      intro st hpre n
+      simp only [Assertion.subst_apply, Aexp.eval_num, TotalMap.update_shadow]
       exists st[x]
-      dsimp
-      rw [TotalMap.update_shadow, TotalMap.update_same]
-      apply hP
+      rw [TotalMap.update_same]
+      exact hpre
 ```
 :::::
 
@@ -4616,53 +4600,29 @@ NOTATION: LATER: Reconsider these precedences
 :::
 
 ```lean
-/-- Imp commands plus `assert` and `assume` -/
-declare_syntax_cat haa_com
 /-- Assert / assume (`assert (b);`, `assume (b);`).  As with `skip`, the
 words `assert` and `assume` are not reserved: the production accepts any
 identifier and the macro below rejects everything else. -/
-syntax ident " (" imp_bexp ")" ";" : haa_com
-```
-
-:::instructors
-Copy of template com
-:::
-
-```lean
-/-- The command that does nothing (`skip;`) -/
-syntax ident ";" : haa_com
-/-- Sequencing: one command after another -/
-syntax haa_com ppDedent(ppLine haa_com) : haa_com
-/-- Assignment -/
-syntax ident " := " imp_aexp ";" : haa_com
-/-- Conditional -/
-syntax "if " "(" imp_bexp ")" ppHardSpace "{" ppLine haa_com ppDedent(ppLine "}" ppHardSpace "else" ppHardSpace "{") ppLine haa_com ppDedent(ppLine "}") : haa_com
-/-- Loop -/
-syntax "while " "(" imp_bexp ")" ppHardSpace "{" ppLine haa_com ppDedent(ppLine "}") : haa_com
-/-- Escape to Lean -/
-syntax:max "~" term:max : haa_com
-
-/-- Include an assert/assume-Imp command in Lean code -/
-syntax:min "impa" ppHardSpace "{" ppLine haa_com ppDedent(ppLine "}") : term
+scoped syntax ident " (" imp_bexp ")" : imp_com
 
 open Lean in
-macro_rules
-  | `(impa { $x:ident ; }) =>
+scoped macro_rules
+  | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
     else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
-  | `(impa { $h:ident ($b) ; }) =>
+  | `(imp { $h:ident ($b) }) =>
     if h.getId == `assert then `(Com.assert (bexp {$b}))
     else if h.getId == `assume then `(Com.assume (bexp {$b}))
     else Macro.throwErrorAt h s!"expected 'assert' or 'assume', got '{h.getId}'"
-  | `(impa { $c1 $c2 }) =>
-    `(Com.seq (impa {$c1}) (impa {$c2}))
-  | `(impa { $x:ident := $a; }) =>
+  | `(imp { $c1; $c2 }) =>
+    `(Com.seq (imp {$c1}) (imp {$c2}))
+  | `(imp { $x:ident := $a }) =>
     `(Com.asgn $x (aexp {$a}))
-  | `(impa { if ($b) {$c1} else {$c2} }) =>
-    `(Com.cond (bexp {$b}) (impa {$c1}) (impa {$c2}))
-  | `(impa { while ($b) {$c} }) =>
-    `(Com.whileDo (bexp {$b}) (impa {$c}))
-  | `(impa { ~$c }) =>
+  | `(imp { if ($b) {$c1} else {$c2} }) =>
+    `(Com.cond (bexp {$b}) (imp {$c1}) (imp {$c2}))
+  | `(imp { while ($b) {$c} }) =>
+    `(Com.whileDo (bexp {$b}) (imp {$c}))
+  | `(imp { ~$c }) =>
     pure c
 ```
 
@@ -4678,7 +4638,7 @@ either a state or an error:
 
 ```lean
 inductive Result : Type where
-  | normal : State → Result
+  | normal (st : State) : Result
   | error : Result
 ```
 
@@ -4689,42 +4649,44 @@ language.
 inductive Com.EvalR : Com → State → Result → Prop where
   /- Old rules, several modified -/
   | skip (st : State) :
-      EvalR (impa {skip;}) st (.normal st)
+      EvalR (imp {skip}) st (.normal st)
   | asgn (st : State) (a : Aexp) (n : Nat) (x : Ident) (h : a.eval st = n) :
-      EvalR (impa {x := ~a;}) st (.normal (x →ₜ n ; st))
+      EvalR (imp {x := ~a}) st (.normal (x →ₜ n ; st))
   | seqNormal (c1 c2 : Com) (st st' : State) (r : Result)
       (h1 : EvalR c1 st (.normal st')) (h2 : EvalR c2 st' r) :
-      EvalR (impa {~c1 ~c2}) st r
+      EvalR (imp {~c1; ~c2}) st r
   | seqError (c1 c2 : Com) (st : State) (h : EvalR c1 st .error) :
-      EvalR (impa {~c1 ~c2}) st .error
+      EvalR (imp {~c1; ~c2}) st .error
   | ifTrue (st : State) (r : Result) (b : Bexp) (c1 c2 : Com)
       (hb : b.eval st = true) (hc : EvalR c1 st r) :
-      EvalR (impa {if (~b) {~c1} else {~c2} }) st r
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st r
   | ifFalse (st : State) (r : Result) (b : Bexp) (c1 c2 : Com)
       (hb : b.eval st = false) (hc : EvalR c2 st r) :
-      EvalR (impa {if (~b) {~c1} else {~c2} }) st r
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st r
   | whileFalse (b : Bexp) (st : State) (c : Com) (hb : b.eval st = false) :
-      EvalR (impa {while (~b) {~c} }) st (.normal st)
+      EvalR (imp {while (~b) {~c} }) st (.normal st)
   | whileTrueNormal (st st' : State) (r : Result) (b : Bexp) (c : Com)
       (hb : b.eval st = true) (hc : EvalR c st (.normal st'))
-      (hloop : EvalR (impa {while (~b) {~c} }) st' r) :
-      EvalR (impa {while (~b) {~c} }) st r
+      (hloop : EvalR (imp {while (~b) {~c} }) st' r) :
+      EvalR (imp {while (~b) {~c} }) st r
   | whileTrueError (st : State) (b : Bexp) (c : Com)
       (hb : b.eval st = true) (hc : EvalR c st .error) :
-      EvalR (impa {while (~b) {~c} }) st .error
+      EvalR (imp {while (~b) {~c} }) st .error
   /- Rules for Assert and Assume -/
   | assertTrue (st : State) (b : Bexp) (hb : b.eval st = true) :
-      EvalR (impa {assert (~b);}) st (.normal st)
+      EvalR (imp {assert (~b)}) st (.normal st)
   | assertFalse (st : State) (b : Bexp) (hb : b.eval st = false) :
-      EvalR (impa {assert (~b);}) st .error
+      EvalR (imp {assert (~b)}) st .error
   | assume (st : State) (b : Bexp) (hb : b.eval st = true) :
-      EvalR (impa {assume (~b);}) st (.normal st)
+      EvalR (imp {assume (~b)}) st (.normal st)
 
-scoped notation:40 (priority := high) st0:41 " =[ " c " ]=> " r:41 =>
-  Com.EvalR c st0 r
-scoped syntax:40 (priority := high) term:41 " =[ " haa_com " ]=> " term:41 : term
-scoped macro_rules
-  | `($st0 =[ $c:haa_com ]=> $r) => `($st0 =[ impa { $c } ]=> $r)
+instance : HasEval Com State Result where
+  Eval := Com.EvalR
+
+@[app_unexpander Com.EvalR]
+def Com.unexpandEvalR : Lean.PrettyPrinter.Unexpander
+  | `($_ $c $st0 $st1) => ``($st0 =[ ~$c ]=> $st1)
+  | _ => throw ()
 ```
 
 We redefine hoare triples: Now, `{{ P }} c {{ Q }}` means that,
@@ -4735,9 +4697,19 @@ satisfies `Q`.
 ```lean
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
-  ∀ st r,
+  ∀ {st : State} {r : Result},
     (st =[ c ]=> r) → P st →
-    (∃ st', r = Result.normal st' ∧ Q st')
+    ∃ st', r = Result.normal st' ∧ Q st'
+
+instance : HasTriple Com where
+  Triple := ValidHoareTriple
+
+theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
+    {{ P }} ~c {{ Q }} ↔ ∀ {st : State} {r : Result},
+      (st =[ c ]=> r) → P st →
+      ∃ st', r = Result.normal st' ∧ Q st' := by rfl
+
+attribute [irreducible] ValidHoareTriple
 ```
 
 :::dev PotentialImprovement
@@ -4746,21 +4718,6 @@ up.  It doesn't work very well for the proofs of hoare rules to
 have `exists st'` in the conclusion.  BCP 10/18: Not sure what sort
 of cleaning up would be useful...
 :::
-
-```lean
-namespace ValidHoareTriple
-
-/-- Hoare triple over assert/assume-Imp commands -/
-scoped syntax:lead "{{" term "}} " haa_com:lead " {{" term "}}" : term
-
-macro_rules
-  | `({{ $P }} $c:haa_com {{ $Q }}) =>
-      `(ValidHoareTriple ({{ $P }}) (impa { $c }) ({{ $Q }}))
-
-end ValidHoareTriple
-
-open scoped ValidHoareTriple
-```
 
 ::::::
 
@@ -4772,23 +4729,28 @@ statement but not by the `assert` statement.
 
 ```lean
 theorem assert_assume_differ : ∃ (P : Assertion) (b : Bexp) (Q : Assertion),
-    ({{ P }} assume (~b); {{ Q }})
-    ∧ ¬ ({{ P }} assert (~b); {{ Q }}) := by
+    ({{ P }} assume (~b) {{ Q }})
+    ∧ ¬ ({{ P }} assert (~b) {{ Q }}) := by
   solution!
-    exists {{ True }}, bexp { false }, ({{ False }} : Assertion)
+    exists {{ True }}, bexp { false }, ({{ False }})
     constructor
     · rw [validHoareTriple_def]
-      intro st r hE _
-      inversion hE with
+      intro st r heval _
+      inversion heval with
       | assume hb => simp at hb
     · intro hC
       rw [validHoareTriple_def] at hC
-      have h : ∅ =[ assert (false); ]=> Result.error := by
+      have h : ∅ =[ assert (false) ]=> Result.error := by
         apply Com.EvalR.assertFalse
-        rfl
-      obtain ⟨st', heq, _⟩ := hC ∅ Result.error h True.intro
-      simp at heq
+        simp
+      obtain ⟨st', h1, h2⟩ := hC h True.intro
+      contradiction
 ```
+
+:::dev "Niklas Halonen (xhalo32)"
+For some reason, after `rw [validHoareTriple_def] at hC`, the existence turns into `Exists ({{r = Result.normal ∧ False}})`.
+Maybe it's the assertion delaborator?
+:::
 
 :::gradeTheorem 1 assert_assume_differ
 :::
@@ -4798,20 +4760,20 @@ Then prove that any triple for an `assert` also works when
 
 ```lean
 theorem assert_implies_assume (P : Assertion) (b : Bexp) (Q : Assertion)
-    (hhoare : {{ P }} assert (~b); {{ Q }}) :
-    {{ P }} assume (~b); {{ Q }} := by
+    (hhoare : {{ P }} assert (~b) {{ Q }}) :
+    {{ P }} assume (~b) {{ Q }} := by
   solution!
-    rw [validHoareTriple_def]
-    intro st r hEval hP
-    inversion hEval with
+    rw [validHoareTriple_def] at hhoare ⊢
+    intro st r heval hpre
+    inversion heval with
     | assume hb =>
       exists st
-      have h : st =[ assert (~b); ]=> Result.normal st := by
+      have h : st =[ assert (~b) ]=> Result.normal st := by
         apply Com.EvalR.assertTrue
         assumption
-      obtain ⟨st', h1, h2⟩ := hhoare st (Result.normal st) h hP
-      injection h1 with e
-      subst e
+      obtain ⟨st', h1, h2⟩ := hhoare h hpre
+      injection h1 with hsteq
+      subst hsteq
       exact ⟨rfl, h2⟩
 ```
 
@@ -4825,24 +4787,23 @@ Next, here are proofs for the old hoare rules adapted to the new
 semantics.  You don't need to do anything with these.
 
 ```lean
-theorem hoare_asgn (Q : Assertion) (x : Ident) (a : Aexp) :
-    {{Q [x ↦ ~a]}} x := ~a; {{ Q }} := by
-  unfold ValidHoareTriple
-  intro st r hE hQ
-  inversion hE with
+theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
+    {{Q [x ↦ ~a]}} x := ~a {{ Q }} := by
+  rw [validHoareTriple_def]
+  intro st r heval hQ
+  rw [Assertion.subst_apply] at hQ
+  inversion heval with
   | asgn n h =>
     exists (x →ₜ n ; st)
     subst h
     exact ⟨rfl, hQ⟩
 
-theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
+theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
-  intro st r hc hP
-  apply hhoare st r
-  · assumption
-  · apply himp
-    assumption
+  rw [validHoareTriple_def] at hhoare ⊢
+  intro st r hc hpre
+  apply_rules
 ```
 
 :::dev PotentialImprovement
@@ -4850,40 +4811,33 @@ These proofs are a bit messy. Can it be made shorter?
 :::
 
 ```lean
-theorem hoare_consequence_post (P Q Q' : Assertion) (c : Com)
+theorem hoare_consequence_post {P Q Q' : Assertion} {c : Com}
     (hhoare : {{ P }} ~c {{ Q' }}) (himp : Q' ->> Q) :
-    {{ P }} ~c {{ Q }} := by
-  intro st r hc hP
-  unfold ValidHoareTriple at hhoare
-  have h : ∃ st', r = Result.normal st' ∧ Q' st' := by
-    apply hhoare st <;> assumption
-  obtain ⟨st', hr, hQ'⟩ := h
+    {{ P }} ~c {{   Q }} := by
+  rw [validHoareTriple_def] at hhoare ⊢
+  intro st r hc hpre
+  obtain ⟨st', hr, hQ'⟩ := hhoare hc hpre
   exists st'
-  constructor
-  · assumption
-  · apply himp
-    assumption
+  exact ⟨hr, himp _ hQ'⟩
 
-theorem hoare_seq (P Q R : Assertion) (c1 c2 : Com)
+theorem hoare_seq {P Q R : Assertion} {c1 c2 : Com}
     (h1 : {{ Q }} ~c2 {{R}}) (h2 : {{ P }} ~c1 {{ Q }}) :
-    {{ P }} ~c1 ~c2 {{R}} := by
-  intro st r h12 pre
+    {{ P }} ~c1; ~c2 {{R}} := by
+  rw [validHoareTriple_def] at h1 h2 ⊢
+  intro st r h12 hpre
   inversion h12 with
   | seqNormal st' hc1 hc2 =>
-    apply h1
-    · apply hc2
-    · apply h2 at hc1
-      apply hc1 at pre
-      obtain ⟨st'', heq, hQ⟩ := pre
-      injection heq with e
-      subst e
-      assumption
+    apply h1 hc2
+    specialize h2 hc1 hpre
+    obtain ⟨st'', heq, hQ⟩ := h2
+    injection heq with e
+    subst e
+    exact hQ
   | seqError hc1 =>
     -- Find contradictory assumption
-    apply h2 at hc1
-    apply hc1 at pre
-    obtain ⟨st', hC, _⟩ := pre
-    simp at hC
+    specialize h2 hc1 hpre
+    obtain ⟨st', hC, _⟩ := h2
+    contradiction
 ```
 
 :::dev PotentialImprovement
@@ -4896,67 +4850,53 @@ HIDE
 Here are the other proof rules (sanity check)
 
 ```lean
-theorem hoare_skip (P : Assertion) :
-    {{ P }} skip; {{ P }} := by
-  intro st r h hP
+theorem hoare_skip {P : Assertion} :
+    {{ P }} skip {{ P }} := by
+  rw [validHoareTriple_def]
+  intro st r h hpre
   inversion h
-  exact ⟨st, rfl, hP⟩
+  exact ⟨st, rfl, hpre⟩
 
-theorem hoare_if (P Q : Assertion) (b : Bexp) (c1 c2 : Com)
+theorem hoare_if {P Q : Assertion} {b : Bexp} {c1 c2 : Com}
     (hTrue : {{ P ∧ b}} ~c1 {{ Q }}) (hFalse : {{ P ∧ ¬ b}} ~c2 {{ Q }}) :
     {{ P }} if (~b) { ~c1 } else { ~c2 } {{ Q }} := by
-  intro st r hE hP
+  rw [validHoareTriple_def] at hTrue hFalse ⊢
+  intro st r hE hpre
   inversion hE with
   | ifTrue hb hc =>
     -- b is true
-    apply hTrue st r
-    · assumption
-    · exact ⟨hP, hb⟩
+    apply_rules [And.intro]
   | ifFalse hb hc =>
     -- b is false
-    apply hFalse st r
-    · assumption
-    · exact ⟨hP, bexp_eval_false b st hb⟩
+    apply hFalse hc
+    exact ⟨hpre, by simp [hb]⟩
 
-theorem hoare_while (P : Assertion) (b : Bexp) (c : Com)
+theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
     (hhoare : {{P ∧ b}} ~c {{ P }}) :
     {{ P }} while (~b) { ~c } {{ P ∧ ¬ b}} := by
-  intro st r he hP
-  have key : ∀ (cmd : Com) (s : State) (r' : Result), (s =[ cmd ]=> r') →
-      cmd = (impa { while (~b) { ~c } }) → P s →
-      ∃ s', r' = Result.normal s' ∧ P s' ∧ ¬ bassertion b s' := by
-    intro cmd s r' hev
-    induction hev with
-    | whileFalse b0 s0 c0 hb =>
-        intro heq hp
-        injection heq with e1 _
-        subst e1
-        exact ⟨s0, rfl, hp, bexp_eval_false _ _ hb⟩
-    | whileTrueNormal s0 s0' r0 b0 c0 hb hc hloop ih1 ih2 =>
-        intro heq hp
-        injection heq with e1 e2
-        subst e1 e2
-        apply ih2 rfl
-        obtain ⟨s1, heq1, hp1⟩ := hhoare _ _ hc ⟨hp, hb⟩
-        injection heq1 with e
-        subst e
-        exact hp1
-    | whileTrueError s0 b0 c0 hb hc =>
-        intro heq hp
-        injection heq with e1 e2
-        subst e1 e2
-        obtain ⟨s1, heq1, _⟩ := hhoare _ _ hc ⟨hp, hb⟩
-        simp at heq1
-    | skip s0 => intro heq; simp at heq
-    | asgn s0 a n x ha => intro heq; simp at heq
-    | seqNormal c1 c2 s0 s0' r0 hh1 hh2 ih1 ih2 => intro heq; simp at heq
-    | seqError c1 c2 s0 hh ih => intro heq; simp at heq
-    | ifTrue s0 r0 b0 c1 c2 hb hc ih => intro heq; simp at heq
-    | ifFalse s0 r0 b0 c1 c2 hb hc ih => intro heq; simp at heq
-    | assertTrue s0 b0 hb => intro heq; simp at heq
-    | assertFalse s0 b0 hb => intro heq; simp at heq
-    | assume s0 b0 hb => intro heq; simp at heq
-  exact key _ st r he rfl hP
+  rw [validHoareTriple_def] at hhoare ⊢
+  intro st r heval hpre
+  generalize heq : (imp { while (~b) { ~c } }) = cmd at heval
+  induction heval generalizing P with
+  | whileFalse b0 s0 c0 hb =>
+    injection heq with hbeq hceq
+    subst hbeq hceq
+    exact ⟨s0, rfl, hpre, by simp [hb]⟩
+  | whileTrueNormal s0 s0' r0 b0 c0 hb hc hloop ih1 ih2 =>
+    injection heq with hbeq hceq
+    subst hbeq hceq
+    apply ih2 hhoare _ rfl
+    obtain ⟨s1, heq1, hs1⟩ := hhoare hc ⟨hpre, hb⟩
+    injection heq1 with he
+    subst he
+    exact hs1
+  | whileTrueError s0 b0 c0 hb hc =>
+    injection heq with hbeq hceq
+    subst hbeq hceq
+    obtain ⟨s1, heq1, hs1⟩ := hhoare hc ⟨hpre, hb⟩
+    simp at heq1
+  | skip | asgn | seqNormal | seqError | ifTrue | ifFalse | assertTrue | assertFalse | assume =>
+    contradiction
 ```
 
 ::::::
@@ -4970,23 +4910,25 @@ and `hoare_assume`.
 -- SOLUTION
 /- HIDE: Equivalently, we could make the postcondition Q ∧ b or the
 precondition Q → b ... -/
-theorem hoare_assert (Q : Assertion) (b : Bexp) :
-    {{Q ∧ b}} assert (~b); {{ Q }} := by
-  intro st r hEval hpre
+theorem hoare_assert {Q : Assertion} {b : Bexp} :
+    {{Q ∧ b}} assert (~b) {{ Q }} := by
+  rw [validHoareTriple_def]
+  intro st r heval hpre
   obtain ⟨hst, hb⟩ := hpre
   exists st
-  inversion hEval with
+  inversion heval with
   | assertTrue hb' => exact ⟨rfl, hst⟩
   | assertFalse hb' => simp [hb'] at hb
 
 /- Stating this in a backwards-direction friendly way. -/
 /- HIDE: Equivalently, we could make the postcondition Q ∧ b... -/
-theorem hoare_assume (Q : Assertion) (b : Bexp) :
-    {{ b → Q }} assume (~b); {{ Q }} := by
-  intro st r hEval hst
+theorem hoare_assume {Q : Assertion} {b : Bexp} :
+    {{ b → Q }} assume (~b) {{ Q }} := by
+  rw [validHoareTriple_def]
+  intro st r heval hpre
   exists st
-  inversion hEval with
-  | assume hb => exact ⟨rfl, hst hb⟩
+  inversion heval with
+  | assume hb => exact ⟨rfl, hpre hb⟩
 -- END SOLUTION
 ```
 
@@ -4997,7 +4939,7 @@ theorem assert_assume_example :
     {{True}}
       assume (X = 1);
       X := X + 1;
-      assert (X = 2);
+      assert (X = 2)
     {{True}} := by
   solution!
     apply hoare_consequence_pre

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -70,6 +70,11 @@ for further exploration at some point...
 ````
 :::
 
+:::dev "Niklas Halonen (xhalo32)"
+Reply to Benjamin's note above:
+The way we do it now in Lean is to have a custom elaborater which avoids all the coercions plus doesn't need the syntax category for assertions.
+:::
+
 :::dev "Benjamin Pierce (bcpierce00)" BeforeNextRelease (year := 2021)
 Any chance we could move the (awkwardly placed)
 weakest precondition discussion to this chapter instead?
@@ -574,7 +579,7 @@ scoped syntax:max (name := assn) "assn(" ident "; " term ")" : term
 scoped syntax "{{" term "}}" : term
 
 @[term_elab assn]
-def assnElab : TermElab := fun stx type? => do
+def assnElab : TermElab := fun stx _type? => do
   match stx with
   | `(assn($st; $t:term)) =>
     let t ← elabTerm t none
@@ -629,6 +634,25 @@ macro_rules
 end
 ```
 
+:::dev "Niklas Halonen"
+Mention (don't explain macro hygiene though) why
+```
+#check {{ st[X] = st[Y] }}
+```
+doesn't work, but instead one should write
+```
+#check {{ fun st => st[X] = st[Y] }}
+```
+
+And mention that when inside the brackets, one sees in the infoview
+```
+st✝ : State
+```
+but outside the brackets, one sees `fun st => st[X] = st[X] : State → Prop`
+
+Also: should we introduce the terminology "pure" for embedding propositions into assertions that are constant functions?
+:::
+
 ```lean
 #check {{ 1 = 2 }}
 #check {{ X = X }}
@@ -653,6 +677,7 @@ variable (f : Nat → Nat → Nat → Nat)
 #check {{ f X Y X = 0 }}
 
 end Assertion
+open scoped Assertion
 ```
 
 ::::terse
@@ -683,56 +708,6 @@ We can place a raw Lean function directly inside assertion notation:
 For example: `{{ fun st => ∀ x, st[x] = 0 }}`
 ::::
 
-:::dev
-NOTATION: SAZ 2024: It is important that this custom notation be
-at a level higher than 1 when added to the `constr` grammar because
-it interacts with the "application" case of `com` and the notation
-for Hoare triples.  That grammar parses embedded function arguments
-at level 1. We never want `f {{P}}` to parse `{ P }` as an
-assertion when used in a command.  Instead we want `{{P}}` to
-"close" the Hoare triple.
-
-```
-NOTATION: Note for Rocq custom grammar hackers.  From what I can tell, the
-Rocq LL(1) parser does left-factorize the grammar, *however* it uses a very
-strict notion of what counts as "equal" for the purposes of the factorization.
-In particular, a grammar entry might have a level,
-as in [e custom assn at level 99] in the notation below.  Leaving out the
-"at level 99" is *semantically equivalent*, because the [assn] grammar starts
-at that level, but omitting it will not work because the grammar for
-Hoare triples below includes "at level 99" -- the [LEVEL "99"] part of the
-grammar counts for factorization.
-
-The upshot is that means that this notation and the Hoare triple notation
-(which overlaps with [{{ _ }}]) must be changed in tandem and use identical
-level specifications.
-```
-:::
-
-::::hide
-```
-/- NOTATION: SAZ 2024 : useful for debugging notations -- use
-[set_option pp.notation false] -/
-#check X  -- X : Ident
-#check (X : Aexp)  -- Aexp.id X
-#check (X : Aexp')  -- Aexp'.ofAexp (Aexp.id X) : Aexp'
-#check (aexp { X } : Aexp')  -- Aexp'.ofAexp (Aexp.id X) : Aexp'
-#check (3 : Aexp)  -- Aexp.num 3
-#check (3 : Aexp')  -- Aexp'.ofNat 3 : Aexp'
-#check {{ X = 3 }}
-#check {{ X > 3 ∧ Y = (4 * X - (Y + Z)) }}
-#check {{ X ≠ 3 ∨ (Y = 4 ∧ Z = 5) }}
-#check {{ Z = Nat.max X Y }}
-#check {{ Z * Z ≤ X
-          ∧ ¬ (Nat.succ Z * Nat.succ Z ≤ X) }}
-#check {{ Nat.add X Y > Nat.max Y X }}
-#check (fun st => ∀ (P : Assertion) m a,
-  ({{ fun st => P (X →ₜ m ; st)
-      ∧ st[X] = Aexp.eval (X →ₜ m ; st) a }}) st)
-#check {{ fun st => st[X] = 0 }}
-```
-::::
-
 ## Example Assertions
 
 ::::full
@@ -742,7 +717,6 @@ new notation.
 
 ```lean
 namespace ExamplePrettyAssertions
-open scoped Assertion
 
 def assertion1 : Assertion := {{ X = 3 }}
 def assertion2 : Assertion := {{ True }}
@@ -750,11 +724,12 @@ def assertion3 : Assertion := {{ False }}
 def assertion4 : Assertion := {{ True ∨ False }}
 def assertion5 : Assertion := {{ X ≤ Y }}
 def assertion6 : Assertion := {{ X = 3 ∨ X ≤ Y }}
-def assertion7 : Assertion := {{ Z = (max X Y) }}
+def assertion7 : Assertion := {{ Z = max X Y }}
 def assertion8 : Assertion := {{ Z * Z ≤ X
                                  ∧ ¬ (((Nat.succ Z) * (Nat.succ Z)) ≤ X) }}
 def assertion9 : Assertion := {{ Nat.add X Y > max Y X }}
-
+variable {xs : List Nat}
+-- #check {{ xs = X }}
 /--
 info: def ExamplePrettyAssertions.assertion8 : Assertion :=
 fun st => st[Z] * st[Z] ≤ st[X] ∧ ¬st[Z].succ * st[Z].succ ≤ st[X]
@@ -790,24 +765,18 @@ assertions:
 
 ```lean
 notation:26 P:27 " <<->> " Q:27 => AssertImplies P Q ∧ AssertImplies Q P
-```
 
-:::dev "Claude"
-The Rocq source puts these notations in a `hoare_spec_scope`, with a
-book comment explaining that "the `hoare_spec_scope` annotation tells Rocq
-that this notation is not global but is intended to be used in particular
-contexts."  Lean has no notation scopes, so the notations are simply global
-and that paragraph is omitted.
-:::
+theorem assertIff_def {P Q : Assertion} : P <<->> Q ↔ AssertImplies P Q ∧ AssertImplies Q P
+    := by rfl
+```
 
 # Hoare Triples, Informally
 
-::::full
-A _Hoare triple_ is a claim about the state before and
-after executing a command.  The standard notation is
+A _Hoare triple_ is a claim about the state before and after executing a command.
+A commond notation for Hoare triples, and the one we use in this book, is
 
 ```display
-{P} c {Q}
+{{P}} c {{Q}}
 ```
 
 meaning:
@@ -819,32 +788,6 @@ meaning:
 Assertion `P` is called the _precondition_ of the triple, and `Q` is
 the _postcondition_.
 
-Because single braces are already used for other things in Lean, we'll write
-Hoare triples with double braces:
-
-```display
-{{P}} c {{Q}}
-```
-::::
-
-::::terse
-A _Hoare triple_ is a claim about the state before and
-after executing a command:
-
-```display
-{{P}} c {{Q}}
-```
-
-This means:
-
-  - If command `c` begins execution in a state satisfying
-    assertion `P`,
-  - and if `c` eventually terminates in some final state,
-  - then that final state will satisfy the assertion `Q`.
-
-Assertion `P` is called the _precondition_ of the triple, and `Q`
-is the _postcondition_.
-::::
 
 :::slidebreak
 :::
@@ -1071,31 +1014,17 @@ We formalize valid Hoare triples in Lean as follows:
 ```lean
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
-  ∀ st st',
+  ∀ {st st' : State},
     (st =[ c ]=> st') →
     P st →
     Q st'
-```
 
-:::dev
+theorem validHoareTriple_def (P : Assertion) (c : Com) (Q : Assertion) :
+    ValidHoareTriple P c Q ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
+      P st →
+      Q st' := by rfl
 ```
-NOTATION: SAZ 2024 One trickiness of these notations is that we
-want the [com] and [assn] grammars to be "open", so that they can
-include expressions parsed by the full [constr] grammar of Rocq.
-However, then there is a conflict of precedence of the
-"application" cases:
-
-The example " {{ True }} X := 0 {{ False }} " does not parse as
-intended because the [com] grammar includes the capability of
-parsing the (ill-typed) term "0 {{ False }}".
-
-This means that the "application" for [com] should disallow
-arguments at the level at which the [assn] grammar is included
-in constr.  The upshot is that this notation should be included
-in the grammar at the *same* level as the assertion notation
-[{{ P }}], which is 2.
-```
-:::
 
 Notation for Hoare triples.  The command between the two assertions is
 parsed with the same grammar as the `imp { … }` notation, so a command
@@ -1103,8 +1032,6 @@ that is a Lean variable (rather than concrete syntax) is spliced in with
 `~c`, just as in the `st =[ c ]=> st'` notation.
 
 ```lean
-open scoped Assertion
-
 namespace ValidHoareTriple
 
 /-- Hoare triple: `{{ P }} c {{ Q }}` -/
@@ -1121,37 +1048,11 @@ open scoped ValidHoareTriple
 ```
 
 ::::hide
-```
-#check ({{ True }} skip; {{ False }})
-#check ({{ True }} X := 0; {{ False }})
+```lean
+#check ({{ True }} skip {{ False }})
+#check ({{ True }} X := 0 {{ False }})
 ```
 ::::
-
-:::dev
-```
-HIDE: AAA: If I try to set the notation as {P} c {Q}, I get the
-following error:
-
-  Error: A notation must include at least one symbol.
-
-Maybe we could use other braces? For instance, I tried it with [P]
-c [Q] and it seems to work (although I don't know how that would
-affect the rest of the book).
-
-BCP: Let's try with the "squashed" double braces for a while and
-see if we like it.
-
-P.S.
-This works:
-   Notation "{ x }" := (x) (at level 0, x at level 99).
-But this doesn't:
-   Notation "{ P }  c  { Q }" :=
-     (ValidHoareTriple P c Q)
-     (at level 0, P at level 99, c at level 99, Q at level 99)
-   : hoare_spec_scope.
-Why??
-```
-:::
 
 :::::exercise (rating := 1) (name := "hoare_post_true")
 Prove that if `Q` holds in every state, then any triple with `Q`
@@ -1161,9 +1062,9 @@ as its postcondition is valid.
 theorem hoare_post_true (P Q : Assertion) (c : Com) (h : ∀ st, Q st) :
     {{ P }} ~c {{ Q }} := by
   solution!
-    unfold ValidHoareTriple
-    intro st st' _heval _hp
-    apply h
+    rw [validHoareTriple_def]
+    intro st st' hc hst
+    exact h st'
 ```
 :::::
 
@@ -1175,9 +1076,9 @@ its precondition is valid.
 theorem hoare_pre_false (P Q : Assertion) (c : Com) (h : ∀ st, ¬ (P st)) :
     {{ P }} ~c {{ Q }} := by
   solution!
-    unfold ValidHoareTriple
-    intro st st' _heval hp
-    apply h at hp
+    rw [validHoareTriple_def]
+    intro st st' hc hst
+    specialize h st hst
     contradiction
 ```
 :::::
@@ -1222,10 +1123,11 @@ assertion `P`:
 
 ```lean
 theorem hoare_skip (P : Assertion) :
-    {{ P }} skip; {{ P }} := by
-  intro st st' h hp
+    {{ P }} skip {{ P }} := by
+  rw [validHoareTriple_def]
+  intro st st' h hst
   inversion h
-  assumption
+  exact hst
 ```
 
 ## Sequencing
@@ -1239,17 +1141,19 @@ state where `P` holds to one where `R` holds:
  {{ P }} c1 {{ Q }}
  {{ Q }} c2 {{ R }}
 ----------------------  (hoare_seq)
-{{ P }} c1;c2 {{ R }}
+{{ P }} c1; c2 {{ R }}
 ```
 
 ```lean
 theorem hoare_seq (P Q R : Assertion) (c1 c2 : Com)
     (h1 : {{ Q }} ~c2 {{ R }}) (h2 : {{ P }} ~c1 {{ Q }}) :
-    {{ P }} ~c1 ~c2 {{ R }} := by
-  intro st st' h12 pre
-  inversion h12 with
+    {{ P }} ~c1; ~c2 {{ R }} := by
+  rw [validHoareTriple_def]
+  intro st st' h hst
+  inversion h with
   | seq st'' hc1 hc2 =>
-    exact h1 _ _ hc2 (h2 _ _ hc1 pre)
+    rw [validHoareTriple_def] at h1 h2
+    exact h1 hc2 (h2 hc1 hst)
 ```
 
 ::::full
@@ -1446,7 +1350,7 @@ However, we can achieve the same effect by evaluating `P` in an
 updated state, defined as follows:
 
 ```lean
-def Assertion.sub (x : Ident) (a : Aexp) (P : Assertion) : Assertion :=
+def Assertion.subst (x : Ident) (a : Aexp) (P : Assertion) : Assertion :=
   fun (st : State) => P (x →ₜ a.eval st ; st)
 ```
 
@@ -1463,12 +1367,25 @@ Introduce a notation typeclass for this (e.g. HasSubst)
 :::
 
 ```lean
+namespace Assertion
+
 /-- Assertion substitution: `P [X ↦ a]` -/
-syntax:100 term:100 " [" ident " ↦ " imp_aexp "]" : term
+scoped syntax:max term:arg " [" ident " ↦ " imp_aexp "]" : term
+-- scoped syntax:max term:arg " [" ident " ↦ " term "]" : term -- TODO can we get this to work
 
 macro_rules
-  | `($P [$x ↦ $a]) => `(Assertion.sub $x (aexp { $a }) $P)
-  -- | `(assn($st; $P [$x ↦ $a])) => ``(assn($st; $P) [$x ↦ $a]) -- maybe we could push substitutions inside
+  | `($P [$x ↦ $a:imp_aexp]) => `(Assertion.subst $x (aexp { $a }) $P)
+  -- | `($P [$x ↦ $a:term]) => `(Assertion.subst $x $a $P) -- TODO
+
+-- TODO unexpander!!!
+
+theorem subst_def {x : Ident} {a : Aexp} {P : Assertion} :
+    P [x ↦ ~a] = fun (st : State) => P (x →ₜ a.eval st ; st) := by rfl
+
+theorem subst_apply {x : Ident} {a : Aexp} {P : Assertion} {st : State} :
+    P [x ↦ ~a] st ↔ P (x →ₜ a.eval st ; st) := by rfl
+
+end Assertion
 ```
 
 This notation allows us to write this operation as:
@@ -1478,9 +1395,9 @@ P [ X ↦ a ]
 ```
 
 ```lean
-#check (fun st => Assertion.sub X (aexp { 2 * X }) ({{ X ≤ 10 }}) st)
+#check (fun st => Assertion.subst X (aexp { 2 * X }) ({{ X ≤ 10 }}) st)
 #check {{ X ≤ 10 }} [X ↦ 2 * X]
-#check (∀ st, ({{ X ≤ 10 }} [X ↦ 2 * X]) st)
+#check (∀ st, {{ X ≤ 10 }} [X ↦ 2 * X] st)
 ```
 
 That is, `P [X ↦ a]` stands for an assertion -- let's call it
@@ -1560,11 +1477,19 @@ We can demonstrate formally that we have captured intuitive meaning of
 namespace ExampleAssertionSub
 example :
     {{ (X ≤ 5) }} [X ↦ 3] <<->> {{ 3 ≤ 5 }} := by
-  constructor <;> (unfold AssertImplies Assertion.sub; intro st h; exact h)
+  rw [assertIff_def]
+  constructor <;>
+  · rw [assertImplies_def]
+    intro st
+    rw [Assertion.subst_apply]
 
 example :
     {{ (X ≤ 5) }} [X ↦ X + 1] <<->> {{ (X + 1) ≤ 5 }} := by
-  constructor <;> (unfold AssertImplies Assertion.sub; intro st h; exact h)
+  rw [assertIff_def]
+  constructor <;>
+  · rw [assertImplies_def]
+    intro st
+    rw [Assertion.subst_apply]
 
 end ExampleAssertionSub
 ```
@@ -1821,7 +1746,7 @@ theorem hoare_asgn_wrong : ∃ a : Aexp,
   solution!
     exists aexp { X + 1 }
     intro hc
-    unfold ValidHoareTriple at hc
+    rw [validHoareTriple_def] at hc
     have h2 : (X →ₜ 1 ; ∅)[X] = (aexp { X + 1 }).eval (X →ₜ 1 ; ∅) := by
       apply hc ∅ (X →ₜ 1 ; ∅)
       · apply Com.EvalR.asgn; rfl
@@ -1895,7 +1820,7 @@ theorem hoare_asgn_fwd (m : Nat) (a : Aexp) (P : Assertion) :
     {{ fun st => P (X →ₜ m ; st)
          ∧ st[X] = a.eval (X →ₜ m ; st) }} := by
   solution!
-    unfold ValidHoareTriple
+    rw [validHoareTriple_def]
     intro st st' heval hpre
     inversion heval with
     | asgn n h =>
@@ -1936,7 +1861,7 @@ theorem hoare_asgn_fwd_exists (a : Aexp) (P : Assertion) :
     {{ fun st => ∃ m, P (X →ₜ m ; st) ∧
          st[X] = a.eval (X →ₜ m ; st) }} := by
   solution!
-    unfold ValidHoareTriple
+    rw [validHoareTriple_def]
     intro st st' heval hpre
     inversion heval with
     | asgn n h =>
@@ -2127,7 +2052,7 @@ Here are the formal versions:
 theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro st st' heval hpre
   apply hhoare st st'
   · assumption
@@ -2137,7 +2062,7 @@ theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
 theorem hoare_consequence_post (P Q Q' : Assertion) (c : Com)
     (hhoare : {{ P }} ~c {{ Q' }}) (himp : Q' ->> Q) :
     {{ P }} ~c {{ Q }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro st st' heval hpre
   apply himp
   apply hhoare st st'
@@ -2269,7 +2194,7 @@ Here's a good candidate for automation:
 theorem hoare_consequence_pre' (P P' Q : Assertion) (c : Com)
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro st st' heval hpre
   apply hhoare st st'
   · assumption
@@ -2299,7 +2224,7 @@ missing part is going to be filled in later in the proof."
 theorem hoare_consequence_pre''' (P P' Q : Assertion) (c : Com)
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro st st' heval hpre
   apply hhoare
   · assumption
@@ -2594,7 +2519,7 @@ show that it satisfies the following specification:
 {{X ≤ Y}} c {{Y ≤ X}}
 ```
 
-Your proof should not need to use `unfold ValidHoareTriple`.
+Your proof should not need to use `rw [validHoareTriple_def]`.
 
 Hints:
    - Remember that Imp commands need to be enclosed in `imp { … }`
@@ -2698,7 +2623,7 @@ theorem invalid_triple : ¬ ∀ (a : Aexp) (n : Nat),
     {{ a = n }}
       X := 3; Y := ~a;
     {{ Y = n }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro h
   solution!
     specialize h (aexp { X }) 2 (X →ₜ 2 ; ∅) (Y →ₜ 3 ; X →ₜ 3 ; X →ₜ 2 ; ∅)
@@ -3836,7 +3761,7 @@ theorem always_loop_hoare' (P Q : Assertion) :
 Hoare logic... -/
 theorem always_loop_hoare'' (P Q : Assertion) :
     {{ P }} while (true) { skip; } {{ Q }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro st st' heval _hP
   have key : ∀ (cmd : Com) (s s' : State), (s =[ cmd ]=> s') →
       cmd = (imp { while (true) { skip; } }) → Q s' := by
@@ -4160,7 +4085,7 @@ a separate namespace, with a different definition of commands). -/
 
 theorem hoare_asgn (Q : Assertion) (x : Ident) (a : Aexp) :
     {{Q [x ↦ ~a]}} x := ~a; {{ Q }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro st st' hE hQ
   inversion hE with
   | asgn n h =>
@@ -4231,7 +4156,7 @@ like this: -/
 theorem hoare_repeat' (P : Assertion) (b : Bexp) (c : Com)
     (h : {{ P }} ~c {{ P }}) :
     {{ P }} repeat { ~c } until (~b) {{ P ∧ b }} := by
-  unfold ValidHoareTriple
+  rw [validHoareTriple_def]
   intro st st' he hP
   have key : ∀ (cmd : Com) (s s' : State), (s =[ cmd ]=> s') →
       cmd = (impr { repeat { ~c } until (~b) }) → P s →
@@ -4572,7 +4497,7 @@ def havoc_pre (x : Ident) (Q : Assertion) (st : State) : Prop :=
 theorem hoare_havoc (Q : Assertion) (x : Ident) :
     {{ fun st => havoc_pre x Q st }} havoc x; {{ Q }} := by
   solution!
-    unfold ValidHoareTriple havoc_pre
+    rw [validHoareTriple_def] havoc_pre
     intro st st' heval hpre
     inversion heval with
     | havoc n => apply hpre
@@ -4837,12 +4762,12 @@ theorem assert_assume_differ : ∃ (P : Assertion) (b : Bexp) (Q : Assertion),
   solution!
     exists {{ True }}, bexp { false }, ({{ False }} : Assertion)
     constructor
-    · unfold ValidHoareTriple
+    · rw [validHoareTriple_def]
       intro st r hE _
       inversion hE with
       | assume hb => simp at hb
     · intro hC
-      unfold ValidHoareTriple at hC
+      rw [validHoareTriple_def] at hC
       have h : ∅ =[ assert (false); ]=> Result.error := by
         apply Com.EvalR.assertFalse
         rfl
@@ -4861,7 +4786,7 @@ theorem assert_implies_assume (P : Assertion) (b : Bexp) (Q : Assertion)
     (hhoare : {{ P }} assert (~b); {{ Q }}) :
     {{ P }} assume (~b); {{ Q }} := by
   solution!
-    unfold ValidHoareTriple
+    rw [validHoareTriple_def]
     intro st r hEval hP
     inversion hEval with
     | assume hb =>

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -558,6 +558,11 @@ A raw Lean assertion can also be written directly inside {{ }}.
 ```
 :::
 
+:::instructors
+The `{{ }}` syntax has `lead` precedence since otherwise it leads to some conflicts with triples.
+This has the downside that assertions need to be wrapped in `()` parentheses when passed as arguments.
+:::
+
 ```lean
 namespace Assertion
 
@@ -565,7 +570,7 @@ section
 open Lean Elab Term
 
 scoped syntax:max (name := assn) "assn(" ident "; " term ")" : term
-scoped syntax "{{" term "}}" : term
+scoped syntax:lead "{{" term "}}" : term
 
 @[term_elab assn]
 def assnElab : TermElab := fun stx _type? => do
@@ -866,6 +871,10 @@ also holds.
 def AssertImplies (P Q : Assertion) : Prop :=
   ∀ st, P st → Q st
 ```
+
+:::instructors
+`AssertImplies` (unlike `ValidHoareTriple`) is semireducible on purpose: when we use the `apply_rules` tactic, it needs to see through the definition.
+:::
 
 Note that the notation for _assertion implication_ is analogous
 to the "usual" Lean implication `→`.
@@ -1172,20 +1181,14 @@ All are valid except the 5th.
 We formalize valid Hoare triples in Lean as follows:
 
 ```lean
+open scoped HasEval
+
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
   ∀ {st st' : State},
     (st =[ c ]=> st') →
     P st →
     Q st'
-
-theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
-    ValidHoareTriple P c Q ↔ ∀ {st st' : State},
-      (st =[ c ]=> st') →
-      P st →
-      Q st' := by rfl
-
-attribute [irreducible] ValidHoareTriple
 ```
 
 :::dev "Niklas Halonen (xhalo32)"
@@ -1200,42 +1203,64 @@ parsed with the same grammar as the `imp { … }` notation, so a command
 that is a Lean variable (rather than concrete syntax) is spliced in with
 `~c`, just as in the `st =[ c ]=> st'` notation.
 
+:::instructors
+This pattern of a generic notation with a notation typeclass plus a category-specific variant is from {name}`HasEval` in Imp.
+It's a bit more complicated since `{{ }}`-notation is already used for assertions.
+
+Since identifiers are terms and also in `imp_com`, we must mark the `imp_com` version with `priority := high`, otherwise e.g. `skip` is elaborated as a regular identifier.
+:::
+
 ```lean
-namespace ValidHoareTriple
+class HasTriple (Com : Type) where
+  Triple : Assertion → Com → Assertion → Prop
+
+namespace HasTriple
 
 /-- Hoare triple: `{{ P }} c {{ Q }}` -/
-scoped syntax:lead "{{" term "}} " imp_com:lead " {{" term "}}" : term
+scoped notation:lead "{{" P "}} " c:lead " {{" Q "}}" => Triple ({{ P }}) c ({{ Q }})
 
-macro_rules
+/-- Hoare triple with `imp_com` command syntax -/
+scoped syntax:lead (priority := high) "{{" term "}} " imp_com:lead " {{" term "}}" : term
+scoped macro_rules
   | `({{ $P }} $c:imp_com {{ $Q }}) =>
-      `(ValidHoareTriple ({{ $P }}) (imp { $c }) ({{ $Q }}))
+      ``(HasTriple.Triple ({{ $P }}) (imp { $c }) ({{ $Q }}))
+end HasTriple
 
-end ValidHoareTriple
+instance : HasTriple Com where
+  Triple := ValidHoareTriple
 
-section
-open scoped ValidHoareTriple
+open scoped HasTriple
+
+theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
+    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
+      P st →
+      Q st' := by rfl
+
+attribute [irreducible] ValidHoareTriple
 ```
 
 ::::hide
 ```lean
 #check ({{ True }} skip {{ False }})
 #check ({{ True }} X := 0 {{ False }})
+#check ∀ c : Com, ({{ True }} ~c {{ False }})
 ```
 ::::
 
 ::::details "Notation encoding: printing triples back"
+This delaborator works only with {name}`Com` from Imp.
 ```lean
 namespace Assertion.Delab
 open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
-
-/-- Print a `ValidHoareTriple` back in `{{ P }} c {{ Q }}` notation. -/
-@[delab app.ValidHoareTriple]
+@[delab app.HasTriple.Triple]
 def delabTriple : Delab := whenPPOption getPPNotation do
-  guard <| (← getExpr).isAppOfArity ``ValidHoareTriple 3
-  let P ← withNaryArg 0 delabAssn
-  let c ← withNaryArg 1 delabComInner
-  let Q ← withNaryArg 2 delabAssn
-  `({{ $P }} $c:imp_com {{ $Q }})
+  guard <| (← getExpr).isAppOfArity ``HasTriple.Triple 5
+  guard <| (← getExpr).getArg! 0 == mkConst ``Com
+  let P ← withNaryArg 2 delabAssn
+  let c ← withNaryArg 3 delabComInner
+  let Q ← withNaryArg 4 delabAssn
+  ``({{ $P }} $c:imp_com {{ $Q }})
 
 end Assertion.Delab
 ```
@@ -1246,7 +1271,19 @@ end Assertion.Delab
 /-- info: {{X ≤ 5}} X := X + 1 {{X ≤ 7}} : Prop -/
 #guard_msgs in
 #check {{ X ≤ 5 }} X := X + 1 {{ X ≤ 7 }}
+
+/--
+info: {{X ≤ 5}}
+  X := X;
+  Y := Y {{X ≤ 7}} : Prop
+-/
+#guard_msgs in
+#check {{ X ≤ 5 }} X := X; Y := Y {{ X ≤ 7 }}
 ```
+:::
+
+:::dev "Niklas Halonen (xhalo32)"
+Is it possible to add a line break after the `Y := Y`?
 :::
 
 :::::exercise (rating := 1) (name := "hoare_post_true")
@@ -1273,7 +1310,7 @@ theorem hoare_pre_false {P Q : Assertion} {c : Com} (h : ∀ st, ¬ (P st)) :
   solution!
     rw [validHoareTriple_def]
     intro st st' hc hst
-    specialize h st hst
+    specialize h st
     contradiction
 ```
 :::::
@@ -1578,7 +1615,7 @@ macro_rules
   | `(assn($st; $P [$x ↦ $a:imp_aexp])) =>
     match P with
     | `($_:ident) => ``(Assertion.subst $x (aexp { $a }) $P $st)
-    | _ => ``(Assertion.subst $x (aexp { $a }) {{ $P }} $st)
+    | _ => ``(Assertion.subst $x (aexp { $a }) ({{ $P }}) $st)
 
 theorem subst_def {x : Ident} {a : Aexp} {P : Assertion} :
     Assertion.subst x a P = fun (st : State) => P (x →ₜ a.eval st ; st) := by rfl
@@ -1635,7 +1672,7 @@ end Assertion.Delab
 
 /-- info: (X ≤ 10) [X ↦ 2 * X] : Assertion -/
 #guard_msgs in
-#check (Assertion.subst X (aexp { 2 * X }) {{ X ≤ 10 }})
+#check (Assertion.subst X (aexp { 2 * X }) ({{ X ≤ 10 }}))
 ```
 :::
 
@@ -2348,6 +2385,8 @@ theorem hoare_consequence_pre' (P P' Q : Assertion) (c : Com)
   exact himp _ hpre
 ```
 
+From now on, we will not usually rewrite `assertImplies_def` explicitly.
+
 Since, after the `rw` and `intro`, the remaining steps just apply hypotheses to the goal (and each other), the
 remaining proof can be compressed into a single tactic: {tactic}`apply_rules`.
 
@@ -2384,9 +2423,8 @@ theorem hoare_asgn_example1' :
     {{True}} X := 1 {{X = 1}} := by
   apply hoare_consequence_pre -- not specifying `(P' := ...)` leaves a "hole" `?P'`
   · -- The goal is `{{?P'}} X := 1 {{X = 1}}`
-    exact hoare_asgn -- Assigns `?P'` to `{{ (X = 1) [X ↦ 1] }}` (automatically closing the `case P'`)
-  · rw [assertImplies_def]
-    intro st _
+    exact hoare_asgn -- Assigns `?P'` to `{{ (X = 1) [X ↦ 1] }}` (automatically closing `case P'`)
+  · intro st _ -- Since `->>` is an implication, we can just use `intro` directly.
     simp
 ```
 
@@ -2520,10 +2558,7 @@ theorem assertion_sub_ex2' :
     · assertion_auto
 ```
 
-:::gradeTheorem 1 assertion_sub_ex1'
-:::
-
-:::gradeTheorem 1 assertion_sub_ex2'
+:::gradeTheorem 1 assertion_sub_ex1' assertion_sub_ex2'
 :::
 :::::
 
@@ -2881,54 +2916,10 @@ theorem if_example :
 :::slidebreak
 :::
 
-:::dev "Niklas Halonen (xhalo32)"
-The following paragraph is outdated (talks about old `bassertion`).
-:::
-
-As we did earlier, it would be nice to eliminate all the low-level
-proof script that isn't about the Hoare rules.  Unfortunately, the
-`assertion_auto` tactic we wrote wasn't quite up to the job.  Looking
-at the proof of `if_example`, we can see why: we had to unfold a
-definition (`bassertion`) that we didn't need in earlier proofs.
-(The step from the boolean equality test `st[X] == 0` to the equation
-`st[X] = 0` is handled by lemmas `simp` already knows, such as
-`beq_iff_eq`.)  So, let's add the unfolding into our tactic.
-
-:::dev
-HIDE: MRC'20: There's probably a better way to engineer this.
-I don't know Ltac very well though.
-:::
-
-:::slidebreak
-:::
-
-Now the proof is quite streamlined.
-
-```lean
-theorem if_example'' :
-    {{True}}
-      if (X = 0) {
-        Y := 2;
-      } else {
-        Y := X + 1;
-      }
-    {{X ≤ Y}} := by
-  apply hoare_if
-  · apply hoare_consequence_pre
-    · exact hoare_asgn
-    · assertion_auto
-  · apply hoare_consequence_pre
-    · exact hoare_asgn
-    · assertion_auto
-```
-
-:::slidebreak
-:::
-
 We can even shorten it a little bit more.
 
 ```lean
-theorem if_example''' :
+theorem if_example' :
     {{True}}
       if (X = 0) {
         Y := 2
@@ -2949,14 +2940,13 @@ defined may be useful.
 theorem if_minus_plus :
     {{True}}
       if (X ≤ Y) {
-        Z := Y - X;
+        Z := Y - X
       } else {
-        Y := X + Z;
+        Y := X + Z
       }
     {{Y = X + Z}} := by
   solution!
-    apply hoare_if <;> apply hoare_consequence_pre <;>
-      (try exact hoare_asgn) <;> try assertion_auto
+    apply hoare_if <;> apply hoare_consequence_pre hoare_asgn (by assertion_auto)
 ```
 :::::
 
@@ -2988,7 +2978,6 @@ namespace to prevent polluting the global name space.  The `scoped`
 notations below are active only inside `namespace If1`.)
 
 ```lean
-end -- closes `open scoped ValidHoareTriple`
 namespace If1
 
 inductive Com : Type where
@@ -3001,46 +2990,30 @@ inductive Com : Type where
 ```
 
 :::instructors
-Copy of template com
+We simply extend `imp_com` in the `If1` namespace with the `if1` syntax rather than defining a new syntax category.
+This means we need to redefine the `macro_rules` with the new `Com`.
 :::
 
 ```lean
-/-- If1 commands: Imp commands plus `if1` -/
-declare_syntax_cat if1_com
-/-- The command that does nothing (`skip;`) -/
-syntax ident ";" : if1_com
-/-- Sequencing: one command after another -/
-syntax if1_com ppDedent(ppLine if1_com) : if1_com
-/-- Assignment -/
-syntax ident " := " imp_aexp ";" : if1_com
-/-- Conditional -/
-syntax "if " "(" imp_bexp ")" ppHardSpace "{" ppLine if1_com ppDedent(ppLine "}" ppHardSpace "else" ppHardSpace "{") ppLine if1_com ppDedent(ppLine "}") : if1_com
-/-- Loop -/
-syntax "while " "(" imp_bexp ")" ppHardSpace "{" ppLine if1_com ppDedent(ppLine "}") : if1_com
 /-- One-sided conditional -/
-syntax "if1 " "(" imp_bexp ")" ppHardSpace "{" ppLine if1_com ppDedent(ppLine "}") : if1_com
-/-- Escape to Lean -/
-syntax:max "~" term:max : if1_com
-
-/-- Include an If1 command in Lean code -/
-syntax:min "imp1" ppHardSpace "{" ppLine if1_com ppDedent(ppLine "}") : term
+scoped syntax "if1 " "(" imp_bexp ")" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") : imp_com
 
 open Lean in
-macro_rules
-  | `(imp1 { $x:ident ; }) =>
+scoped macro_rules
+  | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
     else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
-  | `(imp1 { $c1 $c2 }) =>
-    `(Com.seq (imp1 {$c1}) (imp1 {$c2}))
-  | `(imp1 { $x:ident := $a; }) =>
+  | `(imp { $c1; $c2 }) =>
+    `(Com.seq (imp {$c1}) (imp {$c2}))
+  | `(imp { $x:ident := $a }) =>
     `(Com.asgn $x (aexp {$a}))
-  | `(imp1 { if ($b) {$c1} else {$c2} }) =>
-    `(Com.cond (bexp {$b}) (imp1 {$c1}) (imp1 {$c2}))
-  | `(imp1 { while ($b) {$c} }) =>
-    `(Com.whileDo (bexp {$b}) (imp1 {$c}))
-  | `(imp1 { if1 ($b) {$c} }) =>
-    `(Com.if1 (bexp {$b}) (imp1 {$c}))
-  | `(imp1 { ~$c }) =>
+  | `(imp { if ($b) {$c1} else {$c2} }) =>
+    `(Com.cond (bexp {$b}) (imp {$c1}) (imp {$c2}))
+  | `(imp { while ($b) {$c} }) =>
+    `(Com.whileDo (bexp {$b}) (imp {$c}))
+  | `(imp { if1 ($b) {$c} }) =>
+    `(Com.if1 (bexp {$b}) (imp {$c}))
+  | `(imp { ~$c }) =>
     pure c
 ```
 
@@ -3048,44 +3021,37 @@ macro_rules
 Add two new evaluation rules to relation `Com.EvalR`, below, for
 `if1`. Let the rules for `if` guide you.
 
-:::instructors
-Copy of template eval
-:::
-
 ```lean
 inductive Com.EvalR : Com → State → State → Prop where
   | skip (st : State) :
-      EvalR (imp1 {skip;}) st st
+      EvalR (imp {skip}) st st
   | asgn (st : State) (a : Aexp) (n : Nat) (x : Ident) (h : a.eval st = n) :
-      EvalR (imp1 {x := ~a;}) st (x →ₜ n ; st)
+      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
   | seq (c1 c2 : Com) (st st' st'' : State)
       (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
-      EvalR (imp1 {~c1 ~c2}) st st''
+      EvalR (imp {~c1; ~c2}) st st''
   | ifTrue (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
-      EvalR (imp1 {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
   | ifFalse (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = false)
       (hc : EvalR c2 st st') :
-      EvalR (imp1 {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
   | whileFalse (b : Bexp) (st : State) (c : Com) (hb : b.eval st = false) :
-      EvalR (imp1 {while (~b) {~c} }) st st
+      EvalR (imp {while (~b) {~c} }) st st
   | whileTrue (st st' st'' : State) (b : Bexp) (c : Com)
       (hb : b.eval st = true) (hc : EvalR c st st')
-      (hloop : EvalR (imp1 {while (~b) {~c} }) st' st'') :
-      EvalR (imp1 {while (~b) {~c} }) st st''
+      (hloop : EvalR (imp {while (~b) {~c} }) st' st'') :
+      EvalR (imp {while (~b) {~c} }) st st''
 -- SOLUTION
   | if1True (st st' : State) (b : Bexp) (c : Com) (hb : b.eval st = true)
       (hc : EvalR c st st') :
-      EvalR (imp1 {if1 (~b) {~c} }) st st'
+      EvalR (imp {if1 (~b) {~c} }) st st'
   | if1False (st : State) (b : Bexp) (c : Com) (hb : b.eval st = false) :
-      EvalR (imp1 {if1 (~b) {~c} }) st st
+      EvalR (imp {if1 (~b) {~c} }) st st
 -- END SOLUTION
 
-scoped notation:40 (priority := high) st0:41 " =[ " c " ]=> " st1:41 =>
-  Com.EvalR c st0 st1
-scoped syntax:40 (priority := high) term:41 " =[ " if1_com " ]=> " term:41 : term
-scoped macro_rules
-  | `($st0 =[ $c:if1_com ]=> $st1) => `($st0 =[ imp1 { $c } ]=> $st1)
+instance : HasEval Com State where
+  Eval := Com.EvalR
 ```
 
 The following unit tests should be provable simply by applying your
@@ -3094,25 +3060,26 @@ defined them correctly.
 
 ```lean
 theorem if1true_test :
-    ∅ =[ if1 (X = 0) { X := 1; } ]=> (X →ₜ 1) := by
+    ∅ =[ if1 (X = 0) { X := 1 } ]=> (X →ₜ 1) := by
   solution!
     apply Com.EvalR.if1True
     · rfl
     · apply Com.EvalR.asgn; rfl
 
 theorem if1false_test :
-    (X →ₜ 2) =[ if1 (X = 0) { X := 1; } ]=> (X →ₜ 2) := by
+    (X →ₜ 2) =[ if1 (X = 0) { X := 1 } ]=> (X →ₜ 2) := by
   solution!
     apply Com.EvalR.if1False
     rfl
 ```
 
-:::gradeTheorem 1 if1true_test
-:::
-
-:::gradeTheorem 1 if1false_test
+:::gradeTheorem 1 if1true_test if1false_test
 :::
 :::::
+
+:::dev
+This is outdated. It should explain `HasTriple`
+:::
 
 Now we have to repeat the definition and notation of Hoare triples,
 so that they will use the updated `Com` type.
@@ -3120,24 +3087,27 @@ so that they will use the updated `Com` type.
 ```lean
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
-  ∀ st st',
+  ∀ {st st' : State},
     (st =[ c ]=> st') →
     P st →
     Q st'
 
-namespace ValidHoareTriple
+instance : HasTriple Com where
+  Triple := ValidHoareTriple
 
-/-- Hoare triple over If1 commands -/
-scoped syntax:lead "{{" term "}} " if1_com:lead " {{" term "}}" : term
+theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
+    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
+      P st →
+      Q st' := by rfl
 
-macro_rules
-  | `({{ $P }} $c:if1_com {{ $Q }}) =>
-      `(ValidHoareTriple ({{ $P }}) (imp1 { $c }) ({{ $Q }}))
-
-end ValidHoareTriple
-
-open scoped ValidHoareTriple
+attribute [irreducible] ValidHoareTriple
 ```
+
+:::dev "Niklas Halonen (xhalo32)"
+Do we want a delaborator for the new `Com`?
+Could we somehow extend the one in `Imp` with `if1`?
+:::
 
 :::::exercise (rating := 2) (name := "hoare_if1") (manual := true)
 Invent a Hoare logic proof rule for `if1`.  State and prove a
@@ -3160,9 +3130,10 @@ theorem hoare_if1 (b : Bexp) (c : Com) (P Q : Assertion)
     (htrue : {{ P ∧ b }} ~c {{ Q }})
     (hfalse : ({{ P ∧ ¬ b }}) ->> Q) :
     {{ P }} if1 (~b) { ~c } {{ Q }} := by
+  rw [validHoareTriple_def] at htrue ⊢
   intro st st' heval hpre
   inversion heval with
-  | if1True hb hc => exact htrue _ _ hc ⟨hpre, hb⟩
+  | if1True hb hc => exact htrue hc ⟨hpre, hb⟩
   | if1False hb => exact hfalse _ ⟨hpre, bexp_eval_false b st hb⟩
 -- END SOLUTION
 ```
@@ -3188,15 +3159,18 @@ consequence (for preconditions) and assignment for the new `Com`
 type.
 
 ```lean
-theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
+theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
-  exact hhoare st st' heval (himp st hpre)
+  exact hhoare heval (himp st hpre)
 
-theorem hoare_asgn (Q : Assertion) (x : Ident) (a : Aexp) :
-    {{Q [x ↦ ~a]}} x := ~a; {{ Q }} := by
+theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
+    {{Q [x ↦ ~a]}} x := ~a {{ Q }} := by
+  rw [validHoareTriple_def]
   intro st st' heval hQ
+  rw [Assertion.subst_apply] at hQ
   inversion heval with
   | asgn n h =>
     subst h
@@ -3225,7 +3199,7 @@ where our solution uses a custom Ltac...
 theorem hoare_if1_good :
     {{ X + Y = Z }}
       if1 (Y ≠ 0) {
-        X := X + Y;
+        X := X + Y
       }
     {{ X = Z }} := by
   solution!
@@ -3239,8 +3213,6 @@ theorem hoare_if1_good :
 
 ```lean
 end If1
-section
-open scoped ValidHoareTriple
 ```
 ::::::
 
@@ -3325,39 +3297,33 @@ HIDE: The big comment will not display nicely.  But I guess it's
 folded...
 :::
 
+:::dev "Niklas Halonen (xhalo32)"
+We need to explain the `generalize` tactic.
+:::
+
 ```lean
-theorem hoare_while (P : Assertion) (b : Bexp) (c : Com)
+theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
     (hhoare : {{P ∧ b}} ~c {{ P }}) :
     {{ P }} while (~b) { ~c } {{P ∧ ¬ b}} := by
-  intro st st' heval hP
+  rw [validHoareTriple_def] at hhoare ⊢
+  intro st st' heval hst
   /- We proceed by induction on `heval`, because, in the "keep
   looping" case, its hypotheses talk about the whole loop instead
-  of just `c`. The auxiliary statement `key` generalizes over an
+  of just `c`. We begin by generalizing over an
   arbitrary command, together with an equation remembering that the
-  command is the original loop; otherwise, that information would
-  be lost in the induction. The cases for commands other than
+  command is the original loop. The cases for commands other than
   `while` are dismissed because their equations are contradictory. -/
-  have key : ∀ (cmd : Com) (s s' : State), (s =[ cmd ]=> s') →
-      cmd = (imp { while (~b) { ~c } }) → P s →
-      P s' ∧ ¬ bassertion b s' := by
-    intro cmd s s' hev
-    induction hev with
-    | whileFalse b0 s0 c0 hb =>
-        intro heq hp
-        injection heq with e1 _
-        subst e1
-        exact ⟨hp, bexp_eval_false _ _ hb⟩
-    | whileTrue s0 s0' s0'' b0 c0 hb hc hloop ih1 ih2 =>
-        intro heq hp
-        injection heq with e1 e2
-        subst e1 e2
-        exact ih2 rfl (hhoare _ _ hc ⟨hp, hb⟩)
-    | skip s0 => intro heq; simp at heq
-    | asgn s0 a n x h => intro heq; simp at heq
-    | seq c1 c2 s0 s0' s0'' h1 h2 ih1 ih2 => intro heq; simp at heq
-    | ifTrue s0 s0' b0 c1 c2 hb hc ih => intro heq; simp at heq
-    | ifFalse s0 s0' b0 c1 c2 hb hc ih => intro heq; simp at heq
-  exact key _ st st' heval rfl hP
+  generalize heq : (imp { while (~b) { ~c } }) = cmd at *
+  induction heval with
+  | whileFalse b0 s0 c0 hb =>
+    injection heq with hbeq hceq
+    simp_all
+  | whileTrue s0 s0' s0'' b0 c0 hb hc hloop ih1 ih2 =>
+    injection heq with hbeq hceq
+    subst hbeq hceq
+    exact ih2 (hhoare hc ⟨hst, hb⟩) rfl
+  | skip | asgn | seq | ifTrue | ifFalse =>
+    contradiction
 ```
 
 :::slidebreak
@@ -3661,7 +3627,7 @@ What is this example doing here?? Needs some text.
 theorem while_example :
     {{X ≤ 3}}
       while (X ≤ 2) {
-        X := X + 1;
+        X := X + 1
       }
     {{X = 3}} := by
   apply hoare_consequence_post
@@ -3801,23 +3767,23 @@ It would be nice to automate the second bullet.
 
 ```lean
 theorem always_loop_hoare (Q : Assertion) :
-    {{True}} while (true) { skip; } {{ Q }} := by
+    {{True}} while (true) { skip } {{ Q }} := by
   apply hoare_consequence_post
   · apply hoare_while
     apply hoare_post_true
     intro st
     exact True.intro
-  · intro st ⟨_hinv, hguard⟩
-    exact absurd rfl hguard
+  · intro st ⟨_, hguard⟩
+    simp at hguard
 ```
 ::::
 
 ::::hide
-```
+```lean
 /- A different way through the proof... -/
 theorem always_loop_hoare' (P Q : Assertion) :
-    {{ P }} while (true) { skip; } {{ Q }} := by
-  apply hoare_consequence_pre (P' := (True : Assertion))
+    {{ P }} while (true) { skip } {{ Q }} := by
+  apply hoare_consequence_pre (P' := {{ True }})
   · apply hoare_consequence_post
     · apply hoare_while
       -- Loop body preserves loop invariant
@@ -3825,10 +3791,8 @@ theorem always_loop_hoare' (P Q : Assertion) :
       intro st
       exact True.intro
     · -- Loop invariant and negated guard imply postcondition
-      intro st ⟨_hinv, hguard⟩
-      exfalso
-      apply hguard
-      rfl
+      intro st ⟨_, hguard⟩
+      simp at hguard
   · -- Precondition implies loop invariant
     intro st _
     exact True.intro
@@ -3836,11 +3800,11 @@ theorem always_loop_hoare' (P Q : Assertion) :
 /- And, of course, there is also the low-level way to do it, without using
 Hoare logic... -/
 theorem always_loop_hoare'' (P Q : Assertion) :
-    {{ P }} while (true) { skip; } {{ Q }} := by
+    {{ P }} while (true) { skip } {{ Q }} := by
   rw [validHoareTriple_def]
   intro st st' heval _hP
   have key : ∀ (cmd : Com) (s s' : State), (s =[ cmd ]=> s') →
-      cmd = (imp { while (true) { skip; } }) → Q s' := by
+      cmd = (imp { while (true) { skip } }) → Q s' := by
     intro cmd s s' hev
     induction hev with
     | whileFalse b0 s0 c0 hb =>
@@ -3915,7 +3879,6 @@ evaluation rule for `repeat` and add a new Hoare rule to the
 language for programs involving it.
 
 ```lean
-end
 namespace RepeatExercise
 
 inductive Com : Type where

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -288,7 +288,7 @@ An _assertion_ is a logical claim about the state of a program's
 memory -- formally, a predicate of `State`s.
 
 ```lean
-open scoped MyGetElem
+open scoped Com MyGetElem
 
 abbrev Assertion := State → Prop
 ```
@@ -2503,9 +2503,9 @@ deriving BEq, ReflBEq, LawfulBEq, DecidableEq
 
 ```lean
 macro "assertion_auto" : tactic =>
-  `(tactic| focus (simp [assertImplies_def, assertIff_def, validHoareTriple_def,
-                         Assertion.subst_def, X, Y, Z, W] at *
-                  <;> try lia))
+  `(tactic| focus (simp +decide [assertImplies_def, assertIff_def, validHoareTriple_def,
+                                Assertion.subst_def] at *
+                  <;> lia))
 ```
 
 :::slidebreak
@@ -4081,7 +4081,7 @@ theorem ex1_repeat_works :
     · apply Com.EvalR.seq
       · apply Com.EvalR.asgn; rfl
       · apply Com.EvalR.asgn; rfl
-    · simp
+    · simp +decide
 ```
 
 :::dev "Niklas Halonen (xhalo32)"

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -1295,7 +1295,7 @@ theorem hoare_post_true {P Q : Assertion} {c : Com} (h : ∀ st, Q st) :
     {{ P }} ~c {{ Q }} := by
   solution!
     rw [validHoareTriple_def]
-    intro st st' hc hst
+    intro st st' hc hpre
     exact h st'
 ```
 :::::
@@ -1309,7 +1309,7 @@ theorem hoare_pre_false {P Q : Assertion} {c : Com} (h : ∀ st, ¬ (P st)) :
     {{ P }} ~c {{ Q }} := by
   solution!
     rw [validHoareTriple_def]
-    intro st st' hc hst
+    intro st st' hc hpre
     specialize h st
     contradiction
 ```
@@ -1357,9 +1357,9 @@ assertion `P`:
 theorem hoare_skip {P : Assertion} :
     {{ P }} skip {{ P }} := by
   rw [validHoareTriple_def]
-  intro st st' h hst
+  intro st st' h hpre
   inversion h
-  exact hst
+  exact hpre
 ```
 
 ## Sequencing
@@ -1381,11 +1381,11 @@ theorem hoare_seq {P Q R : Assertion} {c1 c2 : Com}
     (h1 : {{ Q }} ~c2 {{ R }}) (h2 : {{ P }} ~c1 {{ Q }}) :
     {{ P }} ~c1; ~c2 {{ R }} := by
   rw [validHoareTriple_def]
-  intro st st' h hst
+  intro st st' h hpre
   inversion h with
   | seq st'' hc1 hc2 =>
     rw [validHoareTriple_def] at h1 h2
-    exact h1 hc2 (h2 hc1 hst)
+    exact h1 hc2 (h2 hc1 hpre)
 ```
 
 ::::full
@@ -2280,9 +2280,13 @@ theorem assertion_sub_example2 :
     · exact hoare_asgn
     · rw [assertImplies_def]
       intro st h
-      simp
+      simp_all
       lia
 ```
+
+:::dev "Niklas Halonen (xhalo32)"
+The above proof uses `simp_all` purely because `lia` can't see that `X` and `"X"` are the same (they are currently marked as `@[simp]` in Imp).
+:::
 
 :::slidebreak
 :::
@@ -2932,8 +2936,7 @@ theorem if_example' :
 
 ::::::full
 :::::exercise (rating := 2) (name := "if_minus_plus")
-Prove the theorem below using `hoare_if`.  Do not use `unfold
-ValidHoareTriple`.  The `assertion_auto` tactic we just
+Prove the theorem below using `hoare_if`.  Do not use unfold `ValidHoareTriple`.  The `assertion_auto` tactic we just
 defined may be useful.
 
 ```lean
@@ -3052,6 +3055,11 @@ inductive Com.EvalR : Com → State → State → Prop where
 
 instance : HasEval Com State where
   Eval := Com.EvalR
+
+@[app_unexpander Com.EvalR]
+def Com.unexpandEvalR : Lean.PrettyPrinter.Unexpander
+  | `($_ $c $st0 $st1) => ``($st0 =[ ~$c ]=> $st1)
+  | _ => throw ()
 ```
 
 The following unit tests should be provable simply by applying your
@@ -3133,8 +3141,11 @@ theorem hoare_if1 (b : Bexp) (c : Com) (P Q : Assertion)
   rw [validHoareTriple_def] at htrue ⊢
   intro st st' heval hpre
   inversion heval with
-  | if1True hb hc => exact htrue hc ⟨hpre, hb⟩
-  | if1False hb => exact hfalse _ ⟨hpre, bexp_eval_false b st hb⟩
+  | if1True hb hc =>
+    exact htrue hc ⟨hpre, hb⟩
+  | if1False hb =>
+    apply hfalse
+    simp [hpre, hb]
 -- END SOLUTION
 ```
 
@@ -3306,14 +3317,14 @@ theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
     (hhoare : {{P ∧ b}} ~c {{ P }}) :
     {{ P }} while (~b) { ~c } {{P ∧ ¬ b}} := by
   rw [validHoareTriple_def] at hhoare ⊢
-  intro st st' heval hst
+  intro st st' heval hpre
   /- We proceed by induction on `heval`, because, in the "keep
   looping" case, its hypotheses talk about the whole loop instead
   of just `c`. We begin by generalizing over an
   arbitrary command, together with an equation remembering that the
   command is the original loop. The cases for commands other than
   `while` are dismissed because their equations are contradictory. -/
-  generalize heq : (imp { while (~b) { ~c } }) = cmd at *
+  generalize heq : (imp { while (~b) { ~c } }) = cmd at heval
   induction heval with
   | whileFalse b0 s0 c0 hb =>
     injection heq with hbeq hceq
@@ -3321,7 +3332,7 @@ theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
   | whileTrue s0 s0' s0'' b0 c0 hb hc hloop ih1 ih2 =>
     injection heq with hbeq hceq
     subst hbeq hceq
-    exact ih2 (hhoare hc ⟨hst, hb⟩) rfl
+    exact ih2 (hhoare hc ⟨hpre, hb⟩) rfl
   | skip | asgn | seq | ifTrue | ifFalse =>
     contradiction
 ```
@@ -3896,49 +3907,25 @@ repeating as long as the guard stays _false_.  Because of this,
 the body will always execute at least once.
 
 ```lean
-/-- Repeat-Imp commands: Imp commands plus `repeat` -/
-declare_syntax_cat rpt_com
 /-- Repeat loop -/
-syntax "repeat" ppHardSpace "{" ppLine rpt_com ppDedent(ppLine "}") " until " "(" imp_bexp ")" : rpt_com
-```
-
-:::instructors
-Copy of template com
-:::
-
-```lean
-/-- The command that does nothing (`skip;`) -/
-syntax ident ";" : rpt_com
-/-- Sequencing: one command after another -/
-syntax rpt_com ppDedent(ppLine rpt_com) : rpt_com
-/-- Assignment -/
-syntax ident " := " imp_aexp ";" : rpt_com
-/-- Conditional -/
-syntax "if " "(" imp_bexp ")" ppHardSpace "{" ppLine rpt_com ppDedent(ppLine "}" ppHardSpace "else" ppHardSpace "{") ppLine rpt_com ppDedent(ppLine "}") : rpt_com
-/-- Loop -/
-syntax "while " "(" imp_bexp ")" ppHardSpace "{" ppLine rpt_com ppDedent(ppLine "}") : rpt_com
-/-- Escape to Lean -/
-syntax:max "~" term:max : rpt_com
-
-/-- Include a Repeat-Imp command in Lean code -/
-syntax:min "impr" ppHardSpace "{" ppLine rpt_com ppDedent(ppLine "}") : term
+syntax "repeat" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") " until " "(" imp_bexp ")" : imp_com
 
 open Lean in
-macro_rules
-  | `(impr { $x:ident ; }) =>
+scoped macro_rules
+  | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
     else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
-  | `(impr { $c1 $c2 }) =>
-    `(Com.seq (impr {$c1}) (impr {$c2}))
-  | `(impr { $x:ident := $a; }) =>
+  | `(imp { $c1; $c2 }) =>
+    `(Com.seq (imp {$c1}) (imp {$c2}))
+  | `(imp { $x:ident := $a }) =>
     `(Com.asgn $x (aexp {$a}))
-  | `(impr { if ($b) {$c1} else {$c2} }) =>
-    `(Com.cond (bexp {$b}) (impr {$c1}) (impr {$c2}))
-  | `(impr { while ($b) {$c} }) =>
-    `(Com.whileDo (bexp {$b}) (impr {$c}))
-  | `(impr { repeat {$c} until ($b) }) =>
-    `(Com.repeatUntil (impr {$c}) (bexp {$b}))
-  | `(impr { ~$c }) =>
+  | `(imp { if ($b) {$c1} else {$c2} }) =>
+    `(Com.cond (bexp {$b}) (imp {$c1}) (imp {$c2}))
+  | `(imp { while ($b) {$c} }) =>
+    `(Com.whileDo (bexp {$b}) (imp {$c}))
+  | `(imp { repeat {$c} until ($b) }) =>
+    `(Com.repeatUntil (imp {$c}) (bexp {$b}))
+  | `(imp { ~$c }) =>
     pure c
 ```
 
@@ -3954,60 +3941,64 @@ the guard becomes true.
 ```lean
 inductive Com.EvalR : Com → State → State → Prop where
   | skip (st : State) :
-      EvalR (impr {skip;}) st st
+      EvalR (imp {skip}) st st
   | asgn (st : State) (a : Aexp) (n : Nat) (x : Ident) (h : a.eval st = n) :
-      EvalR (impr {x := ~a;}) st (x →ₜ n ; st)
+      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
   | seq (c1 c2 : Com) (st st' st'' : State)
       (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
-      EvalR (impr {~c1 ~c2}) st st''
+      EvalR (imp {~c1; ~c2}) st st''
   | ifTrue (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
-      EvalR (impr {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
   | ifFalse (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = false)
       (hc : EvalR c2 st st') :
-      EvalR (impr {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
   | whileFalse (b : Bexp) (st : State) (c : Com) (hb : b.eval st = false) :
-      EvalR (impr {while (~b) {~c} }) st st
+      EvalR (imp {while (~b) {~c} }) st st
   | whileTrue (st st' st'' : State) (b : Bexp) (c : Com)
       (hb : b.eval st = true) (hc : EvalR c st st')
-      (hloop : EvalR (impr {while (~b) {~c} }) st' st'') :
-      EvalR (impr {while (~b) {~c} }) st st''
+      (hloop : EvalR (imp {while (~b) {~c} }) st' st'') :
+      EvalR (imp {while (~b) {~c} }) st st''
 -- SOLUTION
   | repeatEnd (st st' : State) (b : Bexp) (c : Com) (hc : EvalR c st st')
       (hb : b.eval st' = true) :
-      EvalR (impr {repeat {~c} until (~b) }) st st'
+      EvalR (imp {repeat {~c} until (~b) }) st st'
   | repeatLoop (st st' st'' : State) (b : Bexp) (c : Com)
       (hc : EvalR c st st') (hb : b.eval st' = false)
-      (hloop : EvalR (impr {repeat {~c} until (~b) }) st' st'') :
-      EvalR (impr {repeat {~c} until (~b) }) st st''
+      (hloop : EvalR (imp {repeat {~c} until (~b) }) st' st'') :
+      EvalR (imp {repeat {~c} until (~b) }) st st''
 -- END SOLUTION
 
-scoped notation:40 (priority := high) st0:41 " =[ " c " ]=> " st1:41 =>
-  Com.EvalR c st0 st1
-scoped syntax:40 (priority := high) term:41 " =[ " rpt_com " ]=> " term:41 : term
-scoped macro_rules
-  | `($st0 =[ $c:rpt_com ]=> $st1) => `($st0 =[ impr { $c } ]=> $st1)
+instance : HasEval Com State where
+  Eval := Com.EvalR
+
+@[app_unexpander Com.EvalR]
+def Com.unexpandEvalR : Lean.PrettyPrinter.Unexpander
+  | `($_ $c $st0 $st1) => ``($st0 =[ ~$c ]=> $st1)
+  | _ => throw ()
 ```
 
 A couple of definitions from above, copied here so they use the
 new `Com.EvalR`.
 
 ```lean
-def ValidHoareTriple (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
-  ∀ st st', (st =[ c ]=> st') → P st → Q st'
+def ValidHoareTriple
+    (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
+  ∀ {st st' : State},
+    (st =[ c ]=> st') →
+    P st →
+    Q st'
 
-namespace ValidHoareTriple
+instance : HasTriple Com where
+  Triple := ValidHoareTriple
 
-/-- Hoare triple over Repeat-Imp commands -/
-scoped syntax:lead "{{" term "}} " rpt_com:lead " {{" term "}}" : term
+theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
+    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
+      P st →
+      Q st' := by rfl
 
-macro_rules
-  | `({{ $P }} $c:rpt_com {{ $Q }}) =>
-      `(ValidHoareTriple ({{ $P }}) (impr { $c }) ({{ $Q }}))
-
-end ValidHoareTriple
-
-open scoped ValidHoareTriple
+attribute [irreducible] ValidHoareTriple
 ```
 
 To make sure you've got the evaluation rules for `repeat` right,
@@ -4015,10 +4006,10 @@ prove that `ex1_repeat` evaluates correctly.
 
 ```lean
 def ex1_repeat : Com :=
-  impr {
+  imp {
     repeat {
       X := 1;
-      Y := Y + 1;
+      Y := Y + 1
     } until (X = 1)
   }
 
@@ -4029,8 +4020,12 @@ theorem ex1_repeat_works :
     · apply Com.EvalR.seq
       · apply Com.EvalR.asgn; rfl
       · apply Com.EvalR.asgn; rfl
-    · rfl
+    · simp
 ```
+
+:::dev "Niklas Halonen (xhalo32)"
+Do we want to `open Com.EvalR` to make the previous proof easier to write?
+:::
 
 Now state and prove a theorem, `hoare_repeat`, that expresses an
 appropriate proof rule for `repeat` commands.  Use `hoare_while`
@@ -4048,33 +4043,23 @@ different ways! -/
 theorem hoare_repeat (P Q : Assertion) (b : Bexp) (c : Com)
     (h1 : {{ P }} ~c {{ Q }}) (h2 : {{ Q ∧ ¬ b }} ~c {{ Q }}) :
     {{ P }} repeat { ~c } until (~b) {{ Q ∧ b }} := by
-  have key : ∀ (cmd : Com) (s s' : State), (s =[ cmd ]=> s') →
-      cmd = (impr { repeat { ~c } until (~b) }) →
-      ∀ (P' : Assertion), ({{ P' }} ~c {{ Q }}) → P' s →
-      Q s' ∧ bassertion b s' := by
-    intro cmd s s' hev
-    induction hev with
-    | repeatEnd s0 s0' b0 c0 hc hb =>
-        intro heq P' hP'c hp
-        injection heq with e1 e2
-        subst e1 e2
-        exact ⟨hP'c _ _ hc hp, hb⟩
-    | repeatLoop s0 s0' s0'' b0 c0 hc hb hloop ih1 ih2 =>
-        intro heq P' hP'c hp
-        injection heq with e1 e2
-        subst e1 e2
-        apply ih2 rfl _ h2
-        exact ⟨hP'c _ _ hc hp, bexp_eval_false _ _ hb⟩
-    | skip s0 => intro heq; simp at heq
-    | asgn s0 a n x h => intro heq; simp at heq
-    | seq c1 c2 s0 s0' s0'' hh1 hh2 ih1 ih2 => intro heq; simp at heq
-    | ifTrue s0 s0' b0 c1 c2 hb hc ih => intro heq; simp at heq
-    | ifFalse s0 s0' b0 c1 c2 hb hc ih => intro heq; simp at heq
-    | whileFalse b0 s0 c0 hb => intro heq; simp at heq
-    | whileTrue s0 s0' s0'' b0 c0 hb hc hloop ih1 ih2 =>
-        intro heq; simp at heq
+  rw [validHoareTriple_def] at h1 h2 ⊢
   intro st st' heval hpre
-  exact key _ st st' heval rfl P h1 hpre
+  generalize heq : (imp { repeat { ~c } until (~b) }) = cmd at heval
+  induction heval generalizing P with
+  | repeatEnd s0 s0' b0 c0 hc hb ih =>
+    injection heq with hceq hbeq
+    subst hceq hbeq
+    exact ⟨h1 hc hpre, hb⟩
+  | repeatLoop s0 s0' s0'' b0 c0 hc hb hloop ih1 ih2 =>
+    injection heq with hceq hbeq
+    subst hceq hbeq
+    apply ih2 _ h2 _ rfl
+    constructor
+    · exact h1 hc hpre
+    · simp [hb]
+  | skip | asgn | seq | ifTrue | ifFalse | whileFalse | whileTrue =>
+    contradiction
 -- END SOLUTION
 ```
 
@@ -4111,10 +4096,10 @@ cannot compile the whole module as one block.
 that `hoare_repeat` can handle this litmus test: -/
 
 def ex2_repeat : Com :=
-  impr {
+  imp {
     repeat {
       Y := X;
-      X := X - 1;
+      X := X - 1
     } until (X = 0)
   }
 
@@ -4122,41 +4107,38 @@ def ex2_repeat : Com :=
 the proofs of some more Hoare rules from above (remember we're in
 a separate namespace, with a different definition of commands). -/
 
-theorem hoare_asgn (Q : Assertion) (x : Ident) (a : Aexp) :
-    {{Q [x ↦ ~a]}} x := ~a; {{ Q }} := by
+theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
+    {{Q [x ↦ ~a]}} x := ~a {{ Q }} := by
   rw [validHoareTriple_def]
   intro st st' hE hQ
+  rw [Assertion.subst_apply] at hQ
   inversion hE with
   | asgn n h =>
     subst h
     exact hQ
 
-theorem hoare_consequence (P P' Q Q' : Assertion) (c : Com)
+theorem hoare_consequence {P P' Q Q' : Assertion} {c : Com}
     (hht : {{ P' }} ~c {{ Q' }}) (hPP' : P ->> P') (hQ'Q : Q' ->> Q) :
     {{ P }} ~c {{ Q }} := by
+  rw [validHoareTriple_def] at hht ⊢
   intro st st' hc hP
-  apply hQ'Q
-  apply hht st st'
-  · assumption
-  · apply hPP'
-    assumption
+  apply_rules
 
-theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
+theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' hc hP
-  apply hhoare st st'
-  · assumption
-  · apply himp
-    assumption
+  apply_rules
 
-theorem hoare_seq (P Q R : Assertion) (c1 c2 : Com)
+theorem hoare_seq {P Q R : Assertion} {c1 c2 : Com}
     (h1 : {{ Q }} ~c2 {{R}}) (h2 : {{ P }} ~c1 {{ Q }}) :
-    {{ P }} ~c1 ~c2 {{R}} := by
+    {{ P }} ~c1; ~c2 {{R}} := by
+  rw [validHoareTriple_def] at h1 h2 ⊢
   intro st st' h12 pre
   inversion h12 with
   | seq st'' hc1 hc2 =>
-    exact h1 _ _ hc2 (h2 _ _ hc1 pre)
+    apply_rules
 
 -- END SOLUTION
 ```
@@ -4173,15 +4155,13 @@ theorem ex2_repeat_hoare_repeat :
     {{ X > 0 }}
       ~ex2_repeat
     {{ X = 0 ∧ Y > 0 }} := by
-  unfold ex2_repeat
+  rw [ex2_repeat]
   apply hoare_consequence
   · apply hoare_repeat (Q := {{ Y > 0 }})
-    · apply hoare_seq <;> exact hoare_asgn
-    · apply hoare_seq
-      · exact hoare_asgn
-      · apply hoare_consequence_pre
-        · exact hoare_asgn
-        · assertion_auto
+    · apply hoare_seq hoare_asgn hoare_asgn
+    · apply hoare_seq hoare_asgn
+      apply hoare_consequence_pre hoare_asgn
+      assertion_auto
   · -- body of repeat if exiting right away
     assertion_auto
   · -- final postcondition
@@ -4198,20 +4178,22 @@ theorem hoare_repeat' (P : Assertion) (b : Bexp) (c : Com)
   rw [validHoareTriple_def]
   intro st st' he hP
   have key : ∀ (cmd : Com) (s s' : State), (s =[ cmd ]=> s') →
-      cmd = (impr { repeat { ~c } until (~b) }) → P s →
-      P s' ∧ bassertion b s' := by
+      cmd = (imp { repeat { ~c } until (~b) }) → P s →
+      P s' ∧ b.eval s' := by
     intro cmd s s' hev
     induction hev with
     | repeatEnd s0 s0' b0 c0 hc hb =>
         intro heq hp
         injection heq with e1 e2
         subst e1 e2
-        exact ⟨h _ _ hc hp, hb⟩
+        rw [validHoareTriple_def] at h
+        exact ⟨h hc hp, hb⟩
     | repeatLoop s0 s0' s0'' b0 c0 hc hb hloop ih1 ih2 =>
         intro heq hp
         injection heq with e1 e2
         subst e1 e2
-        exact ih2 rfl (h _ _ hc hp)
+        rw [validHoareTriple_def] at h
+        exact ih2 rfl (h hc hp)
     | skip s0 => intro heq; simp at heq
     | asgn s0 a n x ha => intro heq; simp at heq
     | seq c1 c2 s0 s0' s0'' hh1 hh2 ih1 ih2 => intro heq; simp at heq
@@ -4258,16 +4240,13 @@ example :
     {{ X = 0 ∧ Y > 0}} := by
   apply hoare_consequence
   · apply hoare_repeat' (P := {{ Y > 0 }})
-    apply hoare_seq
-    · exact hoare_asgn
-    · apply hoare_consequence_pre
-      · exact hoare_asgn
-      · -- body of repeat if looping
-        unfold AssertImplies Assertion.sub
-        intro st hy
-        -- loop invariant too weak on its own,
-        -- we need the value of the previous guard
-        sorry
+    apply hoare_seq hoare_asgn
+    apply hoare_consequence_pre hoare_asgn
+    intro st hy
+    simp
+    -- loop invariant too weak on its own,
+    -- we need the value of the previous guard
+    sorry
   · -- initial precondition
     intro st ⟨_, hy⟩
     exact hy
@@ -4286,15 +4265,12 @@ example :
     {{ X = 0 ∧ Y > 0}} := by
   apply hoare_consequence
   · apply hoare_repeat' (P := {{ X > 0 ∧ Y > 0 }})
-    apply hoare_seq
-    · exact hoare_asgn
-    · apply hoare_consequence_pre
-      · exact hoare_asgn
-      · -- body of repeat if looping
-        unfold AssertImplies Assertion.sub
-        intro st ⟨hx, hy⟩
-        -- loop invariant too strong
-        sorry
+    apply hoare_seq hoare_asgn
+    apply hoare_consequence_pre hoare_asgn
+    intro st ⟨hx, hy⟩
+    simp
+    -- loop invariant too strong
+    sorry
   · -- initial precondition
     intro st hp
     exact hp

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -1327,7 +1327,7 @@ Here are some valid instances of the assignment rule:
 
 To formalize the rule, we must first formalize the idea of
 "substituting an expression for an Imp variable in an assertion",
-which we refer to as assertion substitution, or `Assertion.sub`.
+which we refer to as assertion substitution, or `Assertion.subst`.
 
 Intuitively, given a proposition `P`, a variable `X`, and an
 arithmetic expression `a`, we want to derive another proposition
@@ -1366,22 +1366,34 @@ a quick go at implementing it, but did not succeed yet.
 Introduce a notation typeclass for this (e.g. HasSubst)
 :::
 
+:::dev "Niklas Halonen (xhalo32)" PotentialImprovement
+A lot of the substitutions use `[x ↦ ~a]`. Could we have syntax support for `[x ↦ a]`. A naive approach that adds `" [" ident " ↦ " term "]" ` leads to ambiguity.
+:::
+
+:::dev "Niklas Halonen (xhalo32)" NOW
+We need to add an unexpander for the substitution notation which is another argument for HasSubst typeclass.
+:::
+
+:::dev "Niklas Halonen (xhalo32)"
+Is it possible to move the substitution syntax inside the braces like in the original Rocq material?
+I.e. `{{ (X ≤ 10) [X ↦ 2 * X] }}` vs. `{{ X ≤ 10 }} [X ↦ 2 * X]`
+
+Currently in triples we need to write `{{ {{ X < 5 }} [X ↦ X + 1] }}` which looks ugly.
+:::
+
 ```lean
 namespace Assertion
 
 /-- Assertion substitution: `P [X ↦ a]` -/
 scoped syntax:max term:arg " [" ident " ↦ " imp_aexp "]" : term
--- scoped syntax:max term:arg " [" ident " ↦ " term "]" : term -- TODO can we get this to work
 
 macro_rules
   | `($P [$x ↦ $a:imp_aexp]) => `(Assertion.subst $x (aexp { $a }) $P)
-  -- | `($P [$x ↦ $a:term]) => `(Assertion.subst $x $a $P) -- TODO
-
--- TODO unexpander!!!
 
 theorem subst_def {x : Ident} {a : Aexp} {P : Assertion} :
     P [x ↦ ~a] = fun (st : State) => P (x →ₜ a.eval st ; st) := by rfl
 
+@[simp]
 theorem subst_apply {x : Ident} {a : Aexp} {P : Assertion} {st : State} :
     P [x ↦ ~a] st ↔ P (x →ₜ a.eval st ; st) := by rfl
 
@@ -1478,18 +1490,23 @@ namespace ExampleAssertionSub
 example :
     {{ (X ≤ 5) }} [X ↦ 3] <<->> {{ 3 ≤ 5 }} := by
   rw [assertIff_def]
-  constructor <;>
-  · rw [assertImplies_def]
-    intro st
-    rw [Assertion.subst_apply]
+  rw [assertImplies_def]
+  constructor
+  · intro st _
+    simp
+  · intro st h
+    simp [TotalMap.update_def, TotalMap.getElem_def] -- This should use TotalMap.update_apply which is @[simp]
 
 example :
     {{ (X ≤ 5) }} [X ↦ X + 1] <<->> {{ (X + 1) ≤ 5 }} := by
   rw [assertIff_def]
-  constructor <;>
+  constructor
   · rw [assertImplies_def]
     intro st
-    rw [Assertion.subst_apply]
+    simp [TotalMap.update_def, TotalMap.getElem_def]
+  · rw [assertImplies_def]
+    intro st
+    simp [TotalMap.update_def, TotalMap.getElem_def]
 
 end ExampleAssertionSub
 ```
@@ -1498,6 +1515,12 @@ end ExampleAssertionSub
 %%%
 tag := "assn-delaborators"
 %%%
+
+:::dev "Niklas Halonen (xhalo32)" NOW
+To One:
+1. Add delaborator for plain assertions, also for `<<->>`
+2. Move the delab stuff near where the syntax is first introduced for assertions and then add small delaborators when new syntax like triples are introduced.
+:::
 
 ::::full
 As in the {ref "imp-delaborators"}[Imp chapter], the assertion notations
@@ -1608,9 +1631,9 @@ def delabAssertImplies : Delab := whenPPOption getPPNotation do
   guard <| (← getExpr).isAppOfArity ``AssertImplies 2
   `($(← delabAssnArg 0) ->> $(← delabAssnArg 1))
 
-@[delab app.Assertion.sub]
+@[delab app.Assertion.subst]
 def delabSub : Delab := whenPPOption getPPNotation do
-  guard <| (← getExpr).isAppOfArity ``Assertion.sub 3
+  guard <| (← getExpr).isAppOfArity ``Assertion.subst 3
   let `($x:ident) ← withNaryArg 0 delab | failure
   let a ← withNaryArg 1 delabAexpInner
   let P ← withNaryArg 2 delabAssn
@@ -1625,9 +1648,9 @@ end Assertion.Delab
 
 :::ignore
 ```lean -show
-/-- info: {{X ≤ 5}} X := X + 1; {{X ≤ 7}} : Prop -/
+/-- info: {{X ≤ 5}} X := X + 1 {{X ≤ 7}} : Prop -/
 #guard_msgs in
-#check {{ X ≤ 5 }} X := X + 1; {{ X ≤ 7 }}
+#check {{ X ≤ 5 }} X := X + 1 {{ X ≤ 7 }}
 
 /-- info: {{X < 4}} ->> {{X < 5}} : Prop -/
 #guard_msgs in
@@ -1652,13 +1675,18 @@ give the precise proof rule for assignment:
 
 We can prove formally that this rule is indeed valid.
 
+:::dev "Niklas Halonen (xhalo32)" NOW
+The delaboration for `x := ~a` seems to be broken now that I made sequencing use semicolons.
+:::
+
 ```lean
 theorem hoare_asgn (Q : Assertion) (x : Ident) (a : Aexp) :
-    {{ Q [x ↦ ~a] }}  x := ~a; {{ Q }} := by
+    {{ Q [x ↦ ~a] }} x := ~a {{ Q }} := by
   intro st st' hE hQ
   inversion hE with
   | asgn n h =>
     subst h
+    rw [Assertion.subst_def] at hQ
     exact hQ
 ```
 
@@ -1670,7 +1698,7 @@ Here's a first formal proof of a Hoare triple using this rule.
 ```lean
 theorem assertion_sub_example :
     {{ {{ X < 5 }} [X ↦ X + 1] }}
-      X := X + 1;
+      X := X + 1
     {{ X < 5 }} := by
   apply hoare_asgn
 ```
@@ -1702,7 +1730,7 @@ that you have completed the triple properly.
 theorem hoare_asgn_examples1 :
     ∃ P : Assertion,
       {{ P }}
-        X := 2 * X;
+        X := 2 * X
       {{ X ≤ 10 }} := by
   solution!
     exists {{ X ≤ 10 }} [X ↦ 2 * X]
@@ -1715,7 +1743,7 @@ theorem hoare_asgn_examples1 :
 theorem hoare_asgn_examples2 :
     ∃ P : Assertion,
       {{ P }}
-        X := 3;
+        X := 3
       {{ 0 ≤ X ∧ X ≤ 5 }} := by
   solution!
     exists {{ 0 ≤ X ∧ X ≤ 5 }} [X ↦ 3]
@@ -1740,15 +1768,23 @@ counterexample.  (Hint: The rule universally quantifies over the
 arithmetic expression `a`, so your counterexample needs to
 exhibit an `a` for which the rule doesn't work.)
 
+:::dev "Niklas Halonen (xhalo32)"
+The following exercise provides explicit state arguments to a hypothesis:
+```
+apply hc (st := ∅) (st' := X →ₜ 1 ; ∅)
+```
+Should we demonstrate this with an example before this exercise?
+:::
+
 ```lean
 theorem hoare_asgn_wrong : ∃ a : Aexp,
-    ¬ {{ True }} X := ~a; {{ X = a }} := by
+    ¬ {{ True }} X := ~a {{ X = a }} := by
   solution!
     exists aexp { X + 1 }
     intro hc
     rw [validHoareTriple_def] at hc
     have h2 : (X →ₜ 1 ; ∅)[X] = (aexp { X + 1 }).eval (X →ₜ 1 ; ∅) := by
-      apply hc ∅ (X →ₜ 1 ; ∅)
+      apply hc (st := ∅) (st' := X →ₜ 1 ; ∅)
       · apply Com.EvalR.asgn; rfl
       · exact True.intro
     simp [TotalMap.update_eq] at h2

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -1019,12 +1019,21 @@ def ValidHoareTriple
     P st →
     Q st'
 
-theorem validHoareTriple_def (P : Assertion) (c : Com) (Q : Assertion) :
+theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
     ValidHoareTriple P c Q ↔ ∀ {st st' : State},
       (st =[ c ]=> st') →
       P st →
       Q st' := by rfl
+
+attribute [irreducible] ValidHoareTriple
 ```
+
+:::dev "Niklas Halonen (xhalo32)"
+Somethings strange is going on in `theorem if_example`, using `apply hoare_consequence_pre` followed by `· exact hoare_asgn` works, but `refine hoare_consequence_pre hoare_asgn ?_` or `apply hoare_consequence_pre hoare_asgn` don't.
+The only solution I found was to mark `ValidHoareTriple` irreducible.
+
+It has to do something with `apply` and `refine` looking inside the implication in `∀ {st st'}, ...`
+:::
 
 Notation for Hoare triples.  The command between the two assertions is
 parsed with the same grammar as the `imp { … }` notation, so a command
@@ -1059,7 +1068,7 @@ Prove that if `Q` holds in every state, then any triple with `Q`
 as its postcondition is valid.
 
 ```lean
-theorem hoare_post_true (P Q : Assertion) (c : Com) (h : ∀ st, Q st) :
+theorem hoare_post_true {P Q : Assertion} {c : Com} (h : ∀ st, Q st) :
     {{ P }} ~c {{ Q }} := by
   solution!
     rw [validHoareTriple_def]
@@ -1073,7 +1082,7 @@ Prove that if `P` holds in no state, then any triple with `P` as
 its precondition is valid.
 
 ```lean
-theorem hoare_pre_false (P Q : Assertion) (c : Com) (h : ∀ st, ¬ (P st)) :
+theorem hoare_pre_false {P Q : Assertion} {c : Com} (h : ∀ st, ¬ (P st)) :
     {{ P }} ~c {{ Q }} := by
   solution!
     rw [validHoareTriple_def]
@@ -1122,7 +1131,7 @@ assertion `P`:
 ```
 
 ```lean
-theorem hoare_skip (P : Assertion) :
+theorem hoare_skip {P : Assertion} :
     {{ P }} skip {{ P }} := by
   rw [validHoareTriple_def]
   intro st st' h hst
@@ -1145,7 +1154,7 @@ state where `P` holds to one where `R` holds:
 ```
 
 ```lean
-theorem hoare_seq (P Q R : Assertion) (c1 c2 : Com)
+theorem hoare_seq {P Q R : Assertion} {c1 c2 : Com}
     (h1 : {{ Q }} ~c2 {{ R }}) (h2 : {{ P }} ~c1 {{ Q }}) :
     {{ P }} ~c1; ~c2 {{ R }} := by
   rw [validHoareTriple_def]
@@ -1495,7 +1504,7 @@ example :
   · intro st _
     simp
   · intro st h
-    simp [TotalMap.update_def, TotalMap.getElem_def] -- This should use TotalMap.update_apply which is @[simp]
+    simp
 
 example :
     {{ (X ≤ 5) }} [X ↦ X + 1] <<->> {{ (X + 1) ≤ 5 }} := by
@@ -1503,13 +1512,15 @@ example :
   constructor
   · rw [assertImplies_def]
     intro st
-    simp [TotalMap.update_def, TotalMap.getElem_def]
+    simp
   · rw [assertImplies_def]
     intro st
-    simp [TotalMap.update_def, TotalMap.getElem_def]
+    simp
 
 end ExampleAssertionSub
 ```
+
+Most of the `simp` calls rely on {name}`Assertion.subst_apply`, {name}`TotalMap.update_eq` plus some `Aexp` characterizing lemmas like {name}`Aexp.eval_num`.
 
 ## Printing Assertions
 %%%
@@ -1680,8 +1691,9 @@ The delaboration for `x := ~a` seems to be broken now that I made sequencing use
 :::
 
 ```lean
-theorem hoare_asgn (Q : Assertion) (x : Ident) (a : Aexp) :
+theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
     {{ Q [x ↦ ~a] }} x := ~a {{ Q }} := by
+  rw [validHoareTriple_def]
   intro st st' hE hQ
   inversion hE with
   | asgn n h =>
@@ -1700,7 +1712,7 @@ theorem assertion_sub_example :
     {{ {{ X < 5 }} [X ↦ X + 1] }}
       X := X + 1
     {{ X < 5 }} := by
-  apply hoare_asgn
+  exact hoare_asgn
 ```
 
 :::slidebreak
@@ -1734,7 +1746,7 @@ theorem hoare_asgn_examples1 :
       {{ X ≤ 10 }} := by
   solution!
     exists {{ X ≤ 10 }} [X ↦ 2 * X]
-    apply hoare_asgn
+    exact hoare_asgn
 ```
 :::::
 
@@ -1747,7 +1759,7 @@ theorem hoare_asgn_examples2 :
       {{ 0 ≤ X ∧ X ≤ 5 }} := by
   solution!
     exists {{ 0 ≤ X ∧ X ≤ 5 }} [X ↦ 3]
-    apply hoare_asgn
+    exact hoare_asgn
 ```
 :::::
 
@@ -1771,7 +1783,7 @@ exhibit an `a` for which the rule doesn't work.)
 :::dev "Niklas Halonen (xhalo32)"
 The following exercise provides explicit state arguments to a hypothesis:
 ```
-apply hc (st := ∅) (st' := X →ₜ 1 ; ∅)
+apply hc (st := ∅) (st' := X →ₜ 1)
 ```
 Should we demonstrate this with an example before this exercise?
 :::
@@ -1783,11 +1795,11 @@ theorem hoare_asgn_wrong : ∃ a : Aexp,
     exists aexp { X + 1 }
     intro hc
     rw [validHoareTriple_def] at hc
-    have h2 : (X →ₜ 1 ; ∅)[X] = (aexp { X + 1 }).eval (X →ₜ 1 ; ∅) := by
-      apply hc (st := ∅) (st' := X →ₜ 1 ; ∅)
+    have h2 : (X →ₜ 1)[X] = (aexp { X + 1 }).eval (X →ₜ 1) := by
+      apply hc (st := ∅) (st' := X →ₜ 1)
       · apply Com.EvalR.asgn; rfl
       · exact True.intro
-    simp [TotalMap.update_eq] at h2
+    simp at h2
 ```
 
 :::solution
@@ -1850,21 +1862,18 @@ the postcondition.
 :::
 
 ```lean
-theorem hoare_asgn_fwd (m : Nat) (a : Aexp) (P : Assertion) :
+theorem hoare_asgn_fwd {m : Nat} {a : Aexp} {P : Assertion} :
     {{ P ∧ X = m }}
-      X := ~a;
+      X := ~a
     {{ fun st => P (X →ₜ m ; st)
          ∧ st[X] = a.eval (X →ₜ m ; st) }} := by
   solution!
     rw [validHoareTriple_def]
-    intro st st' heval hpre
+    intro st st' heval ⟨hp, hx⟩
     inversion heval with
     | asgn n h =>
-      obtain ⟨hp, hx⟩ := hpre
-      subst h
-      have hx' : st[X] = m := hx
-      rw [← hx', TotalMap.update_eq, TotalMap.update_shadow,
-          TotalMap.update_same]
+      subst h hx
+      rw [TotalMap.update_eq, TotalMap.update_shadow, TotalMap.update_same]
       exact ⟨hp, rfl⟩
 ```
 :::::
@@ -1893,7 +1902,7 @@ https://www.cl.cam.ac.uk/archive/mjcg/HL/Notes/Notes.pdf
 ```lean
 theorem hoare_asgn_fwd_exists (a : Aexp) (P : Assertion) :
     {{ P }}
-      X := ~a;
+      X := ~a
     {{ fun st => ∃ m, P (X →ₜ m ; st) ∧
          st[X] = a.eval (X →ₜ m ; st) }} := by
   solution!
@@ -2085,25 +2094,23 @@ observation is captured by two _Rules of Consequence_.
 Here are the formal versions:
 
 ```lean
-theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
+theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
-  rw [validHoareTriple_def]
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
-  apply hhoare st st'
-  · assumption
-  · apply himp
-    assumption
+  apply hhoare heval
+  rw [assertImplies_def] at himp
+  exact himp _ hpre
 
-theorem hoare_consequence_post (P Q Q' : Assertion) (c : Com)
+theorem hoare_consequence_post {P Q Q' : Assertion} {c : Com}
     (hhoare : {{ P }} ~c {{ Q' }}) (himp : Q' ->> Q) :
     {{ P }} ~c {{ Q }} := by
-  rw [validHoareTriple_def]
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
+  rw [assertImplies_def] at himp
   apply himp
-  apply hhoare st st'
-  · assumption
-  · assumption
+  exact hhoare heval hpre
 ```
 
 :::slidebreak
@@ -2127,13 +2134,13 @@ tried it in class.
 
 ```lean
 theorem hoare_asgn_example1 :
-    {{True}} X := 1; {{X = 1}} := by
+    {{True}} X := 1 {{X = 1}} := by
   workinclass!
-    apply hoare_consequence_pre
-    · apply hoare_asgn
-    · unfold AssertImplies Assertion.sub
+    apply hoare_consequence_pre (P' := {{X = 1}} [X ↦ 1])
+    · exact hoare_asgn
+    · rw [assertImplies_def]
       intro st _
-      rfl
+      simp
 ```
 
 :::slidebreak
@@ -2150,17 +2157,21 @@ We can also use it to prove the example mentioned earlier.
 
 Or, formally ...
 
+:::instructors
+This proof uses `simp` followed by `lia` which is a flexible tactic, so the `simp` is considered terminal.
+:::
+
 ```lean
 theorem assertion_sub_example2 :
     {{X < 4}}
-      X := X + 1;
+      X := X + 1
     {{X < 5}} := by
   workinclass!
-    apply hoare_consequence_pre
-    · apply hoare_asgn
-    · unfold AssertImplies Assertion.sub
+    apply hoare_consequence_pre (P' := {{X < 5}} [X ↦ X + 1])
+    · exact hoare_asgn
+    · rw [assertImplies_def]
       intro st h
-      simp [TotalMap.update_eq] at *
+      simp
       lia
 ```
 
@@ -2178,15 +2189,18 @@ vary both the precondition and the postcondition.
        {{P}} c {{Q}}
 ```
 
+:::dev "Niklas Halonen (xhalo32)"
+In the following proof, `(P' := P')` is not necessary, however it avoids having a metavariable in the first goal.
+Another option is to just write `exact hoare_consequence_pre (hoare_consequence_post htriple hpost) hpre`.
+:::
+
 ```lean
-theorem hoare_consequence (P P' Q Q' : Assertion) (c : Com)
+theorem hoare_consequence {P P' Q Q' : Assertion} {c : Com}
     (htriple : {{ P' }} ~c {{ Q' }}) (hpre : P ->> P') (hpost : Q' ->> Q) :
     {{ P }} ~c {{ Q }} := by
   apply hoare_consequence_pre (P' := P')
-  · apply hoare_consequence_post (Q' := Q')
-    · assumption
-    · assumption
-  · assumption
+  · exact hoare_consequence_post htriple hpost
+  · exact hpre
 ```
 
 ## Automation
@@ -2194,6 +2208,11 @@ theorem hoare_consequence (P P' Q Q' : Assertion) (c : Com)
 Many of the proofs we have done so far with Hoare triples can be
 streamlined using the automation techniques that we introduced in
 the _Automation_ chapter of _Logical Foundations_.
+
+:::dev "Niklas Halonen (xhalo32)" NOW
+The following paragraph is outdated.
+We already have characterizing lemmas like `validHoareTriple_def`, but rarely do we need to use them with `simp`.
+:::
 
 Recall that the `simp` tactic can be told to unfold definitions as
 part of its simplifications.  The definitions we keep needing to
@@ -2212,6 +2231,10 @@ counterpart is the `assertion_auto` tactic's simp list below -- not global
 meaning in goals the way `->>` and `Assertion.sub` do.
 :::
 
+:::dev "Niklas Halonen (xhalo32)" NOW
+The following paragraph is outdated.
+:::
+
 ::::full
 The proof of `hoare_consequence_pre`, repeated below, looks
 like an opportune place for automation, because all it does
@@ -2226,102 +2249,76 @@ but that's just application of a hypothesis.)
 Here's a good candidate for automation:
 ::::
 
+```display
+theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
+    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
+    {{ P }} ~c {{ Q }} := by
+  rw [validHoareTriple_def] at hhoare ⊢
+  intro st st' heval hpre
+  apply hhoare heval
+  rw [assertImplies_def] at himp
+  exact himp _ hpre
+```
+
+:::slidebreak
+:::
+
+Since `AssertImplies` is not marked `irreducible`, and `assertImplies_def` is a proof by definitional equality, we can skip the `rw [assertImplies_def] at himp` and use `P ->> P'` like an implication directly.
+
+:::dev "Niklas Halonen (xhalo32)"
+This needs a better explanation of when it's okay to use definitions without using their characterizing lemmas.
+:::
+
 ```lean
 theorem hoare_consequence_pre' (P P' Q : Assertion) (c : Com)
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
-  rw [validHoareTriple_def]
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
-  apply hhoare st st'
-  · assumption
-  · apply himp
-    assumption
+  apply hhoare heval
+  exact himp _ hpre
 ```
 
-::::full
-Notice that this proof passes the states `st` and `st'` to `apply
-hhoare` explicitly.  We didn't actually need to: when an argument
-of the applied theorem is not determined by the goal, `apply`
-introduces a _metavariable_ `?st` as a placeholder and lets a later
-step of the proof determine it.  Here, `assumption` instantiates
-`?st` with `st` when it discovers `st` in the assumption `heval`.
-Using `apply` this way is like telling Lean, "Be patient: The
-missing part is going to be filled in later in the proof."
-::::
-
-:::slidebreak
-:::
-
-::::terse
-`apply` will find `st` for us, using a metavariable.
-::::
+Since, after the `rw` and `intro`, the remaining steps just apply hypotheses to the goal (and each other), the
+remaining proof can be compressed into a single tactic: {tactic}`apply_rules`.
 
 ```lean
-theorem hoare_consequence_pre''' (P P' Q : Assertion) (c : Com)
+theorem hoare_consequence_pre'' (P P' Q : Assertion) (c : Com)
     (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
     {{ P }} ~c {{ Q }} := by
-  rw [validHoareTriple_def]
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
-  apply hhoare
-  · assumption
-  · apply himp
-    assumption
+  apply_rules
 ```
 
 :::slidebreak
 :::
 
-Since the remaining steps just apply hypotheses to each other, the
-entire proof can actually be compressed into a single line, by writing
-the term that `exact`ly proves the conclusion.
-
-```lean
-theorem hoare_consequence_pre'''' (P P' Q : Assertion) (c : Com)
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
-  intro st st' heval hpre
-  exact hhoare st st' heval (himp st hpre)
-```
-
-::::full
-Of course, it's hard to write such a one-liner without having gone
-through the original proof of `hoare_consequence_pre` to see the
-steps it used. But now that we know the shape of the argument, it's
-a good bet that the same trick will also work for
-`hoare_consequence_post`.
-::::
-
-:::slidebreak
-:::
-
-::::terse
-...as can the proof for the postcondition consequence
-rule.
-::::
+The same trick works for `hoare_consequence_post`.
 
 ```lean
 theorem hoare_consequence_post' (P Q Q' : Assertion) (c : Com)
     (hhoare : {{ P }} ~c {{ Q' }}) (himp : Q' ->> Q) :
     {{ P }} ~c {{ Q }} := by
+  rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
-  exact himp st' (hhoare st st' heval hpre)
+  apply_rules
 ```
 
 :::slidebreak
 :::
 
-We can also use a metavariable to streamline a proof
-(`hoare_asgn_example1`), that we did earlier as an example of
-using the consequence rule:
+We can also leave a metavariable for `P'` in `hoare_asgn_example1`, that we did earlier as an example of using the consequence rule:
 
 ```lean
 theorem hoare_asgn_example1' :
-    {{True}} X := 1; {{X = 1}} := by
-  apply hoare_consequence_pre  -- no need to state an assertion
-  · apply hoare_asgn
-  · unfold AssertImplies Assertion.sub
+    {{True}} X := 1 {{X = 1}} := by
+  apply hoare_consequence_pre -- not specifying `(P' := ...)` leaves a "hole" `?P'`
+  · -- The goal is `{{?P'}} X := 1 {{X = 1}}`
+    exact hoare_asgn -- Assigns `?P'` to `{{X = 1}} [X ↦ 1]` (automatically closing the `case P'`)
+  · rw [assertImplies_def]
     intro st _
-    rfl
+    simp
 ```
 
 :::slidebreak
@@ -2332,10 +2329,10 @@ automation.
 
 ```lean
 theorem hoare_asgn_example1'' :
-    {{True}} X := 1; {{X = 1}} := by
+    {{True}} X := 1 {{X = 1}} := by
   apply hoare_consequence_pre
-  · apply hoare_asgn
-  · simp [AssertImplies, Assertion.sub, TotalMap.update_eq]
+  · exact hoare_asgn
+  · simp [assertImplies_def]
 ```
 
 Now we have quite a nice proof script: it simply identifies the
@@ -2363,11 +2360,11 @@ but cannot finish it: the leftover goal is arithmetic, so it needs
 ```lean
 theorem assertion_sub_example2' :
     {{X < 4}}
-      X := X + 1;
+      X := X + 1
     {{X < 5}} := by
   apply hoare_consequence_pre
-  · apply hoare_asgn
-  · simp [AssertImplies, Assertion.sub, TotalMap.update_eq]  -- an arithmetic goal remains
+  · exact hoare_asgn
+  · simp [assertImplies_def] -- an arithmetic goal remains
     lia
 ```
 
@@ -2378,15 +2375,22 @@ Let's introduce our own tactic to handle both that bullet and the
 bullet from example 1.  A `macro` declaration gives a name to a
 canned sequence of tactics:
 
+:::dev "Niklas Halonen (xhalo32)"
+It's unfortunate that we need to unfold `X, Y, Z, W` in `assertion_auto` as `simp` wouldn't otherwise reduce `X == Y` to `false`.
+Note that `Ident` is an `abbrev`.
+Making it an `implicit_reducible` def breaks `lia` for some reason and doesn't resolve the issue.
+```
+@[implicit_reducible]
+def Ident := String
+deriving BEq, ReflBEq, LawfulBEq, DecidableEq
+```
+:::
+
 ```lean
-/-- Prove routine facts about assertions: unfold the Hoare-logic
-definitions and lifting functions, simplify, and finish any leftover
-arithmetic with `lia`. -/
 macro "assertion_auto" : tactic =>
-  `(tactic| (intros
-             <;> try (simp [assertImplies_def, ValidHoareTriple, Assertion.sub,
-                            W, X, Y, Z] at *)
-             <;> try lia))
+  `(tactic| focus (simp [assertImplies_def, assertIff_def, validHoareTriple_def,
+                         Assertion.subst_def, X, Y, Z, W] at *
+                  <;> try lia))
 ```
 
 :::slidebreak
@@ -2395,10 +2399,10 @@ macro "assertion_auto" : tactic =>
 ```lean
 theorem assertion_sub_example2'' :
     {{X < 4}}
-      X := X + 1;
+      X := X + 1
     {{X < 5}} := by
   apply hoare_consequence_pre
-  · apply hoare_asgn
+  · exact hoare_asgn
   · assertion_auto
 ```
 
@@ -2407,9 +2411,9 @@ theorem assertion_sub_example2'' :
 
 ```lean
 theorem hoare_asgn_example1''' :
-    {{True}} X := 1; {{X = 1}} := by
+    {{True}} X := 1 {{X = 1}} := by
   apply hoare_consequence_pre
-  · apply hoare_asgn
+  · exact hoare_asgn
   · assertion_auto
 ```
 
@@ -2430,20 +2434,20 @@ automated by following the examples above.
 ```lean
 theorem assertion_sub_ex1' :
     {{ X ≤ 5 }}
-      X := 2 * X;
+      X := 2 * X
     {{ X ≤ 10 }} := by
   solution!
     apply hoare_consequence_pre
-    · apply hoare_asgn
+    · exact hoare_asgn
     · assertion_auto
 
 theorem assertion_sub_ex2' :
     {{ 0 ≤ 3 ∧ 3 ≤ 5 }}
-      X := 3;
+      X := 3
     {{ 0 ≤ X ∧ X ≤ 5 }} := by
   solution!
     apply hoare_consequence_pre
-    · apply hoare_asgn
+    · exact hoare_asgn
     · assertion_auto
 ```
 
@@ -2478,14 +2482,14 @@ assignment.  Note the use of `hoare_seq` in conjunction with
 theorem hoare_asgn_example3 (a : Aexp) (n : Nat) :
     {{a = n}}
       X := ~a;
-      skip;
+      skip
     {{X = n}} := by
   apply hoare_seq
   · -- right part of seq
-    apply hoare_skip
+    exact hoare_skip
   · -- left part of seq
     apply hoare_consequence_pre
-    · apply hoare_asgn
+    · exact hoare_asgn
     · assertion_auto
 ```
 
@@ -2531,18 +2535,18 @@ explicitly identifies `X = 1` as the intermediate assertion.
 theorem hoare_asgn_example4 :
     {{ True }}
       X := 1;
-      Y := 2;
+      Y := 2
     {{ X = 1 ∧ Y = 2 }} := by
   apply hoare_seq (Q := {{ X = 1 }})
   · -- right part of seq
     solution!
       apply hoare_consequence_pre
-      · apply hoare_asgn
+      · exact hoare_asgn
       · assertion_auto
   · -- left part of seq
     solution!
       apply hoare_consequence_pre
-      · apply hoare_asgn
+      · exact hoare_asgn
       · assertion_auto
 ```
 :::::
@@ -2592,21 +2596,20 @@ HIDE: CH: Here goes:
 :::
 
 ```lean
-def swap_program : Com :=
-  solution!(imp { Z := X; X := Y; Y := Z; })
+def swap_program : Com := solution!(imp { Z := X; X := Y; Y := Z })
 
 theorem swap_exercise :
     {{X ≤ Y}}
       ~swap_program
     {{Y ≤ X}} := by
   solution!
-    unfold swap_program
+    rw [swap_program]
     apply hoare_seq
     · apply hoare_seq
-      · apply hoare_asgn
-      · apply hoare_asgn
+      · exact hoare_asgn
+      · exact hoare_asgn
     · apply hoare_consequence_pre
-      · apply hoare_asgn
+      · exact hoare_asgn
       · assertion_auto
 ```
 :::::
@@ -2657,20 +2660,16 @@ Having chosen your `a` and `n`, proceed as follows:
 ```lean
 theorem invalid_triple : ¬ ∀ (a : Aexp) (n : Nat),
     {{ a = n }}
-      X := 3; Y := ~a;
+      X := 3; Y := ~a
     {{ Y = n }} := by
-  rw [validHoareTriple_def]
   intro h
+  simp only [validHoareTriple_def] at h
   solution!
-    specialize h (aexp { X }) 2 (X →ₜ 2 ; ∅) (Y →ₜ 3 ; X →ₜ 3 ; X →ₜ 2 ; ∅)
-    have heval : (X →ₜ 2 ; ∅) =[ X := 3; Y := X; ]=>
-        (Y →ₜ 3 ; X →ₜ 3 ; X →ₜ 2 ; ∅) := by
-      apply Com.EvalR.seq
+    specialize h (aexp { X }) 2 (st := X →ₜ 2) (st' := Y →ₜ 3 ; X →ₜ 3 ; X →ₜ 2) ?_
+    · apply Com.EvalR.seq
       · apply Com.EvalR.asgn; rfl
       · apply Com.EvalR.asgn; rfl
-    apply h at heval
-    have hcontra := heval rfl
-    simp [TotalMap.update_eq] at hcontra
+    simp at h
 ```
 :::::
 
@@ -2737,51 +2736,21 @@ Better:
 :::slidebreak
 :::
 
-::::full
-Strictly speaking, `P ∧ b` combines an assertion with a boolean
-expression.  The assertion notation handles this by evaluating `b` in
-the current state.  We'll write `bassertion b` for the resulting assertion:
-"the boolean expression `b` evaluates to `true` in the given state."
-::::
+:::dev "Niklas Halonen (xhalo32)"
+I have removed `bassertion` as it's an unnecessary abstraction and only adds overhead for the reader.
 
-::::terse
-We'll write `bassertion b` for the assertion "the boolean expression
-`b` evaluates to `true` in the given state."
-::::
-
-```lean
-def bassertion (b : Bexp) : Assertion := {{ b }}
-
-@[simp] theorem bassertion_apply (b : Bexp) (st : State) :
-    bassertion b st = (b.eval st = true) := rfl
-
-instance : Coe Bexp Assertion := ⟨bassertion⟩
-```
-
-A useful fact about `bassertion`:
-
-:::dev BeforeNextRelease
-```
-Robert Rand: This isn't an identity but that's because
-we're using [~(bassertion b st)] in our triples, instead of a more
-direct/intuitive predicate.
-
-Some alternatives: 1) P_True b and P_False b (defined directly as
-desired) 1) bassertion b false (adds relevant argument to bassertion)
-2) ((bassertion (!b)) st) (clearer, but less direct).
-```
+The following theorem is now unnecessary.
 :::
 
 ```lean
 theorem bexp_eval_false (b : Bexp) (st : State) (h : b.eval st = false) :
     ¬ ({{ b }}) st := by
+  dsimp
   simp [h]
 ```
 
 ::::full
-Here `simp` is able to find that `b.eval st` is assumed to be
-`false` (by rewriting with `h`), notice that the goal claims it is
-`true`, and use the resulting contradiction to complete the proof.
+Here, we first reduce the expression to `¬Bexp.eval st b = true` with {tactic}`dsimp`, which is trivial after we instruct `simp` to rewrite `b.eval st` to `false`.
 ::::
 
 :::dev "One An (meluge)"
@@ -2799,23 +2768,18 @@ The statement of the rule reads: given `htrue : {{ P ∧ b }} ~c1 {{Q}}`
 and `hfalse : {{ P ∧ ¬b }} ~c2 {{Q}}`, we can conclude
 `{{P}} if (~b) { ~c1 } else { ~c2 } {{Q}}`.
 
-That is (unwrapping the notations):
-
-```display
-theorem hoare_if (P Q : Assertion) (b : Bexp) (c1 c2 : Com)
-    (htrue : ValidHoareTriple (fun st => P st ∧ bassertion b st) c1 Q)
-    (hfalse : ValidHoareTriple (fun st => P st ∧ ¬ (bassertion b st)) c2 Q) :
-    ValidHoareTriple P (Com.cond b c1 c2) Q
-```
-
 ```lean
-theorem hoare_if (P Q : Assertion) (b : Bexp) (c1 c2 : Com)
+theorem hoare_if {P Q : Assertion} {b : Bexp} {c1 c2 : Com}
     (htrue : {{ P ∧ b }} ~c1 {{ Q }}) (hfalse : {{ P ∧ ¬ b }} ~c2 {{ Q }}) :
     {{ P }} if (~b) { ~c1 } else { ~c2 } {{ Q }} := by
-  intro st st' hE hP
+  rw [validHoareTriple_def] at htrue hfalse ⊢
+  intro st st' hE hpre
   inversion hE with
-  | ifTrue hb hc => exact htrue _ _ hc ⟨hP, hb⟩
-  | ifFalse hb hc => exact hfalse _ _ hc ⟨hP, bexp_eval_false b st hb⟩
+  | ifTrue hb hc1 =>
+    exact htrue hc1 ⟨hpre, hb⟩
+  | ifFalse hb hc =>
+    rw [← Bool.not_eq_true] at hb
+    exact hfalse hc ⟨hpre, hb⟩
 ```
 
 ### Example
@@ -2829,19 +2793,27 @@ the rule satisfies the specification we wanted.
 theorem if_example :
     {{True}}
       if (X = 0) {
-        Y := 2;
+        Y := 2
       } else {
-        Y := X + 1;
+        Y := X + 1
       }
     {{X ≤ Y}} := by
-  -- the proof is the same for both the true and false branches
-  apply hoare_if <;>
-  · apply hoare_consequence_pre
-    · apply hoare_asgn
+  apply hoare_if
+  · -- Then
+    apply hoare_consequence_pre
+    · exact hoare_asgn
+    · assertion_auto
+  · -- Else
+    apply hoare_consequence_pre
+    · exact hoare_asgn
     · assertion_auto
 ```
 
 :::slidebreak
+:::
+
+:::dev "Niklas Halonen (xhalo32)"
+The following paragraph is outdated (talks about old `bassertion`).
 :::
 
 As we did earlier, it would be nice to eliminate all the low-level
@@ -2874,10 +2846,10 @@ theorem if_example'' :
     {{X ≤ Y}} := by
   apply hoare_if
   · apply hoare_consequence_pre
-    · apply hoare_asgn
+    · exact hoare_asgn
     · assertion_auto
   · apply hoare_consequence_pre
-    · apply hoare_asgn
+    · exact hoare_asgn
     · assertion_auto
 ```
 
@@ -2890,13 +2862,12 @@ We can even shorten it a little bit more.
 theorem if_example''' :
     {{True}}
       if (X = 0) {
-        Y := 2;
+        Y := 2
       } else {
-        Y := X + 1;
+        Y := X + 1
       }
     {{X ≤ Y}} := by
-  apply hoare_if <;> apply hoare_consequence_pre <;>
-    (try apply hoare_asgn) <;> try assertion_auto
+  apply hoare_if <;> apply hoare_consequence_pre hoare_asgn (by assertion_auto)
 ```
 
 ::::::full
@@ -2916,7 +2887,7 @@ theorem if_minus_plus :
     {{Y = X + Z}} := by
   solution!
     apply hoare_if <;> apply hoare_consequence_pre <;>
-      (try apply hoare_asgn) <;> try assertion_auto
+      (try exact hoare_asgn) <;> try assertion_auto
 ```
 :::::
 
@@ -3054,14 +3025,14 @@ defined them correctly.
 
 ```lean
 theorem if1true_test :
-    ∅ =[ if1 (X = 0) { X := 1; } ]=> (X →ₜ 1 ; ∅) := by
+    ∅ =[ if1 (X = 0) { X := 1; } ]=> (X →ₜ 1) := by
   solution!
     apply Com.EvalR.if1True
     · rfl
     · apply Com.EvalR.asgn; rfl
 
 theorem if1false_test :
-    (X →ₜ 2 ; ∅) =[ if1 (X = 0) { X := 1; } ]=> (X →ₜ 2 ; ∅) := by
+    (X →ₜ 2) =[ if1 (X = 0) { X := 1; } ]=> (X →ₜ 2) := by
   solution!
     apply Com.EvalR.if1False
     rfl
@@ -3191,7 +3162,7 @@ theorem hoare_if1_good :
   solution!
     apply hoare_if1
     · apply hoare_consequence_pre
-      · apply hoare_asgn
+      · exact hoare_asgn
       · assertion_auto
     · assertion_auto
 ```
@@ -3627,7 +3598,7 @@ theorem while_example :
   apply hoare_consequence_post
   · apply hoare_while
     apply hoare_consequence_pre
-    · apply hoare_asgn
+    · exact hoare_asgn
     · assertion_auto
   · assertion_auto
 ```
@@ -4020,7 +3991,7 @@ def ex1_repeat : Com :=
   }
 
 theorem ex1_repeat_works :
-    ∅ =[ ex1_repeat ]=> (Y →ₜ 1 ; X →ₜ 1 ; ∅) := by
+    ∅ =[ ex1_repeat ]=> (Y →ₜ 1 ; X →ₜ 1) := by
   solution!
     apply Com.EvalR.repeatEnd
     · apply Com.EvalR.seq
@@ -4173,11 +4144,11 @@ theorem ex2_repeat_hoare_repeat :
   unfold ex2_repeat
   apply hoare_consequence
   · apply hoare_repeat (Q := {{ Y > 0 }})
-    · apply hoare_seq <;> apply hoare_asgn
+    · apply hoare_seq <;> exact hoare_asgn
     · apply hoare_seq
-      · apply hoare_asgn
+      · exact hoare_asgn
       · apply hoare_consequence_pre
-        · apply hoare_asgn
+        · exact hoare_asgn
         · assertion_auto
   · -- body of repeat if exiting right away
     assertion_auto
@@ -4256,9 +4227,9 @@ example :
   apply hoare_consequence
   · apply hoare_repeat' (P := {{ Y > 0 }})
     apply hoare_seq
-    · apply hoare_asgn
+    · exact hoare_asgn
     · apply hoare_consequence_pre
-      · apply hoare_asgn
+      · exact hoare_asgn
       · -- body of repeat if looping
         unfold AssertImplies Assertion.sub
         intro st hy
@@ -4284,9 +4255,9 @@ example :
   apply hoare_consequence
   · apply hoare_repeat' (P := {{ X > 0 ∧ Y > 0 }})
     apply hoare_seq
-    · apply hoare_asgn
+    · exact hoare_asgn
     · apply hoare_consequence_pre
-      · apply hoare_asgn
+      · exact hoare_asgn
       · -- body of repeat if looping
         unfold AssertImplies Assertion.sub
         intro st ⟨hx, hy⟩
@@ -5025,7 +4996,7 @@ theorem assert_assume_example :
     · apply hoare_seq
       · apply hoare_seq
         · apply hoare_assert
-        · apply hoare_asgn
+        · exact hoare_asgn
       · apply hoare_assume
     · assertion_auto
 ```

--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -1249,18 +1249,22 @@ attribute [irreducible] ValidHoareTriple
 ::::
 
 ::::details "Notation encoding: printing triples back"
-This delaborator works only with {name}`Com` from Imp.
+The delaborator is agnostic to the command type: it prints the command with
+whatever printer is registered for its constructors and splices the result
+into the triple, so a language-extension chapter only has to register a
+printer for its own `Com`.
 ```lean
 namespace Assertion.Delab
 open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
 @[delab app.HasTriple.Triple]
 def delabTriple : Delab := whenPPOption getPPNotation do
   guard <| (← getExpr).isAppOfArity ``HasTriple.Triple 5
-  guard <| (← getExpr).getArg! 0 == mkConst ``Com
   let P ← withNaryArg 2 delabAssn
-  let c ← withNaryArg 3 delabComInner
+  let c ← withNaryArg 3 delab
   let Q ← withNaryArg 4 delabAssn
-  ``({{ $P }} $c:imp_com {{ $Q }})
+  match c with
+  | `(imp { $c:imp_com }) => ``({{ $P }} $c:imp_com {{ $Q }})
+  | c => ``({{ $P }} ~$c {{ $Q }})
 
 end Assertion.Delab
 ```
@@ -3020,6 +3024,55 @@ scoped macro_rules
     pure c
 ```
 
+The delaborators are re-instantiated the same way: the Imp printer is
+parameterized over the namespace of the command constructors, so the
+extended printer is that printer at `If1.Com` plus one case for `if1`.
+
+::::details "Notation encoding: printing the extended commands back"
+```lean
+namespace Delab
+open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
+
+/-- Rebuild `imp_com` syntax from an `If1.Com` term. -/
+partial def delabComInner : DelabM (TSyntax `imp_com) :=
+  delabComInnerFor ``Com do
+    let e ← getExpr
+    guard <| e.isAppOfArity ``Com.if1 2
+    let b ← withAppFn <| withAppArg delabBexpInner
+    let c ← withAppArg If1.Delab.delabComInner
+    `(imp_com| if1 ($b) {$c})
+
+@[delab app.If1.Com.skip, delab app.If1.Com.asgn, delab app.If1.Com.seq,
+  delab app.If1.Com.cond, delab app.If1.Com.whileDo, delab app.If1.Com.if1]
+partial def delabCom : Delab := whenPPOption getPPNotation do
+  guard <| match_expr ← getExpr with
+    | Com.skip => true
+    | Com.asgn _ _ => true
+    | Com.seq _ _ => true
+    | Com.cond _ _ _ => true
+    | Com.whileDo _ _ => true
+    | Com.if1 _ _ => true
+    | _ => false
+  match ← delabComInner with
+  | `(imp_com| ~$e) => pure e
+  | e => `(term| imp { $e })
+
+end Delab
+```
+::::
+
+:::ignore
+```lean -show
+/-- info: imp {
+  if1 (X = 0) {
+    X := 1
+  }
+} : Com -/
+#guard_msgs in
+#check imp { if1 (X = 0) { X := 1 } }
+```
+:::
+
 :::::exercise (rating := 2) (name := "if1_ceval")
 Add two new evaluation rules to relation `Com.EvalR`, below, for
 `if1`. Let the rules for `if` guide you.
@@ -3112,9 +3165,17 @@ theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
 attribute [irreducible] ValidHoareTriple
 ```
 
-:::dev "Niklas Halonen (xhalo32)"
-Do we want a delaborator for the new `Com`?
-Could we somehow extend the one in `Imp` with `if1`?
+:::ignore
+```lean -show
+/--
+info: {{True}}
+  if1 (X = 0) {
+    skip
+  } {{True}} : Prop
+-/
+#guard_msgs in
+#check ({{ True }} if1 (X = 0) { skip } {{ True }})
+```
 :::
 
 :::::exercise (rating := 2) (name := "hoare_if1") (manual := true)

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -1106,17 +1106,39 @@ inductive Com.EvalR : Com → State → State → Prop where
   | whileTrue (st st' st'' : State) (b : Bexp) (c : Com) (hb : b.eval st = true)
       (hc : EvalR c st st') (hloop : Com.EvalR (imp {while (~b) {~c}}) st' st'') :
       EvalR (imp {while (~b) {~c}}) st st''
+```
 
-notation:40 st0:41 " =[ " c " ]=> " st1:41 => Com.EvalR c st0 st1
+:::instructors
+We define evaluation notation using a typeclass to make extending it easier in the Hoare chapter.
+:::
+
+```lean
+class HasEval (Com : Type) (St : Type) where
+  Eval : Com → St → St → Prop
+
+namespace HasEval
+scoped notation:40 st0:41 " =[ " c " ]=> " st1:41 => Eval c st0 st1
+
 -- Also accept a bare Imp command between the brackets, so concrete programs can
 -- be written without the `imp { … }` wrapper. Bare `Com` terms still work via the
 -- notation above; splice a Lean term into the command with `~`.
-syntax:40 term:41 " =[ " imp_com " ]=> " term:41 : term
-macro_rules
-  | `($st0 =[ $c:imp_com ]=> $st1) => `($st0 =[ imp { $c } ]=> $st1)
+scoped syntax:40 term:41 " =[ " imp_com " ]=> " term:41 : term
+scoped macro_rules
+  | `($st0 =[ $c:imp_com ]=> $st1) => ``($st0 =[ imp { $c } ]=> $st1)
+end HasEval
+
+instance : HasEval Com State where
+  Eval := Com.EvalR
+
+open scoped HasEval
+
+@[app_unexpander Com.EvalR]
+def Com.unexpandEvalR : Lean.PrettyPrinter.Unexpander
+  | `($_ $c $st0 $st1) => ``($st0 =[ ~$c ]=> $st1)
+  | _ => throw ()
 ```
 
-:::dev "Niklas Halonen"
+:::dev "Niklas Halonen (xhalo32)"
 Currently in Hoare.lean the info view in
 ```
 theorem hoare_skip (P : Assertion) :

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -688,12 +688,12 @@ declare_syntax_cat imp_com
 
 ::::details "Notation encoding: commands, macro rules"
 ```lean
-/-- The command that does nothing (`skip;`) -/
-syntax ident ";" : imp_com
+/-- The command that does nothing (`skip`) -/
+syntax ident : imp_com
 /-- Sequencing: one command after another -/
-syntax imp_com ppDedent(ppLine imp_com) : imp_com
+syntax imp_com ";" ppDedent(ppLine imp_com) : imp_com
 /-- Assignment -/
-syntax ident " := " imp_aexp ";" : imp_com
+syntax ident " := " imp_aexp : imp_com
 /-- Conditional -/
 syntax "if " "(" imp_bexp ")" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}" ppHardSpace "else" ppHardSpace "{") ppLine imp_com ppDedent(ppLine "}") : imp_com
 /-- Loop -/
@@ -706,12 +706,12 @@ syntax:min "imp" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") : term
 
 open Lean in
 macro_rules
-  | `(imp { $x:ident ; }) =>
+  | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
     else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
-  | `(imp { $c1 $c2 }) =>
+  | `(imp { $c1 ; $c2 }) =>
     `(Com.seq (imp {$c1}) (imp {$c2}))
-  | `(imp { $x:ident := $a; }) =>
+  | `(imp { $x:ident := $a }) =>
     `(Com.asgn $x (aexp {$a}))
   | `(imp { if ($b) {$c1} else {$c2} }) =>
     `(Com.cond (bexp {$b}) (imp {$c1}) (imp {$c2}))
@@ -743,20 +743,20 @@ partial def delabComInner : DelabM (TSyntax `imp_com) := do
     match_expr e with
     -- `mkIdent` rather than a quotation-literal `skip`, which would pick up
     -- macro hygiene scopes and print as `skip✝`.
-    | Com.skip => `(imp_com| $(mkIdent `skip):ident ;)
+    | Com.skip => `(imp_com| $(mkIdent `skip):ident)
     | Com.asgn _ _ =>
       match ← withAppFn <| withAppArg getExpr with
       | .const nm _ =>
         let a ← withAppArg delabAexpInner
-        `(imp_com| $(mkIdent nm):ident := $a;)
+        `(imp_com| $(mkIdent nm):ident := $a)
       | .lit (.strVal s) =>
         let a ← withAppArg delabAexpInner
-        `(imp_com| $(mkIdent (.mkSimple s)):ident := $a;)
+        `(imp_com| $(mkIdent (.mkSimple s)):ident := $a)
       | _ => `(imp_com| ~$(← delab))
     | Com.seq _ _ =>
       let s1 ← withAppFn <| withAppArg delabComInner
       let s2 ← withAppArg delabComInner
-      `(imp_com| $s1 $s2)
+      `(imp_com| $s1; $s2)
     | Com.cond _ _ _ =>
       let b  ← withAppFn <| withAppFn <| withAppArg delabBexpInner
       let c1 ← withAppFn <| withAppArg delabComInner
@@ -800,7 +800,7 @@ def fact_in_lean : Com := imp {
   Y := 1;
   while (Z ≠ 0) {
     Y := Y * Z;
-    Z := Z - 1;
+    Z := Z - 1
   }
 }
 ```
@@ -818,7 +818,7 @@ imp {
   Y := 1;
   while (Z ≠ 0) {
     Y := Y * Z;
-    Z := Z - 1;
+    Z := Z - 1
   }
 }
 -/
@@ -847,15 +847,15 @@ is *displayed*. Nevertheless, seeing the raw constructors is sometimes very help
 
 ```lean
 /-- info: imp {
-  X := X + 1;
+  X := X + 1
 } : Com -/
 #guard_msgs in
-#check imp { X := X + 1; }
+#check imp { X := X + 1 }
 
 /-- info: Com.asgn X ((Aexp.id X).plus (Aexp.num 1)) : Com -/
 #guard_msgs in
 set_option pp.notation false in
-#check imp { X := X + 1; }
+#check imp { X := X + 1 }
 ```
 
 ## More Examples
@@ -868,8 +868,8 @@ A few more examples.
 Assignment:
 
 ```lean
-def plus2 : Com := imp { X := X + 2; }
-def XtimesYinZ : Com := imp { Z := X * Y; }
+def plus2 : Com := imp { X := X + 2 }
+def XtimesYinZ : Com := imp { Z := X * Y }
 ```
 
 :::slidebreak
@@ -880,7 +880,7 @@ Loops:
 ```lean
 def subtract_slowly_body : Com := imp {
   Z := Z - 1;
-  X := X - 1;
+  X := X - 1
 }
 
 def subtract_slowly : Com := imp {
@@ -902,24 +902,24 @@ def subtract_3_from_5_slowly : Com := imp {
 An infinite loop:
 
 ```lean
-def loop : Com := imp { while (true) { skip; } }
+def loop : Com := imp { while (true) { skip } }
 ```
 
-::::hide
+:::hide
 ```
 /- Exponentiation: -/
 def exp_body : Com := imp {
   Z := Z * X;
-  Y := Y - 1;
+  Y := Y - 1
 }
 def pexp : Com := imp {
-  while (Y <> 0) {
+  while (Y ≠ 0) {
     ~exp_body
   }
 }
 /- (Note that `pexp` should be run in a state where `Z` is `1`.) -/
 ```
-::::
+:::
 
 # Evaluating Commands
 
@@ -945,9 +945,9 @@ In SmallStep we need to package the state and command into a pair,
 ```lean
 def Com.ceval_fun_no_while (st : State) (c : Com) : State :=
   match c with
-  | imp {skip;} => st
-  | imp {x := ~a;} => (x →ₜ a.eval st ; st)
-  | imp {~c1 ~c2} =>
+  | imp {skip} => st
+  | imp {x := ~a} => (x →ₜ a.eval st ; st)
+  | imp {~c1; ~c2} =>
       let st' := ceval_fun_no_while st c1
       ceval_fun_no_while st' c2
   | imp {if (~b) {~c1} else {~c2}} =>
@@ -1077,11 +1077,11 @@ TODO Propose you use inline notation such as `Com.EvalR (imp {skip;}) st st`
 
 ```lean
 inductive Com.EvalR : Com → State → State → Prop where
-  | skip (st : State) : EvalR (imp {skip;}) st st
+  | skip (st : State) : EvalR (imp {skip}) st st
   | asgn (st : State) (a : Aexp) (n : Nat) (x : Ident) (h : a.eval st = n) :
-      EvalR (imp {x := ~a;}) st (x →ₜ n ; st)
+      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
   | seq (c1 c2 : Com) (st st' st'' : State) (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
-      EvalR (imp {~c1 ~c2}) st st''
+      EvalR (imp {~c1; ~c2}) st st''
   | ifTrue (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
       EvalR (imp {if (~b) {~c1} else {~c2}}) st st'
@@ -1103,6 +1103,30 @@ macro_rules
   | `($st0 =[ $c:imp_com ]=> $st1) => `($st0 =[ imp { $c } ]=> $st1)
 ```
 
+:::dev "Niklas Halonen"
+Currently in Hoare.lean the info view in
+```
+theorem hoare_skip (P : Assertion) :
+    {{ P }} skip {{ P }} := by
+  intro st st' h hp
+```
+displays
+```
+P : Assertion
+st st' : State
+h : st =[
+  imp {
+    skip
+  } ]=>
+  st'
+hp : P st
+⊢ P st'
+```
+but we would like it to display `h : st =[ skip ]=> st'`.
+
+This issue is also relevant for other `EvalR` present in Hoare.lean.
+:::
+
 The cost of defining evaluation as a relation instead of a function is
 that we now need to construct a _proof_ that some program evaluates to
 some result state, rather than letting Lean's computation mechanism do
@@ -1113,9 +1137,9 @@ example :
     ∅ =[
       X := 2;
       if (X ≤ 1) {
-        Y := 3;
+        Y := 3
       } else {
-        Z := 4;
+        Z := 4
       }
     ]=> (Z →ₜ 4 ; X →ₜ 2 ; ∅) := by
   -- We must supply the intermediate state.
@@ -1132,7 +1156,7 @@ example :
     ∅ =[
       X := 0;
       Y := 1;
-      Z := 2;
+      Z := 2
     ]=> (Z →ₜ 2 ; Y →ₜ 1 ; X →ₜ 0 ; ∅) := by
   solution!
     apply Com.EvalR.seq (st' := (X →ₜ 0 ; ∅))
@@ -1368,7 +1392,7 @@ def pup_to_n : Com := solution!(
     Y := 0;
     while (1 ≤ X) {
       Y := Y + X;
-      X := X - 1;
+      X := X - 1
     }
   })
 ```
@@ -1541,18 +1565,18 @@ exactly when `c` is while-free, then prove it equivalent to `Com.no_whiles`.
 ```lean
 def Com.no_whiles (c : Com) : Bool :=
   match c with
-  | imp {skip;} => true
-  | imp {_x := ~_a;} => true
-  | imp {~c1 ~c2} => no_whiles c1 && no_whiles c2
+  | imp {skip} => true
+  | imp {_x := ~_a} => true
+  | imp {~c1; ~c2} => no_whiles c1 && no_whiles c2
   | imp {if (~_) {~ct} else {~cf}} => no_whiles ct && no_whiles cf
   | imp {while (~_) {~_}} => false
 
 inductive Com.NoWhilesR : Com → Prop where
   -- SOLUTION
-  | skip : Com.NoWhilesR (imp { skip; })
-  | asgn (x : Ident) (a : Aexp) : Com.NoWhilesR (imp { x := ~a; })
+  | skip : Com.NoWhilesR (imp { skip })
+  | asgn (x : Ident) (a : Aexp) : Com.NoWhilesR (imp { x := ~a })
   | seq (c1 c2 : Com) (h1 : Com.NoWhilesR c1) (h2 : Com.NoWhilesR c2) :
-      Com.NoWhilesR (imp { ~c1 ~c2 })
+      Com.NoWhilesR (imp { ~c1; ~c2 })
   | cond (b : Bexp) (c1 c2 : Com) (h1 : Com.NoWhilesR c1) (h2 : Com.NoWhilesR c2) :
       Com.NoWhilesR (imp { if (~b) { ~c1 } else { ~c2 } })
   -- END SOLUTION

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -1114,9 +1114,13 @@ inductive Com.EvalR : Com → State → State → Prop where
 We define evaluation notation using a typeclass to make extending it easier in the Hoare chapter.
 :::
 
+:::dev "Niklas Halonen (xhalo32)"
+Setting `In` and `Out` as `outParam`s is a hack to resolve various typeclass synthesis problems or at least I can't explain why it works.
+:::
+
 ```lean
-class HasEval (Com : Type) (St : Type) where
-  Eval : Com → St → St → Prop
+class HasEval (Com : Type) (In : outParam <| Type) (Out : outParam <| Type) where
+  Eval : Com → In → Out → Prop
 
 namespace HasEval
 scoped notation:40 st0:41 " =[ " c " ]=> " st1:41 => Eval c st0 st1
@@ -1129,7 +1133,7 @@ scoped macro_rules
   | `($st0 =[ $c:imp_com ]=> $st1) => ``($st0 =[ imp { $c } ]=> $st1)
 end HasEval
 
-instance : HasEval Com State where
+instance : HasEval Com State State where
   Eval := Com.EvalR
 
 open scoped HasEval

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -129,6 +129,8 @@ We give the type of variable identifiers a name, `Ident`. For now it is just
    `String`; naming it makes the intent clearer.
 
 ```lean
+open scoped MyGetElem
+
 abbrev Ident := String
 abbrev State := TotalMap Ident Nat
 ```
@@ -192,16 +194,22 @@ def W : Ident := "W"
 def X : Ident := "X"
 def Y : Ident := "Y"
 def Z : Ident := "Z"
-
-attribute [simp] X Y Z W -- this helps `simp` reduce some total map terms
 ```
 
-::::full
-(This convention for naming program variables (`X`, `Y`, `Z`) clashes a
-bit with our earlier use of uppercase letters for types. Since we're not
-using polymorphism heavily in the chapters developed to Imp, this
-overloading should not cause confusion.)
-::::
+:::instructors
+Making `X Y Z W` `@[simp] def`s has the unwanted side effect that sometimes `X` and `"X"` get mixed up in the proof state.
+We opt to use `simp +decide` instead (e.g. in `assertion_auto` in Hoare).
+:::
+
+:::ignore
+```lean -show
+example : X ≠ Y := by
+  simp +decide
+
+example : (Y →ₜ 1 ; X →ₜ 2)[X] = 2 := by
+  simp +decide
+```
+:::
 
 ## Notations
 %%%
@@ -209,8 +217,7 @@ tag := "imp-notations"
 %%%
 
 ::::full
-To make Imp programs easier to read and write, we introduce some notations and implicit
-coercions.
+To make Imp programs easier to read and write, we introduce some notations.
 
 You do not need to understand exactly what these declarations do. Briefly, though,
 here is how the two blocks below fit together:
@@ -336,40 +343,9 @@ macro_rules
 ```
 ::::
 
-::::full
-We make it a little easier to write Imp programs using normal constructors (i.e.,
-without notation), by using _implicit coercions_.
-In Lean, a `Coe` instance tells the elaborator how to turn a
-value of one type into another automatically:
- - `Coe Ident Aexp` lets us write a bare variable (an `Ident`) where an
-   `Aexp` is expected; the identifier is implicitly wrapped with `id`.
- - `OfNat Aexp n` lets us write a numeric literal where an `Aexp` is
-   expected; it is implicitly wrapped with `num`.
- - `Coe Bool Bexp` lets us write a boolean literal (`true`/`false`) where a
-   `Bexp` is expected; it is implicitly wrapped with `bool`.
-::::
-
 ```lean
-instance : Coe Ident Aexp where
-  coe := .id
-
-instance (n : Nat) : OfNat Aexp n where
-  ofNat := .num n
-
-instance : Coe Bool Bexp where
-  coe := .bool
-```
-
-::::full
-With these coercions we can write `.plus 3 (.mult X 2)` instead of the fully
-   explicit `.plus (.num 3) (.mult (.id "X") (.num 2))`, and `.and true (.not …)`
-   instead of `.and (.bool true) (.not …)`. More readably still, the concrete
-   syntax from the {ref "imp-notations"}[Notations section] lets us write these examples directly:
-::::
-
-```lean
-def example_aexp : Aexp := aexp { 3 + (X * 2) }
-def example_bexp : Bexp := bexp { true ∧ ¬(X ≤ 4) }
+#check aexp { 3 + (X * 2) }
+#check bexp { true ∧ ¬(X ≤ 4) }
 ```
 
 ## Delaborators
@@ -570,7 +546,7 @@ The arithmetic and boolean evaluators must now be extended to handle
 variables, taking a state `st` as an extra argument.  A variable is
 looked up in the state with the map-indexing notation `st[x]` from the
 `Typeclasses` chapter.
-For the notation to work, we need to `open scoped MyGetElem`, which opens only the scoped items like notation from the module.
+For the notation to work, we used `open scoped MyGetElem` earlier, which opens only the scoped items like notation from the module.
 ::::
 
 :::terse
@@ -578,8 +554,6 @@ Now we need to add an `st` parameter to both evaluation functions:
 :::
 
 ```lean
-open scoped MyGetElem
-
 def Aexp.eval (st : State) (a : Aexp) : Nat :=
   match a with
   | num   n     =>  n
@@ -666,30 +640,13 @@ inductive Com where
 ```
 
 :::instructors
-Concrete syntax for commands, in the style of the `ssft24` Imp `Stmt`
-   grammar: an `imp_com` category with an `imp { … }` hook. Assignments and
-   `skip` end in `;`, and sequencing is written by juxtaposition. Conditions use
-   the `imp_bexp` grammar; the branch/loop bodies use the `imp_com` grammar. As
-   with expressions, `~c` escapes back to an ordinary Lean term of type `Com`.
-:::
-
-::::details "Notation encoding: commands"
-```lean
-/-- Imp commands -/
-declare_syntax_cat imp_com
-```
-::::
-
-:::instructors
-`skip` is *not* a reserved keyword: it is accepted through a bare
-   identifier-terminated command (`syntax ident ";" : imp_com`) and recognised
-   in the macro below, which rejects any other identifier. This keeps `skip`
-   usable as the bare constructor name {name}`Com.skip` in `match`/`induction`
-   elsewhere in the file, and avoids reserving `skip` globally.
+We don't make `skip` a reserved keyword on purpose because otherwise `skip` couldn't be used as a name and {name}`Com.skip` would not work.
 :::
 
 ::::details "Notation encoding: commands, macro rules"
 ```lean
+/-- Imp commands -/
+declare_syntax_cat imp_com
 /-- The command that does nothing (`skip`) -/
 syntax ident : imp_com
 /-- Sequencing: one command after another -/
@@ -706,8 +663,10 @@ syntax:max "~" term:max : imp_com
 /-- Include an Imp command in Lean code -/
 syntax:min "imp" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") : term
 
+namespace Com
+
 open Lean in
-macro_rules
+scoped macro_rules
   | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
     else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
@@ -721,6 +680,10 @@ macro_rules
     `(Com.whileDo (bexp {$b}) (imp {$c}))
   | `(imp { ~$c }) =>
     pure c
+
+end Com
+
+open scoped Com
 ```
 ::::
 
@@ -738,17 +701,11 @@ unrecognized subcommand with the `~` escape.
 namespace Imp.Delab
 open Lean PrettyPrinter Delaborator SubExpr
 
-/-- Rebuild `imp_com` concrete syntax from a command term whose constructors
-live in namespace `ns` — `Com` for Imp itself, and an extension chapter's own
-command type elsewhere, with its constructors beyond Imp's five handled by
-`extra`.  Constructors are matched by name (`ns ++ `seq`, …) because each
-extension declares a fresh inductive; there is no shared type to match on. -/
 partial def delabComInnerFor (ns : Name) (extra : DelabM (TSyntax `imp_com)) :
     DelabM (TSyntax `imp_com) := do
   let e ← getExpr
   let stx ←
-    -- `mkIdent` rather than a quotation-literal `skip`, which would pick up
-    -- macro hygiene scopes and print as `skip✝`.
+    -- Using `(imp_com| skip)` would delaborate as `skip✝`. `mkIdent` fixes this.
     if e.isConstOf (ns ++ `skip) then
       `(imp_com| $(mkIdent `skip):ident)
     else if e.isAppOfArity (ns ++ `asgn) 2 then
@@ -802,6 +759,14 @@ end Imp.Delab
 :::ignore
 ```lean -show
 section
+/--
+info: imp {
+  skip
+} : Com
+-/
+#guard_msgs in
+#check imp { skip }
+
 variable (x : Ident) (a : Aexp)
 /-- info: imp {
   x := ~a

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -738,15 +738,20 @@ unrecognized subcommand with the `~` escape.
 namespace Imp.Delab
 open Lean PrettyPrinter Delaborator SubExpr
 
-/-- Rebuild `imp_com` concrete syntax from a `Com` term. -/
-partial def delabComInner : DelabM (TSyntax `imp_com) := do
+/-- Rebuild `imp_com` concrete syntax from a command term whose constructors
+live in namespace `ns` — `Com` for Imp itself, and an extension chapter's own
+command type elsewhere, with its constructors beyond Imp's five handled by
+`extra`.  Constructors are matched by name (`ns ++ `seq`, …) because each
+extension declares a fresh inductive; there is no shared type to match on. -/
+partial def delabComInnerFor (ns : Name) (extra : DelabM (TSyntax `imp_com)) :
+    DelabM (TSyntax `imp_com) := do
   let e ← getExpr
   let stx ←
-    match_expr e with
     -- `mkIdent` rather than a quotation-literal `skip`, which would pick up
     -- macro hygiene scopes and print as `skip✝`.
-    | Com.skip => `(imp_com| $(mkIdent `skip):ident)
-    | Com.asgn _ _ =>
+    if e.isConstOf (ns ++ `skip) then
+      `(imp_com| $(mkIdent `skip):ident)
+    else if e.isAppOfArity (ns ++ `asgn) 2 then
       match ← withAppFn <| withAppArg getExpr with
       | .lit (.strVal s) =>
         let a ← withAppArg delabAexpInner
@@ -755,21 +760,26 @@ partial def delabComInner : DelabM (TSyntax `imp_com) := do
         let `($x:ident) ← withAppFn <| withAppArg delab | failure
         let a ← withAppArg delabAexpInner
         `(imp_com| $x:ident := $a)
-    | Com.seq _ _ =>
-      let s1 ← withAppFn <| withAppArg delabComInner
-      let s2 ← withAppArg delabComInner
+    else if e.isAppOfArity (ns ++ `seq) 2 then
+      let s1 ← withAppFn <| withAppArg (delabComInnerFor ns extra)
+      let s2 ← withAppArg (delabComInnerFor ns extra)
       `(imp_com| $s1; $s2)
-    | Com.cond _ _ _ =>
+    else if e.isAppOfArity (ns ++ `cond) 3 then
       let b  ← withAppFn <| withAppFn <| withAppArg delabBexpInner
-      let c1 ← withAppFn <| withAppArg delabComInner
-      let c2 ← withAppArg delabComInner
+      let c1 ← withAppFn <| withAppArg (delabComInnerFor ns extra)
+      let c2 ← withAppArg (delabComInnerFor ns extra)
       `(imp_com| if ($b) {$c1} else {$c2})
-    | Com.whileDo _ _ =>
+    else if e.isAppOfArity (ns ++ `whileDo) 2 then
       let b ← withAppFn <| withAppArg delabBexpInner
-      let c ← withAppArg delabComInner
+      let c ← withAppArg (delabComInnerFor ns extra)
       `(imp_com| while ($b) {$c})
-    | _ => `(imp_com| ~$(← delab))
+    else
+      extra <|> `(imp_com| ~$(← delab))
   annAsTerm stx
+
+/-- Rebuild `imp_com` concrete syntax from a `Com` term. -/
+partial def delabComInner : DelabM (TSyntax `imp_com) :=
+  delabComInnerFor ``Com failure
 
 @[delab app.Com.skip, delab app.Com.asgn, delab app.Com.seq,
   delab app.Com.cond, delab app.Com.whileDo]

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -192,6 +192,8 @@ def W : Ident := "W"
 def X : Ident := "X"
 def Y : Ident := "Y"
 def Z : Ident := "Z"
+
+attribute [simp] X Y Z W -- this helps `simp` reduce some total map terms
 ```
 
 ::::full
@@ -1154,7 +1156,7 @@ h : st =[
     skip
   } ]=>
   st'
-hp : P st
+hst : P st
 ⊢ P st'
 ```
 but we would like it to display `h : st =[ skip ]=> st'`.

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -746,13 +746,13 @@ partial def delabComInner : DelabM (TSyntax `imp_com) := do
     | Com.skip => `(imp_com| $(mkIdent `skip):ident)
     | Com.asgn _ _ =>
       match ← withAppFn <| withAppArg getExpr with
-      | .const nm _ =>
-        let a ← withAppArg delabAexpInner
-        `(imp_com| $(mkIdent nm):ident := $a)
       | .lit (.strVal s) =>
         let a ← withAppArg delabAexpInner
         `(imp_com| $(mkIdent (.mkSimple s)):ident := $a)
-      | _ => `(imp_com| ~$(← delab))
+      | _ =>
+        let `($x:ident) ← withAppFn <| withAppArg delab | failure
+        let a ← withAppArg delabAexpInner
+        `(imp_com| $x:ident := $a)
     | Com.seq _ _ =>
       let s1 ← withAppFn <| withAppArg delabComInner
       let s2 ← withAppArg delabComInner
@@ -786,6 +786,19 @@ partial def delabCom : Delab := whenPPOption getPPNotation do
 end Imp.Delab
 ```
 ::::
+
+:::ignore
+```lean -show
+section
+variable (x : Ident) (a : Aexp)
+/-- info: imp {
+  x := ~a
+} : Com -/
+#guard_msgs in
+#check imp { x := ~a }
+end
+```
+:::
 
 ::::full
 As an example, here is the factorial function again, written as a formal

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -35,7 +35,7 @@ and do not use tactics not in this table; in particular,
 | `Automation`      | `lia`, `try`, `repeat`, `specialize`, `trivial`, `simp`, `generalize` |
 | `Typeclasses`     | `decide` |
 | `HL` chapters     | *(none new)* |
-| `HL/Hoare`        | `show` (in a solution only) |
+| `HL/Hoare`        | `show` (in a solution only), `apply_rules` |
 
 Additional notation beyond the `Basics` is also introduced gradually alongside
 the tactics. The table below similarly lists new notation, which should also be


### PR DESCRIPTION
This PR reworks many of the proofs to be more idiomatic Lean (at least according to my intuition).

We also made the Imp command syntax in Imp.lean use semicolons in sequencing rather than after assignment.

## Unresolved questions

Right before we introduce the `apply_rules` automation, we show the reader that they don't need to use `rw [assertImplies_def] at himp` since `apply_rules` can work with `P ->> P'` by its definition. How do we want to explain this?