### PR TITLE
Imp: Com.EvalR implicit arguments

### DIFF
--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -3387,10 +3387,10 @@ theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
   `while` are dismissed because their equations are contradictory. -/
   generalize heq : (imp { while (~b) { ~c } }) = cmd at heval
   induction heval with
-  | whileFalse b0 s0 c0 hb =>
+  | @whileFalse b0 s0 c0 hb =>
     injection heq with hbeq hceq
     simp_all
-  | whileTrue s0 s0' s0'' b0 c0 hb hc hloop ih1 ih2 =>
+  | @whileTrue s0 s0' s0'' b0 c0 hb hc hloop ih1 ih2 =>
     injection heq with hbeq hceq
     subst hbeq hceq
     exact ih2 (hhoare hc ⟨hpre, hb⟩) rfl

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -1,5 +1,6 @@
 import SFLMeta
 
+import LF.CustomTactics
 import LF.Typeclasses
 
 import Lean.PrettyPrinter.Delaborator
@@ -1067,20 +1068,20 @@ TODO Propose you use inline notation such as `Com.EvalR (imp {skip;}) st st`
 
 ```lean
 inductive Com.EvalR : Com → State → State → Prop where
-  | skip (st : State) : EvalR (imp {skip}) st st
-  | asgn (st : State) (a : Aexp) (n : Nat) (x : Ident) (h : a.eval st = n) :
+  | skip {st : State} : EvalR (imp {skip}) st st
+  | asgn {st : State} {a : Aexp} {n : Nat} {x : Ident} (h : a.eval st = n) :
       EvalR (imp {x := ~a}) st (x →ₜ n ; st)
-  | seq (c1 c2 : Com) (st st' st'' : State) (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
+  | seq {c1 c2 : Com} {st st' st'' : State} (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
       EvalR (imp {~c1; ~c2}) st st''
-  | ifTrue (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = true)
+  | ifTrue {st st' : State} {b : Bexp} {c1 c2 : Com} (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
       EvalR (imp {if (~b) {~c1} else {~c2}}) st st'
-  | ifFalse (st st' : State) (b : Bexp) (c1 c2 : Com) (hb : b.eval st = false)
+  | ifFalse {st st' : State} {b : Bexp} {c1 c2 : Com} (hb : b.eval st = false)
       (hc : EvalR c2 st st') :
       EvalR (imp {if (~b) {~c1} else {~c2}}) st st'
-  | whileFalse (b : Bexp) (st : State) (c : Com) (hb : b.eval st = false) :
+  | whileFalse {b : Bexp} {st : State} {c : Com} (hb : b.eval st = false) :
       EvalR (imp {while (~b) {~c}}) st st
-  | whileTrue (st st' st'' : State) (b : Bexp) (c : Com) (hb : b.eval st = true)
+  | whileTrue {st st' st'' : State} {b : Bexp} {c : Com} (hb : b.eval st = true)
       (hc : EvalR c st st') (hloop : Com.EvalR (imp {while (~b) {~c}}) st' st'') :
       EvalR (imp {while (~b) {~c}}) st st''
 ```
@@ -1211,10 +1212,10 @@ Is the following proposition provable?
 ```lean
 theorem quiz1_answer (c : Com) (st st' : State)
     (h : st =[ skip; ~c ]=> st') : st =[ c ]=> st' := by
-  cases h with
-  | seq _ _ _ smid _ h1 h2 =>
-      cases h1 with
-      | skip _ => exact h2
+  inversion h with
+  | seq smid h1 h2 =>
+    inversion h1
+    exact h2
 ```
 :::
 ::::
@@ -1251,9 +1252,9 @@ Is the following proposition provable?
 ```lean
 theorem quiz3_answer (b : Bexp) (c : Com) (st st' : State)
     (h : st =[ if (~b) { ~c } else { ~c } ]=> st') : st =[ c ]=> st' := by
-  cases h with
-  | ifTrue _ _ _ _ _ hb hc => exact hc
-  | ifFalse _ _ _ _ _ hb hc => exact hc
+  inversion h with
+  | ifTrue hb hc => exact hc
+  | ifFalse hb hc => exact hc
 ```
 :::
 ::::
@@ -1280,16 +1281,16 @@ theorem quiz4_answer (b : Bexp) (hbtrue : ∀ st, b.eval st = true)
       (s =[ cmd ]=> s') → cmd = (imp { while (~b) { ~c } }) → False := by
     intro cmd s s' hce
     induction hce with
-    | whileFalse b0 s0 c0 hbf =>
+    | @whileFalse b0 s0 c0 hbf =>
         intro heq; injection heq with e1 _; subst e1
         rw [hbtrue s0] at hbf; simp at hbf
-    | whileTrue s0 s0' s0'' b0 c0 hbt hc0 hloop ih1 ih2 =>
+    | @whileTrue s0 s0' s0'' b0 c0 hbt hc0 hloop ih1 ih2 =>
         intro heq; exact ih2 heq
-    | skip s0 => intro heq; simp at heq
-    | asgn s0 a n x h => intro heq; simp at heq
-    | seq d1 d2 s0 s0' s0'' hh1 hh2 ih1 ih2 => intro heq; simp at heq
-    | ifTrue s0 s0' b0 d1 d2 hb0 hc0 ih => intro heq; simp at heq
-    | ifFalse s0 s0' b0 d1 d2 hb0 hc0 ih => intro heq; simp at heq
+    | @skip s0 => intro heq; simp at heq
+    | @asgn s0 a n x h => intro heq; simp at heq
+    | @seq d1 d2 s0 s0' s0'' hh1 hh2 ih1 ih2 => intro heq; simp at heq
+    | @ifTrue s0 s0' b0 d1 d2 hb0 hc0 ih => intro heq; simp at heq
+    | @ifFalse s0 s0' b0 d1 d2 hb0 hc0 ih => intro heq; simp at heq
   exact key _ st st' hev rfl
 ```
 :::
@@ -1349,34 +1350,34 @@ Informal proof needed! (And one can surely be found in some past
 theorem ceval_deterministic (c : Com) (st st1 st2 : State)
     (e1 : st =[ c ]=> st1) (e2 : st =[ c ]=> st2) : st1 = st2 := by
   induction e1 generalizing st2 with
-  | skip st =>
-      cases e2 with
-      | skip => rfl
-  | asgn st a n x h =>
-      cases e2 with
-      | asgn _ _ n' _ h' => subst h; subst h'; rfl
-  | seq c1 c2 st st' st'' h1 h2 ih1 ih2 =>
-      cases e2 with
-      | seq _ _ _ st2' _ h1' h2' =>
+  | @skip st =>
+      inversion e2
+      rfl
+  | @asgn st a n x h =>
+      inversion e2 with
+      | asgn h' => subst h; subst h'; rfl
+  | @seq c1 c2 st st' st'' h1 h2 ih1 ih2 =>
+      inversion e2 with
+      | seq st2' h1' h2' =>
           have hst : st' = st2' := ih1 _ h1'
           subst hst
           exact ih2 _ h2'
-  | ifTrue st st' b c1 c2 hb hc ih =>
-      cases e2 with
-      | ifTrue _ _ _ _ _ hb' hc' => exact ih _ hc'
-      | ifFalse _ _ _ _ _ hb' hc' => simp_all
-  | ifFalse st st' b c1 c2 hb hc ih =>
-      cases e2 with
-      | ifTrue _ _ _ _ _ hb' hc' => simp_all
-      | ifFalse _ _ _ _ _ hb' hc' => exact ih _ hc'
-  | whileFalse b st c hb =>
-      cases e2 with
-      | whileFalse _ _ _ hb' => rfl
-      | whileTrue _ _ _ _ _ hb' hc' hl' => simp_all
-  | whileTrue st st' st'' b c hb hc hloop ih1 ih2 =>
-      cases e2 with
-      | whileFalse _ _ _ hb' => simp_all
-      | whileTrue _ st2' _ _ _ hb' hc' hl' =>
+  | @ifTrue st st' b c1 c2 hb hc ih =>
+      inversion e2 with
+      | ifTrue hb' hc' => exact ih _ hc'
+      | ifFalse hb' hc' => simp_all
+  | @ifFalse st st' b c1 c2 hb hc ih =>
+      inversion e2 with
+      | ifTrue hb' hc' => simp_all
+      | ifFalse hb' hc' => exact ih _ hc'
+  | @whileFalse b st c hb =>
+      inversion e2 with
+      | whileFalse hb' => rfl
+      | whileTrue hb' hc' hl' => simp_all
+  | @whileTrue st st' st'' b c hb hc hloop ih1 ih2 =>
+      inversion e2 with
+      | whileFalse hb' => simp_all
+      | whileTrue st2' _ hc' hl' =>
           have hst : st' = st2' := ih1 _ hc'
           subst hst
           exact ih2 _ hl'
@@ -1476,8 +1477,8 @@ theorem plus2_spec (st : State) (n : Nat) (st' : State)
   -- Inverting `heval` forces one step of the `ceval` computation: since
   -- `plus2` is an assignment, `st'` must be `st` extended at `X`.
   unfold plus2 at heval
-  cases heval with
-  | asgn _ _ m _ h =>
+  inversion heval with
+  | asgn m h =>
       simp only [Aexp.eval_plus, Aexp.eval_id, Aexp.eval_num] at h
       rw [TotalMap.update_eq]
       lia
@@ -1497,8 +1498,8 @@ theorem XtimesYinZ_spec1 (st : State) (nx ny : Nat) (st' : State)
     (hx : st[X] = nx) (hy : st[Y] = ny) (heval : st =[ XtimesYinZ ]=> st') :
     st'[Z] = nx * ny := by
   unfold XtimesYinZ at heval
-  cases heval with
-  | asgn _ _ n _ h =>
+  inversion heval with
+  | asgn n h =>
       simp only [Aexp.eval_mult, Aexp.eval_id] at h
       subst hx hy
       rw [TotalMap.update_eq]
@@ -1524,6 +1525,11 @@ GRADE_MANUAL 3: XtimesYinZ_spec
 :::
 :::::
 
+:::dev "Niklas Halonen (xhalo32)"
+We should use the `generalize` tactic here instead of `have key`.
+I've changed some Hoare proofs from `have key` to `generalize` but the tactic hasn't been explained yet.
+:::
+
 :::::exercise (rating := 3) (name := "loop_never_stops")
 Hint: proceed by induction on the assumed derivation showing that `loop`
 terminates.  Most of the cases are immediately contradictory and so can be
@@ -1538,16 +1544,16 @@ theorem loop_never_stops (st st' : State) : ¬ (st =[ loop ]=> st') := by
     have key : ∀ (c : Com) (s s' : State), (s =[ c ]=> s') → c = loop → False := by
       intro c s s' hce
       induction hce with
-      | whileFalse b s0 c0 hb =>
+      | @whileFalse b s0 c0 hb =>
           intro heq; unfold loop at heq; injection heq with e1 _
           subst e1; simp at hb
-      | whileTrue s0 s0' s0'' b c0 hb hc hloop ih1 ih2 =>
+      | @whileTrue s0 s0' s0'' b c0 hb hc hloop ih1 ih2 =>
           intro heq; exact ih2 heq
-      | skip s0 => intro heq; simp [loop] at heq
-      | asgn s0 a n x h => intro heq; simp [loop] at heq
-      | seq c1 c2 s0 s0' s0'' h1 h2 ih1 ih2 => intro heq; simp [loop] at heq
-      | ifTrue s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
-      | ifFalse s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
+      | @skip s0 => intro heq; simp [loop] at heq
+      | @asgn s0 a n x h => intro heq; simp [loop] at heq
+      | @seq c1 c2 s0 s0' s0'' h1 h2 ih1 ih2 => intro heq; simp [loop] at heq
+      | @ifTrue s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
+      | @ifFalse s0 s0' b c1 c2 hb hc ih => intro heq; simp [loop] at heq
     exact key loop st st' contra rfl
 ```
 :::::
@@ -1629,20 +1635,20 @@ theorem no_whiles_terminating (c : Com) (st : State) (h : Com.NoWhilesR c) :
     ∃ st', st =[ c ]=> st' := by
   solution!
     induction h generalizing st with
-    | skip => exact ⟨st, .skip st⟩
-    | asgn x a => exact ⟨(x →ₜ a.eval st ; st), .asgn st a (a.eval st) x rfl⟩
-    | seq c1 c2 h1 h2 ih1 ih2 =>
+    | @skip => exact ⟨st, .skip⟩
+    | @asgn x a => exact ⟨(x →ₜ a.eval st ; st), .asgn rfl⟩
+    | @seq c1 c2 h1 h2 ih1 ih2 =>
         obtain ⟨st', hc1⟩ := ih1 st
         obtain ⟨st'', hc2⟩ := ih2 st'
-        exact ⟨st'', .seq c1 c2 st st' st'' hc1 hc2⟩
-    | cond b c1 c2 h1 h2 ih1 ih2 =>
+        exact ⟨st'', .seq hc1 hc2⟩
+    | @cond b c1 c2 h1 h2 ih1 ih2 =>
         cases hb : b.eval st with
         | true =>
             obtain ⟨st', hc1⟩ := ih1 st
-            exact ⟨st', .ifTrue st st' b c1 c2 hb hc1⟩
+            exact ⟨st', .ifTrue hb hc1⟩
         | false =>
             obtain ⟨st', hc2⟩ := ih2 st
-            exact ⟨st', .ifFalse st st' b c1 c2 hb hc2⟩
+            exact ⟨st', .ifFalse hb hc2⟩
 ```
 
 And here is an alternative solution by induction on `c` (using
@@ -1653,23 +1659,23 @@ And here is an alternative solution by induction on `c` (using
 theorem no_whiles_terminating' (c : Com) (st1 : State)
     (hb : c.no_whiles = true) : ∃ st2, st1 =[ c ]=> st2 := by
   induction c generalizing st1 with
-  | skip => exact ⟨st1, .skip st1⟩
-  | asgn x a => exact ⟨(x →ₜ a.eval st1 ; st1), .asgn st1 a (a.eval st1) x rfl⟩
-  | seq c1 c2 ih1 ih2 =>
+  | @skip => exact ⟨st1, .skip⟩
+  | @asgn x a => exact ⟨(x →ₜ a.eval st1 ; st1), .asgn rfl⟩
+  | @seq c1 c2 ih1 ih2 =>
       simp only [Com.no_whiles, Bool.and_eq_true] at hb
       obtain ⟨st1', hc1⟩ := ih1 st1 hb.1
       obtain ⟨st1'', hc2⟩ := ih2 st1' hb.2
-      exact ⟨st1'', .seq c1 c2 st1 st1' st1'' hc1 hc2⟩
-  | cond b ct cf ih1 ih2 =>
+      exact ⟨st1'', .seq hc1 hc2⟩
+  | @cond b ct cf ih1 ih2 =>
       simp only [Com.no_whiles, Bool.and_eq_true] at hb
       cases hbev : b.eval st1 with
       | true =>
           obtain ⟨st2, h⟩ := ih1 st1 hb.1
-          exact ⟨st2, .ifTrue st1 st2 b ct cf hbev h⟩
+          exact ⟨st2, .ifTrue hbev h⟩
       | false =>
           obtain ⟨st2, h⟩ := ih2 st1 hb.2
-          exact ⟨st2, .ifFalse st1 st2 b ct cf hbev h⟩
-  | whileDo b c ih => simp [Com.no_whiles] at hb
+          exact ⟨st2, .ifFalse hbev h⟩
+  | @whileDo b c ih => simp [Com.no_whiles] at hb
 -- END SOLUTION
 ```
 :::::


### PR DESCRIPTION
Also changed to using `inversion` tactic in a couple of places. I think there are still plenty of `cases` which should be changed to `inversion` at some point.

Even though this PR is based on my own branch, I wanted to keep it separate since it's about another file (Imp).

Should we make the same changes in Slang?