### PR TITLE
Fix infinite regress in Imp delaborator

### DIFF
--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -752,7 +752,10 @@ partial def delabComInner : DelabM (TSyntax `imp_com) := do
       | .lit (.strVal s) =>
         let a ← withAppArg delabAexpInner
         `(imp_com| $(mkIdent (.mkSimple s)):ident := $a;)
-      | _ => `(imp_com| ~$(← delab))
+      | _ =>
+        let x ← withAppFn <| withAppArg delab
+        let a ← withAppArg delab
+        `(imp_com| ~($(mkIdent ``Com.asgn) $x $a))
     | Com.seq _ _ =>
       let s1 ← withAppFn <| withAppArg delabComInner
       let s2 ← withAppArg delabComInner


### PR DESCRIPTION
Previously, saturated applications of `Com.asgn` that didn't match one of the cases that is expressible in the grammar would be elaborated as antiquotations. Unfortunately, the antiquotation elaboration itself was problematic, because it directly invoked `delab` which returned to the very same case.

This meant that the delaborator would hit its max recursion depth, and emit an ellipsis instead of an understandable term.

One example of a case not expressible in the grammar is when a free Lean variable stands for the Imp variable to be assigned.

An alternative solution here is to also add an explicit quotation and escape mechanism for names. Instead of using `ident` for the LHS of the assignment, you could use a custom parser like `varname` that can be `ident` or `"~" term`; this would allow the antiquotation from the inexpressible term to be smaller in some cases, but it does introduce some precedence subtlety if you use the same antiquotation operator. This PR goes with the smaller fix.

I'm not familiar enough with the repository to know where to put a regression test, but here's an example that demonstrates the fix:

    #check fun (x : Ident) (a : Aexp) => Com.asgn x a

Without this fix, that line outputs:

    fun x a => ⋯ : Ident → Aexp → Com

With the fix, it outputs:

    fun x a => (Com.asgn x a) : Ident → Aexp → Com

Without the fix,

    #check fun (x : Ident) (a : Aexp) => imp {
      if (true) {
        skip;
      } else {
        ~(Com.asgn x a)
      }
    }

emits

    fun x a =>
      imp {
        if (true) {
          skip;
        } else {
          ~⋯
        }
      } : Ident → Aexp → Com

and with it it emits:

    fun x a =>
      imp {
        if (true) {
          skip;
        } else {
          ~(Com.asgn x a)
        }
      } : Ident → Aexp → Com