### PR TITLE
Remove `abbrev`s (#189)

### DIFF
--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -2775,14 +2775,14 @@ The following reasoning principle is _not_ derivable with the tools we've seen s
 ::::
 
 ```lean
-def excluded_middle := ∀ a : Prop, a ∨ ¬ a
+def ExcludedMiddle := ∀ a : Prop, a ∨ ¬ a
 ```
 
 ::::full
 To understand operationally why this is the case, recall that,
 to prove a statement of the form {lean}`a ∨ b`, we use the {tactic}`left` and {tactic}`right`
 tactics, which effectively require knowing which side of the disjunction
-holds. But the universally quantified {lean}`a` in {lean}`excluded_middle` is an
+holds. But the universally quantified {lean}`a` in {lean}`ExcludedMiddle` is an
 _arbitrary_ proposition, which we know nothing about. We don't have enough
 information to choose which of {tactic}`left` or {tactic}`right` to apply.
 
@@ -2975,17 +2975,17 @@ theorem not_exists_dist (α : Type) (p : α → Prop) :
 :::::exercise (rating := 5) (name := "classical_axioms")
 For those who like a challenge, here is an exercise adapted from the Coq'Art
 book by Bertot and Casteran (p. 123). Each of the following five statements,
-together with {lean}`excluded_middle`, can be considered as characterizing
+together with {lean}`ExcludedMiddle`, can be considered as characterizing
 classical logic. We can't prove any one of them in Lean without `Classical`,
 but adding any _one_ of them as an axiom allows us to work classically.
 
 To see this, prove that all six propositions (these five plus
-{lean}`excluded_middle`) are equivalent.
+{lean}`ExcludedMiddle`) are equivalent.
 
 Hint: Rather than considering all pairs of statements pairwise,
 prove a single circular chain of implications that connects them all.
 You should not use {tactic}`by_cases`, as this implicitly introduces
-a dependency on {lean}`excluded_middle`.
+a dependency on {lean}`ExcludedMiddle`.
 
 :::dev "Jonathan Chan"
 If the hint suggests proving the implications in a loop,
@@ -2993,30 +2993,30 @@ why do the solutions not do this?
 :::
 
 ```lean
-def peirce := ∀ a b : Prop, ((a → b) → a) → a
+def Peirce := ∀ a b : Prop, ((a → b) → a) → a
 
-def not_not := ∀ a : Prop, ¬ ¬ a → a
+def NotNot := ∀ a : Prop, ¬ ¬ a → a
 
-def de_morgan_not_and_not := ∀ a b : Prop, ¬ (¬ a ∧ ¬ b) → a ∨ b
+def DeMorganNotAndNot := ∀ a b : Prop, ¬ (¬ a ∧ ¬ b) → a ∨ b
 
-def imp_or := ∀ a b : Prop, (a → b) → (¬ a ∨ b)
+def ImpOr := ∀ a b : Prop, (a → b) → (¬ a ∨ b)
 
-def consequentia_mirabilis := ∀ a : Prop, (¬ a → a) → a
+def ConsequentiaMirabilis := ∀ a : Prop, (¬ a → a) → a
 
 -- SOLUTION
-theorem imp_or_em : imp_or → excluded_middle := by
+theorem ImpOr_em : ImpOr → ExcludedMiddle := by
   intro h a
   obtain hna | ha := h a a (fun ha => ha)
   · right; exact hna
   · left; exact ha
 
-theorem em_imp_or : excluded_middle → imp_or := by
+theorem em_ImpOr : ExcludedMiddle → ImpOr := by
   intro h a b hab
   obtain ha | hna := h a
   · right; exact hab ha
   · left; exact hna
 
-theorem em_demorgan : excluded_middle → de_morgan_not_and_not := by
+theorem em_demorgan : ExcludedMiddle → DeMorganNotAndNot := by
   intro h a b hnn
   obtain ha | hna := h a
   · left; exact ha
@@ -3024,46 +3024,46 @@ theorem em_demorgan : excluded_middle → de_morgan_not_and_not := by
     · right; exact hb
     · exfalso; exact hnn ⟨hna, hnb⟩
 
-theorem demorgan_em : de_morgan_not_and_not → excluded_middle := by
+theorem demorgan_em : DeMorganNotAndNot → ExcludedMiddle := by
   intro h a
   apply h a (¬ a)
   intro ⟨hna, hnna⟩
   exact hnna hna
-theorem em_not_not : excluded_middle → not_not := by
+theorem em_not_not : ExcludedMiddle → NotNot := by
   intro h a hnna
   obtain ha | hna := h a
   · exact ha
   · exfalso; exact hnna hna
 
-theorem not_not_em' : not_not → excluded_middle := by
+theorem not_not_em' : NotNot → ExcludedMiddle := by
   intro h a; exact h _ (excluded_middle_irrefutable a)
 
-theorem em_cm : excluded_middle → consequentia_mirabilis := by
+theorem em_cm : ExcludedMiddle → ConsequentiaMirabilis := by
   intro h a hnaa
   obtain ha | hna := h a
   · exact ha
   · exact (hnaa hna)
 
-theorem cm_em : consequentia_mirabilis → excluded_middle := by
+theorem cm_em : ConsequentiaMirabilis → ExcludedMiddle := by
   intro hc a; apply hc
   intro h; right
   intro ha; apply h
   left; exact ha
 
-theorem cm_not_not : consequentia_mirabilis → not_not := by
+theorem cm_not_not : ConsequentiaMirabilis → NotNot := by
   intro h a hnna; apply h
   intro hna; exfalso; exact hnna hna
 
-theorem not_not_cm : not_not → consequentia_mirabilis := by
+theorem not_not_cm : NotNot → ConsequentiaMirabilis := by
   intro h a hnaa; apply h
   intro hna; exact hna (hnaa hna)
 
-theorem cm_peirce : consequentia_mirabilis → peirce := by
+theorem cm_peirce : ConsequentiaMirabilis → Peirce := by
   intro h a b haba; apply h
   intro hna; apply haba
   intro ha; contradiction
 
-theorem peirce_cm : peirce → consequentia_mirabilis := by
+theorem peirce_cm : Peirce → ConsequentiaMirabilis := by
   intro h a; exact h a False
 
 -- END SOLUTION

--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -2068,13 +2068,13 @@ In view of this theorem, we can say that the boolean computation {lean}`Nat.even
 is _reflected_ in the truth of the proposition {lean}`∃ k, n = Nat.double k`.
 
 ::::hide
-```
-/- Similarly, we can state what it means for a number to be nonzero
-    in two different ways: -/
+Similarly, we can state what it means for a number to be nonzero
+in two different ways:
 
-abbrev Nonzero (n : Nat) : Prop := ∃ m, n = succ m
+```lean
+def Nonzero (n : Nat) : Prop := ∃ m, n = Nat.succ m
 
-abbrev nonzero (n : Nat) := not (n == 0)
+def nonzero (n : Nat) := not (n == 0)
 
 theorem nonzero_bool_prop (n : Nat) :
     nonzero n = true ↔ Nonzero n := by
@@ -2730,7 +2730,7 @@ theorem revAppend_nil {α : Type} {xs : List α} : revAppend [] xs = xs := rfl
 theorem revAppend_cons {α : Type} {x : α} {xs ys : List α} :
     revAppend (x :: xs) ys = revAppend xs (x :: ys) := rfl
 
-abbrev trRev {α} (xs : List α) : List α := revAppend xs []
+def trRev {α} (xs : List α) : List α := revAppend xs []
 ```
 
 This version of {lean}`List.rev` is said to be _tail recursive_, because the recursive
@@ -2775,7 +2775,7 @@ The following reasoning principle is _not_ derivable with the tools we've seen s
 ::::
 
 ```lean
-abbrev excluded_middle := ∀ a : Prop, a ∨ ¬ a
+def excluded_middle := ∀ a : Prop, a ∨ ¬ a
 ```
 
 ::::full
@@ -2993,15 +2993,15 @@ why do the solutions not do this?
 :::
 
 ```lean
-abbrev peirce := ∀ a b : Prop, ((a → b) → a) → a
+def peirce := ∀ a b : Prop, ((a → b) → a) → a
 
-abbrev not_not := ∀ a : Prop, ¬ ¬ a → a
+def not_not := ∀ a : Prop, ¬ ¬ a → a
 
-abbrev de_morgan_not_and_not := ∀ a b : Prop, ¬ (¬ a ∧ ¬ b) → a ∨ b
+def de_morgan_not_and_not := ∀ a b : Prop, ¬ (¬ a ∧ ¬ b) → a ∨ b
 
-abbrev imp_or := ∀ a b : Prop, (a → b) → (¬ a ∨ b)
+def imp_or := ∀ a b : Prop, (a → b) → (¬ a ∨ b)
 
-abbrev consequentia_mirabilis := ∀ a : Prop, (¬ a → a) → a
+def consequentia_mirabilis := ∀ a : Prop, (¬ a → a) → a
 
 -- SOLUTION
 theorem imp_or_em : imp_or → excluded_middle := by


### PR DESCRIPTION
Re [#lean-software-foundations-contributors > Abbreviations in Logic.lean](https://leanprover.zulipchat.com/#narrow/channel/607217-lean-software-foundations-contributors/topic/Abbreviations.20in.20Logic.2Elean/with/614061239), closes #189 trivially.