### PR TITLE
Use Lean terminology for types

### DIFF
--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -101,8 +101,8 @@ A datatype definition:
 :::
 
 ::::full
-Let's start with a very simple example.  The following declaration tells
-Lean that we are defining a set of data values, i.e. a _type_.
+Let's start with a very simple example.  The following declaration introduces
+a new type and lists its possible values.
 ::::
 
 ```lean
@@ -701,8 +701,8 @@ TODO
 
 ::::full
 The enumerated types we have seen so far are so-named because
-their definitions explicitly enumerate a finite set of
-elements: their constructors. Here is a more interesting
+their definitions explicitly list all of their values, one
+constructor at a time. Here is a more interesting
 inductive type definition, `Color`, where one of the constructors
 takes an argument:
 ::::
@@ -1332,7 +1332,7 @@ namespace NatPlayground
 All the types we have defined so far — both enumerated types
 such as {name}`Day`, {name}`MyBool`, and {name}`Playground.Bit` and tuple types such as
 {name}`Playground.Nibble` built from them — are finite. The natural numbers, on
-the other hand, are an infinite set, so we'll need to use a
+the other hand, form an infinite type, so we'll need to use a
 slightly richer form of inductive type declaration to represent
 them: _recursive_ inductive types.
 

--- a/LF/IndProp.lean
+++ b/LF/IndProp.lean
@@ -570,7 +570,7 @@ wow!
 
 ## Example: Binary relation for comparing numbers
 
-A binary _relation_ on a set `α` has Lean type `α → α → Prop`.
+A binary _relation_ on a type `α` has Lean type `α → α → Prop`.
 This is a family of propositions parameterized by two elements
 of `α` -- i.e., a proposition about pairs of elements of `α`.
 

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -354,7 +354,7 @@ there if we just go on like this.
 
 ::::full
 To prove interesting facts about numbers, lists, and other
-inductively defined sets, we often need a more powerful reasoning
+inductive types, we often need a more powerful reasoning
 principle: _induction_.
 :::dev "Benjamin Pierce (bcpierce00)"
 I changed boldface back to italic here, but I'm happy to discuss using boldface in a principled and consistent (and sparing) way...

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -979,17 +979,17 @@ them. 'Nuff said.)
 ::::full
 Proofs by induction over datatypes like {name}`NatList` are a
 little less familiar than standard natural number induction, but
-the idea is equally simple.  Each `inductive` declaration defines
-a set of data values that can be built up using the declared
+the idea is equally simple.  Each `inductive` declaration defines a
+type whose values can be built up using the declared
 constructors. For example, a boolean can be either {name}`true` or
 {name}`false`; a number can be either {lean}`0` or else {name}`Nat.succ` applied to another
 number; and a list can be either {lean}`[]` or else `::` applied to a
 number and a list.  Moreover, applications of the declared
 constructors to one another are the _only_ possible shapes that
-elements of an inductively defined set can have.
+values of an inductive type can have.
 
 This last fact directly gives rise to a way of reasoning about
-inductively defined sets: a number is either {lean}`0` or else it is {lean}`Nat.succ`
+inductive types: a number is either {lean}`0` or else it is {lean}`Nat.succ`
 applied to some _smaller_ number; a list is either {lean}`[]` or else
 it is `::` applied to some number and some _smaller_ list;
 etc.  Thus, if we have in mind some proposition `P` that mentions a

--- a/LF/Scratch.lean
+++ b/LF/Scratch.lean
@@ -335,7 +335,7 @@ namespace NatPlayground
   All the types we have defined so far -- both "enumerated
   types" such as `Day`, `Bool`, and `Bit` and tuple types such as
   `Nibble` built from them -- are finite.  The natural numbers, on
-  the other hand, are an infinite set, so we'll need to use a
+  the other hand, form an infinite type, so we'll need to use a
   slightly richer form of type declaration to represent them.
 -/
 


### PR DESCRIPTION
I read through the current sources for places where “set” was still being used in the Rocq sense of a whole datatype.

This changes the clear cases to “type” or “value,” while leaving genuine mathematical sets, simp sets, sets of rules, and ordinary uses unchanged.

A couple of these lines overlap with #213 and #228, since those PRs edit the same files.

Closes #226.