### PR TITLE
README: On SFL build structure, expected use

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,29 +74,6 @@ For discussions, we use a combination of tools.
 These conventions are still developing, so feel free to suggest better ways of
 working!
 
-## Repository organization and Makefile targets
-
-Each volume has its own top-level directory (LF, HL, etc.).
-
-Within that directory, each chapter has a `.lean` file, in Verso format.
-
-Running `make` at the top level produces, for each volume, four
-different ready-for-distribution outputs in a temporary top-level
-`_out` directory, each with both `.lean` and `.html` variants.
-
-- **student**   (full prose, solutions elided)
-- **solutions** (full prose, solutions shown)
-- **terse**     (little prose, no solutions, workinclass elided;
-                 for lecturing)
-- **grading**   (solutions variant with automated grading support,
-                 for instructors)
-
-There are also more specific `make` targets that build faster: see the `Makefile`.
-
-To build everything and preview it locally, do `make serve`,
-then visit http://localhost:8000
-(`make serve` builds stuff then serves `_out/` on port 8000).
-
 ## Git branches and CI
 
 We use Git and GitHub, with some simple conventions:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ per-chapter build target: a whole volume is the smallest unit.)
 The first build compiles the whole Lean toolchain's dependencies and
 takes a while; later builds are incremental.
 
-## Orientation
+## Repository organization
 
 Each volume has its own top-level directory - `LF`, `HL`, and `TS` - each
 of which is paired with a top-level `.lean` file.
@@ -51,7 +51,9 @@ written in [Verso](https://verso.lean-lang.org/) format.
 
 Running `make` at the top level produces, for each volume, four
 different ready-for-distribution outputs in a temporary top-level
-`_out` directory, each with both `.lean` and `.html` variants.
+`_out` directory, each with both `.lean` and `.html` variants (in
+`_out/<vol>/<variant>/lean/` and `_out/<vol>/<variant>/html-multi/`
+respectively).
 
 - **student**   (full prose, solutions elided)
 - **solutions** (full prose, solutions shown)

--- a/README.md
+++ b/README.md
@@ -44,8 +44,37 @@ takes a while; later builds are incremental.
 
 ## Orientation
 
-For everything else — repo layout, conventions, PR workflow — see
-[CONTRIBUTING.md](CONTRIBUTING.md).
+Each volume has its own top-level directory - `LF`, `HL`, and `TS` - each
+of which is paired with a top-level `.lean` file.
+Within each directory there are multiple `.lean` files, one per chapter,
+written in [Verso](https://verso.lean-lang.org/) format.
+
+Running `make` at the top level produces, for each volume, four
+different ready-for-distribution outputs in a temporary top-level
+`_out` directory, each with both `.lean` and `.html` variants.
+
+- **student**   (full prose, solutions elided)
+- **solutions** (full prose, solutions shown)
+- **terse**     (little prose, no solutions, workinclass elided;
+                 for lecturing)
+- **grading**   (solutions variant with automated grading support,
+                 for instructors)
+
+Students are expected to work through the student `.lean` versions,
+filling in the exercises, or to go through the HTML and switch
+to the Lean just for exercises. See [ALPHATESTERS.md](AlPHATESTERS.md)
+for additional instructions. Instructors are expected to work through
+the terse version in class, and use the grading version for grading
+homework exercises done by students. We do not keep the solutions
+private because GenAI makes this pointless: Anyone can now generate
+solutions to any exercise. The solutions aim to show well engineered
+proofs.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for much more about the
+Software Foundations in Lean project — philosophy, conventions,
+repo layout, PR workflow, etc.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To build everything and preview the HTML locally:
 
     make serve
 
-(This builds all volumes in all three variants — student / solutions / terse —
-into `_out/`, then serves that directory on port 8000.)  
+This builds all volumes in four variants — student / solutions / terse / grading —
+into `_out/`, then serves that directory on port 8000.
 
     Then open `http://localhost:8000` in a web browser.
 
@@ -62,7 +62,7 @@ different ready-for-distribution outputs in a temporary top-level
 
 Students are expected to work through the student `.lean` versions,
 filling in the exercises, or to go through the HTML and switch
-to the Lean just for exercises. See [ALPHATESTERS.md](AlPHATESTERS.md)
+to the Lean just for exercises. See [ALPHATESTERS.md](ALPHATESTERS.md)
 for additional instructions. Instructors are expected to work through
 the terse version in class, and use the grading version for grading
 homework exercises done by students. We do not keep the solutions


### PR DESCRIPTION
Answering questions from a curious outsider made me realize that you shouldn't have to go through `CONTRIBUTING.md` just to understand how the repo is organized, what `make` produces, and how to use it. So I lifted some and adjusted some text from `CONTRIBUTING.md` to the README to explain that.