### PR TITLE
Polish the Logical Foundations postscript

### DIFF
--- a/LF/Postscript.lean
+++ b/LF/Postscript.lean
@@ -9,27 +9,23 @@ htmlSplit := .never
 file := some "Postscript"
 %%%
 
-:::dev
-The FULL version could use some real text
-:::
-
-Congratulations: We've made it to the end of _Logical Foundations_!
+Congratulations: We've reached the end of _Logical Foundations_!
 
 # Looking Back
 
-We've covered quite a bit of ground so far.  Here's a quick review...
+We've covered quite a bit of ground. Along the way, we developed three
+connected themes:
 
-- _Functional programming_:
-       - "declarative" programming style (recursion over immutable
-         data structures, rather than looping over mutable arrays
-         or pointer structures)
-       - higher-order functions
-       - polymorphism
+_Functional programming_:
+
+- recursive definitions over immutable data
+- higher-order functions
+- polymorphism
 
 :::slidebreak
 :::
 
-- _Logic_, the mathematical basis for software engineering:
+_Logic_, the mathematical basis for software engineering:
 
 ```
        logic                        calculus
@@ -37,102 +33,49 @@ We've covered quite a bit of ground so far.  Here's a quick review...
 software engineering       mechanical/civil engineering
 ```
 
-- inductively defined sets and relations
+- inductively defined propositions and relations
 - inductive proofs
 - proof objects
 
 :::slidebreak
 :::
 
-- _Lean_, an industrial-strength proof assistant
-- functional core language
-- core tactics
-- automation
+_Lean_, an industrial-strength proof assistant:
+
+- a functional programming language
+- tactics for constructing proofs
+- proof automation
 
 # Looking Forward
 
-OLD: If what you've seen so far has whetted your interest, you have
-several choices for further reading in later volumes of the
-_Software Foundations_ series.  Some of these are intended to be
-accessible to readers immediately after finishing _Logical
-Foundations_; others require a few chapters from Volume 2,
-_Programming Language Foundations_.  The Preface chapter in each
-volume gives details about prerequisites.
+The next volumes carry these ideas into programming-language theory
+and program verification:
 
-FINISH: As of August 2026, there are two more volumes written in Lean.
+- _{volumeName "ts"}[]_ develops operational semantics and type systems,
+  including the simply typed lambda calculus and the progress and
+  preservation theorems.
 
-    _Hoare Logic_: This short volume describes one of the primary methods
-    for reasoning about _imperative_ programs- programs with state and
-    mutation, like C++, Java, C, and Assembly- in a pure logic
-    like Lean's. This method, called _Hoare Logic_, is embeddable into
-    Lean's type system and is a powerful tool for determining
-    the correct behavior of imperative code. Since most of the code
-    in the wild today is imperative, this technique is both well-established
-    and popular among industry professionals who analyze and fortify the
-    correctness of systems.
+- _{volumeName "hl"}[]_ introduces imperative programs and Hoare logic,
+  a framework for stating and proving correctness properties of programs
+  with mutable state.
 
-    _Type Systems_: Another tool for reasoning about the correctness of a program
-    is a _type system_. You have interacted thoroughly with Lean's rich type system,
-    which is one of the most complex in a modern programming language. Most
-    languages have type systems that are far less complex, but which still provide
-    incredibly useful guardrails against ill-behaved programs. In this volume you
-    will explore how to read, analyze, and design type systems in a proof assistant.
-
-
-
-:::dev BeforeNextRelease
-```
-Might be worth explicitly advertising each volume, like
-this?  Some danger of redunancy tho...
-
-        - _Programming Language Foundations_ (volume 2, by a set of
-          authors similar to this book's) covers material that
-          might be found in a graduate course on the theory of
-          programming languages, including Hoare logic, operational
-          semantics, and type systems.
-
-        - _Verified Functional Algorithms_ (volume 3, by Andrew
-          Appel) builds on the themes of functional programming and
-          program verification in Rocq, addressing a range of topics
-          that might be found in a standard data structures course,
-          with an eye to formal verification.
-```
-:::
+Both volumes build directly on the definitions and proof techniques
+introduced here.
 
 # Resources
 
-Here are some other good places to learn more...
+This volume also contains optional sections and exercises that develop
+some topics further.
 
-- This book includes some optional chapters covering topics
-  that you may find useful.  Take a look at the #<a
-  href="toc.html">#table of contents#</a># and the #<a
-  href="deps.html">#chapter dependency diagram#</a># to find
-  them.
+For questions about Lean, the
+[Lean community Zulip](https://leanprover.zulipchat.com/) is an active
+place to ask questions and discuss formalization.
 
-- For questions about Rocq, the `#coq` area of Stack
-  Overflow (<https://stackoverflow.com/questions/tagged/coq>)
-  is an excellent community resource.
+The following books continue in several different directions:
 
-- Here are some great books on functional programming
-     - Learn You a Haskell for Great Good, by Miran Lipovaca
-       Lipovaca 2011.
-     - Real World Haskell, by Bryan O'Sullivan, John Goerzen,
-       and Don Stewart O'Sullivan 2008
-     - ...and many other excellent books on Haskell, OCaml,
-       Scheme, Racket, Scala, F sharp, etc., etc.
-
-- And some further resources for Rocq:
-    - Certified Programming with Dependent Types, by Adam
-      Chlipala Chlipala 2013.
-    - Interactive Theorem Proving and Program Development:
-      Coq'Art: The Calculus of Inductive Constructions, by Yves
-      Bertot and Pierre Casteran Bertot 2004.
-
-- If you're interested in real-world applications of formal
-  verification to critical software, see the Postscript chapter
-  of _Programming Language Foundations_.
-
-- For applications of Rocq in building verified systems, the
-  lectures and course materials for the 2017 DeepSpec Summer
-  School are a great resource.
-  <https://deepspec.org/event/dsss17/index.html>
+- [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/)
+  explores Lean as a programming language.
+- [Theorem Proving in Lean 4](https://docs.lean-lang.org/theorem_proving_in_lean4/)
+  gives a systematic introduction to Lean's logic and proof language.
+- [Mathematics in Lean](https://leanprover-community.github.io/mathematics_in_lean/)
+  develops formalized mathematics using Lean and Mathlib.


### PR DESCRIPTION
I gave the LF Postscript a focused pass so it reads as a finished chapter rather than a translated draft. This removes the remaining scaffolding, tightens the recap, points readers toward the next two volumes, and replaces the old Rocq links with current Lean resources.

Tested with:
- `lake build LF.Postscript`
- `make lf-student`
- `make style-check`