### PR TITLE
Typeclasses: explain `MyGetElem` and encapsulation better

### DIFF
--- a/LF/Typeclasses.lean
+++ b/LF/Typeclasses.lean
@@ -693,12 +693,14 @@ def emptyNatMap : TotalMap Nat Nat := ∅
 
 ### Getting Elements
 
-While `TotalMap`s happen to be implemented as functions under the hood,
-we would prefer not to expose this
-fact in its public interface. Accordingly, we define new operations for querying and
-updating mappings. As a first attempt at a query operation, playing the role that `find` played for the {ref "Lists"}[Lists] chapter's
-list-based maps, we could define a function
-`get` for getting the value associated with a key:
+:::dev "Niklas Halonen (xhalo32)"
+I have clarified here that `MyGetElem` has nothing to do with the encapsulation (`inner` vs `get`).
+It's simply notation that expands to the public API (`get`).
+:::
+
+While `TotalMap`s happen to be implemented as functions under the hood, we would prefer not to expose this fact in its public interface.
+Accordingly, we define new operations for querying and updating mappings.
+We define a function `get` for getting the value associated with a key playing the role that `find` played for the {ref "Lists"}[Lists] chapter's list-based maps,
 
 ```lean
 def get {α β : Type} (m : TotalMap α β) (a : α) := m.inner a
@@ -811,7 +813,7 @@ notation `m[a]` to access elements of a map `m`.
 ```lean
 namespace TotalMap
 
-theorem getElem_def {α  β : Type} (m : TotalMap α β) (a : α) : m[a] = m.get a := by rfl
+theorem getElem_def {α β : Type} (m : TotalMap α β) (a : α) : m[a] = m.get a := by rfl
 
 example : emptyNatMap[1] = default := by rfl
 
@@ -824,7 +826,7 @@ We want the public API of {name}`TotalMap` to use the `m[a]` notation instead of
 
 ```lean
 @[simp]
-theorem get_eq_getElem {α β : Type} (m : TotalMap α β) (a : α) : m.get a = m[a] := by rfl
+theorem get_eq_getElem {α β : Type} (m : TotalMap α β) (a : α) : m.get a = m[a] := rfl
 
 example {n : Nat} : emptyNatMap.get n = emptyNatMap[n] := by
   simp
@@ -1032,12 +1034,15 @@ unclear what the Lean `IndProp` chapter will end up containing. Revisit later.
 
 :::dev "Niklas Halonen (xhalo32)"
 Regarding reflection: I have used `show ("bar" == "foo") = false by simp` in some of the above sections which would be good to explain in more detail in the reflection section.
-Disclaimer: I don't actually know how Lean proves it under the hood, I just assume it's relevant to reflection.
+The `BEq` instance is derived from `DecidableEq` in {name}`instBEqOfDecidableEq`.
+All of the following proofs of the fact use `decide` internally.
 ```lean
+-- set_option trace.Meta.synthInstance true in
+-- set_option trace.Meta.whnf true in
 example : ("bar" == "foo") = false := by
-  simp only [String.reduceBEq]
+  simp -- goes through a simproc `String.reduceBEq` which reduces to `decide`
 example : ("bar" == "foo") = false := by
-  rfl
+  rfl -- ends up calling `decide ("bar" = "foo")`
 example : ("bar" == "foo") = false := by
   decide
 ```
@@ -1144,7 +1149,7 @@ The type shows a `?m.4`, which indicates that Lean can't infer the type.
 A type which can't be inferred doesn't have any type classes like `MyGetElem`, so typeclass resolution gets stuck in the following example:
 
 ```lean -keep +error
-example : ({ "foo" ↦ true })["foo"] = true := rfl
+example : ({ "foo" ↦ true })["foo"] = true := by rfl
 ```
 
 ## Partial Maps
@@ -1170,25 +1175,38 @@ structure PartialMap (α : Type) (β : Type) where
 instance {α β : Type} : EmptyCollection (PartialMap α β) where
   emptyCollection := { inner := ∅ }
 
-def PartialMap.toTotal  {α β : Type} (m : PartialMap α β) : TotalMap α (Option β) := m.inner
+namespace PartialMap
 
-instance  {α β : Type} : MyGetElem (PartialMap α β) α (Option β) where
+def toTotal {α β : Type} (m : PartialMap α β) : TotalMap α (Option β) := m.inner
+
+/-- This exposes implementation-specific details of `PartialMap`.
+Avoid using this outside the `PartialMap` namespace. -/
+theorem toTotal_def {α β : Type} (m : PartialMap α β) : m.toTotal = m.inner := by rfl
+
+instance {α β : Type} : MyGetElem (PartialMap α β) α (Option β) where
   getElem m a := m.toTotal[a]
 
-theorem getElem_def  {α β : Type} (m : PartialMap α β) (a : α) : m[a] = m.toTotal[a] := rfl
+theorem getElem_def {α β : Type} (m : PartialMap α β) (a : α) : m[a] = m.toTotal[a] := rfl
+
+def emptyNatMap : PartialMap Nat Nat where
+  inner := ∅
+
+example : emptyNatMap[1] = default := by rfl
+
+example {n : Nat} : emptyNatMap[n] = none := by
+  rw [getElem_def, toTotal_def, emptyNatMap]
+  dsimp only
+  rw [TotalMap.getElem_def, TotalMap.get_def, TotalMap.empty_def, Option.default_eq_none]
+
+@[simp]
+theorem toTotal_eq_getElem {α β : Type} (m : PartialMap α β) (a : α) :
+    m.toTotal[a] = m[a] := rfl
 ```
 
-Remember that we discussed earlier with total maps that using accessing the `inner` field
-and performing function application application exposes the implementation,
-and that's why we introduced a new notation {name}`MyGetElem`?
-Here we extend that concept, and instead of using a `def` for partial maps, like this...
+Remember that we discussed earlier with total maps that accessing the `inner` field and performing function application application exposes the implementation, and that's why we introduced the API {name}`TotalMap.get`?
+We follow a similar principle with {name}`PartialMap`s, and define {name}`PartialMap.toTotal` to be the public API counterpart to {name}`PartialMap.inner`.
 
-```display
-def PartialMap (α : Type) (β : Type) := TotalMap α (Option β)`
-```
-
-...we define partial maps as a structure containing a total map.
-This more strongly hides the fact that it's implemented using a total map.
+We again want the public API to use the `m[a]` notation instead of `m.toTotal[a]` so we provide the reverse direction of {name}`getElem_def` as a {tactic}`simp` lemma to specify that the {tactic}`simp` normal form is `m[a]`.
 
 Updating a partial map at a key means storing a {name}`some` value there.
 To update, we create a new partial map from `a →ₜ some b ; m.toTotal` by wrapping it in angle brackets, i.e. using the anonymous constructor syntax.
@@ -1196,9 +1214,7 @@ This is equivalent to writing `{ inner := a →ₜ some b ; m.toTotal }`.
 We also introduce a similar notation for it as for total maps.
 
 ```lean
-namespace PartialMap
-
-def update  {α β : Type} [BEq α] (m : PartialMap α β) (a : α) (b : β) : PartialMap α β :=
+def update {α β : Type} [BEq α] (m : PartialMap α β) (a : α) (b : β) : PartialMap α β :=
   ⟨a →ₜ some b ; m.toTotal⟩
 
 notation a:55 " →ₚ " b:55 " ; " m:55 => PartialMap.update m a b
@@ -1211,8 +1227,10 @@ def examplePmap : PartialMap String Bool := "Church" →ₚ true ; "Turing" →�
 Next, we provide some fundamental properties about {name}`toTotal`:
 
 ```lean
+@[simp]
 theorem toTotal_empty {α β : Type} : (∅ : PartialMap α β).toTotal = (∅ : TotalMap α (Option β)) := rfl
 
+@[simp]
 theorem toTotal_update{α β : Type} [BEq α] (m : PartialMap α β) (a : α) (b : β) :
     (a →ₚ b ; m).toTotal = a →ₜ some b ; m.toTotal := rfl
 ```
@@ -1221,8 +1239,7 @@ As an example, here's how we can use these on some concrete maps:
 
 ```lean
 example : (2 →ₚ 3)[2] = some 3 := by
-  rw [getElem_def, toTotal_update, toTotal_empty, TotalMap.getElem_def]
-  rfl
+  rw [getElem_def, toTotal_update, toTotal_empty, TotalMap.update_eq]
 ```
 
 This also holds by definition (`rfl`), since all the rewrites in the above proof do the computation step-by-step.
@@ -1249,37 +1266,48 @@ theorem ext {α β : Type} {m₁ m₂ : PartialMap α β} (h : ∀ a : α, m₁[
 Now, let's lift the {name}`TotalMap` lemmas:
 
 ```lean
+@[simp]
 theorem getElem_empty {α β : Type} [BEq α] (a : α) : (∅ : PartialMap α β)[a] = none := by
   rw [getElem_def, toTotal_empty, TotalMap.getElem_empty, Option.default_eq_none]
 
-theorem update_eq {α β : Type} [BEq α] [ReflBEq α] (m : PartialMap α β) (a : α) (b : β) : (a →ₚ b ; m)[a] = some b := by
+@[simp]
+theorem update_eq {α β : Type} [BEq α] [ReflBEq α] (m : PartialMap α β) (a : α) (b : β) :
+    (a →ₚ b ; m)[a] = some b := by
   rw [getElem_def, toTotal_update, TotalMap.update_eq]
 
-theorem update_neq {α β : Type} [BEq α] [LawfulBEq α] {m : PartialMap α β} {a₁ a₂ : α} (h : a₁ ≠ a₂) (b : β) :
-    (a₁ →ₚ b ; m)[a₂] = m[a₂] := by
-  dsimp [getElem_def, toTotal_update]
+@[simp]
+theorem update_neq {α β : Type} [BEq α] [LawfulBEq α] {m : PartialMap α β} {a₁ a₂ : α}
+    (h : a₁ ≠ a₂) (b : β) : (a₁ →ₚ b ; m)[a₂] = m[a₂] := by
+  simp only [getElem_def, toTotal_update]
   rw [TotalMap.update_neq h]
 
 theorem update_shadow {α β : Type} [BEq α] [LawfulBEq α] (m : PartialMap α β) (a : α) (b₁ b₂ : β) :
     (a →ₚ b₂ ; a →ₚ b₁ ; m) = (a →ₚ b₂ ; m) := by
   apply ext
   intro x
-  dsimp [getElem_def, toTotal_update]
+  simp only [getElem_def, toTotal_update]
   rw [TotalMap.update_shadow]
 
-theorem update_same {α β : Type} [BEq α] [LawfulBEq α] {m : PartialMap α β} {a : α} {b : β} (h : m[a] = some b) :
-    (a →ₚ b ; m) = m := by
+theorem update_same {α β : Type} [BEq α] [LawfulBEq α] {m : PartialMap α β} {a : α} {b : β}
+    (h : m[a] = some b) : (a →ₚ b ; m) = m := by
   apply ext
   intro x
-  dsimp [getElem_def, toTotal_update]
+  simp only [getElem_def, toTotal_update]
   rw [← h, getElem_def, TotalMap.update_same]
 
-theorem update_permute {α β : Type} [BEq α] [LawfulBEq α] {m : PartialMap α β} {a₁ a₂ : α} {b₁ b₂ : β} (h : a₁ ≠ a₂) :
-    (a₁ →ₚ b₁ ; a₂ →ₚ b₂ ; m) = (a₂ →ₚ b₂ ; a₁ →ₚ b₁ ; m) := by
+theorem update_permute {α β : Type} [BEq α] [LawfulBEq α] {m : PartialMap α β} {a₁ a₂ : α}
+    {b₁ b₂ : β} (h : a₁ ≠ a₂) : (a₁ →ₚ b₁ ; a₂ →ₚ b₂ ; m) = (a₂ →ₚ b₂ ; a₁ →ₚ b₁ ; m) := by
   apply ext
   intro x
-  dsimp [getElem_def, toTotal_update]
+  simp only [getElem_def, toTotal_update]
   rw [TotalMap.update_permute h]
+
+example : (2 →ₚ 3)[2] = some 3 := by
+  simp
+
+example : examplePmap["Post"] = none := by
+  rw [examplePmap]
+  simp
 ```
 
 And let's add `{}`-notation for partial maps as well.
@@ -1316,8 +1344,8 @@ theorem subset_def {α β : Type} (m₁ m₂ : PartialMap α β) :
 We can then show that map update preserves map inclusion, that is:
 
 ```lean
-theorem update_subset {α β : Type} [BEq α] [LawfulBEq α] (m₁ m₂ : PartialMap α β) (a : α) (b : β) (h : m₁ ⊆ m₂) :
-    (a →ₚ b ; m₁) ⊆ (a →ₚ b ; m₂) := by
+theorem update_subset {α β : Type} [BEq α] [LawfulBEq α] (m₁ m₂ : PartialMap α β) (a : α) (b : β)
+    (h : m₁ ⊆ m₂) : (a →ₚ b ; m₁) ⊆ (a →ₚ b ; m₂) := by
   rw [subset_def] at h ⊢
   intro a' b' hb
   by_cases ha : a = a'

--- a/LF/Typeclasses.lean
+++ b/LF/Typeclasses.lean
@@ -693,8 +693,8 @@ def emptyNatMap : TotalMap Nat Nat := ∅
 
 ### Getting Elements
 
-:::dev "Niklas Halonen (xhalo32)"
-I have clarified here that `MyGetElem` has nothing to do with the encapsulation (`inner` vs `get`).
+:::instructors
+Note that `MyGetElem` has nothing to do with the encapsulation (`inner` vs `get`).
 It's simply notation that expands to the public API (`get`).
 :::
 
@@ -1203,7 +1203,7 @@ theorem toTotal_eq_getElem {α β : Type} (m : PartialMap α β) (a : α) :
     m.toTotal[a] = m[a] := rfl
 ```
 
-Remember that we discussed earlier with total maps that accessing the `inner` field and performing function application application exposes the implementation, and that's why we introduced the API {name}`TotalMap.get`?
+We previously defined {name}`TotalMap.get` so that users can retrieve elements from a {name}`TotalMap` in a manner independent of its actual implementation, which is a function stored in {name}`TotalMap.inner`.
 We follow a similar principle with {name}`PartialMap`s, and define {name}`PartialMap.toTotal` to be the public API counterpart to {name}`PartialMap.inner`.
 
 We again want the public API to use the `m[a]` notation instead of `m.toTotal[a]` so we provide the reverse direction of {name}`getElem_def` as a {tactic}`simp` lemma to specify that the {tactic}`simp` normal form is `m[a]`.


### PR DESCRIPTION
- Added `PartialMap.toTotal_def` plus `emptyNatMap` examples
- Added `PartialMap.toTotal_eq_getElem`
- Removed mention of `def PartialMap`
- Added examples that use the `PartialMap` simp lemmas
- Made some simp lemmas use `rfl` instead of `by rfl` to be `dsimp` compatible