### PR TITLE
branch_watch: stale badge, notes from review threads, awaiting-review badge

### DIFF
--- a/scripts/branch_watch.py
+++ b/scripts/branch_watch.py
@@ -11,15 +11,19 @@ picture of who is touching what:
     recent activity orders it within its group — five columns: the branch
     (linked to its PR) over its author and last-activity time on a second line
     in small type; a Status cell of glyph badges (✅ ready, 👍 approved with open
-    threads, 🔴 changes requested, 💬N open threads, ✏️ draft, ❗ auto-merge held,
+    threads, 🔴 changes requested, 🟠 ready for review, 💬N open threads,
+    ✏️ draft, ❗ auto-merge held,
     🔗 fixes issue, ⚠️ main = no longer merges cleanly against `main`, plus
     "based on X" when the PR is stacked on a branch other than `main`); an
     Overlaps cell naming
-    which *other* PR branches it shares files with (plain = clean co-edit,
+    which *other* PRs it shares files with — as `#N` links to those PRs, each
+    hovering to reveal its branch name and PR title (plain = clean co-edit,
     ⚠️ = a real conflict from an in-memory merge not a filename guess, ⊃/⊂ = one
     branch's commits contain the other's), a Changes count — files touched and
-    total lines changed — (expander), and any
-    `#Note: …` lines reviewers left on the PR.  Every icon carries a hover
+    total lines changed — (expander), and a `#Note` cell carrying a dark-red
+    **Stale** badge once the PR has been open more than 48 hours, followed by any
+    `#Note: …` lines reviewers left on the PR — both in the conversation and in
+    still-unresolved review threads on the files.  Every icon carries a hover
     tooltip (via `<abbr>`) and is glued to its text with a non-breaking space,
     and a legend below the table spells the glyphs out too.  Only branches with
     an open PR appear in the table, and only they are weighed when marking its
@@ -66,6 +70,9 @@ from datetime import datetime, timezone
 # contains this marker. Keep it stable; it is how the updater finds "its" issue.
 ISSUE_MARKER = "<!-- branch-watch:auto -->"
 REMOTE = "origin"
+
+# A PR open longer than this is flagged "Stale" in the `#Note`s column.
+STALE_HOURS = 48
 
 
 # --------------------------------------------------------------------------
@@ -307,7 +314,21 @@ def user_realname(login, token):
 
 # A reviewer flags a note for this table by writing a line `#Note: …` in a PR
 # comment; the text after the marker (to end of line) is surfaced in the table.
+# Both kinds of comment count: the top-level conversation, and review comments
+# left on the files themselves — the latter only while their thread is still
+# unresolved, so that resolving the thread retires the note from the table.
 _NOTE_RE = re.compile(r"#Note:\s*(.*)", re.IGNORECASE)
+
+
+def parse_ts(iso):
+    """GitHub's ISO-8601 UTC timestamp (`2026-08-12T09:14:00Z`) as an aware
+    datetime, or None if absent/unparseable."""
+    if not iso:
+        return None
+    try:
+        return datetime.strptime(iso, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
 
 
 # GraphQL is used (rather than the REST `pulls` list) because it returns the
@@ -321,14 +342,18 @@ query($owner:String!, $name:String!, $cursor:String) {
       pageInfo { hasNextPage endCursor }
       nodes {
         number
+        title
         url
         isDraft
+        createdAt
         headRefName
         baseRefName
         reviewDecision
         autoMergeRequest { enabledAt }
         mergeQueueEntry { state }
-        reviewThreads(first:100) { nodes { isResolved } }
+        reviewThreads(first:100) {
+          nodes { isResolved comments(first:100) { nodes { body } } }
+        }
         closingIssuesReferences(first:10) { nodes { number url } }
         comments(first:100) { nodes { body } }
       }
@@ -341,12 +366,15 @@ query($owner:String!, $name:String!, $cursor:String) {
 def fetch_prs(slug, token):
     """Map branch short-name -> per-PR dict for open PRs.
 
-    Each value carries `num`, `url`, `draft`, the `base` branch it targets
+    Each value carries `num`, its `title` (hover text for the `#N` references in
+    the Overlaps column), `url`, `draft`, the `base` branch it targets
     (interesting only when it is not `main` — a stacked PR), `review_decision`
     (`REVIEW_REQUIRED`/`APPROVED`/`CHANGES_REQUESTED`/None), the count of
     `unresolved` review threads, the `auto_merge` / `in_queue` booleans that
-    together reveal an auto-merge that is stuck outside the merge queue, and the
-    list of `#Note: …` `notes` reviewers left in the PR conversation."""
+    together reveal an auto-merge that is stuck outside the merge queue, the
+    `created` timestamp behind the "Stale" badge, and the list of `#Note: …`
+    `notes` reviewers left — in the PR conversation *and* in unresolved review
+    threads on the files."""
     owner, _, name = slug.partition("/")
     prs = {}
     cursor = None
@@ -363,15 +391,26 @@ def fetch_prs(slug, token):
             # (fixes/closes/resolves #N); GitHub resolves these for us.
             closes = [{"num": i["number"], "url": i["url"]}
                       for i in pr["closingIssuesReferences"]["nodes"]]
-            # `#Note: …` lines a reviewer left in the PR conversation.
+            # `#Note: …` lines a reviewer left in the PR conversation, plus
+            # those on the files themselves — every comment of every *unresolved*
+            # review thread.  A resolved thread has been dealt with, so its notes
+            # drop off the table on their own.
             notes = []
             for c in pr["comments"]["nodes"]:
                 notes += _NOTE_RE.findall(c["body"] or "")
-            notes = [n.strip() for n in notes if n.strip()]
+            for t in threads:
+                if t["isResolved"]:
+                    continue
+                for c in t["comments"]["nodes"]:
+                    notes += _NOTE_RE.findall(c["body"] or "")
+            # A note repeated across comments (a quoted reply, say) is one note.
+            notes = list(dict.fromkeys(n.strip() for n in notes if n.strip()))
             prs[pr["headRefName"]] = {
                 "num": pr["number"],
+                "title": pr["title"],
                 "url": pr["url"],
                 "draft": pr["isDraft"],
+                "created": parse_ts(pr["createdAt"]),
                 "base": pr["baseRefName"],
                 "review_decision": pr["reviewDecision"],
                 "unresolved": unresolved,
@@ -429,8 +468,11 @@ def status_badges(pr):
     space, so an icon never wraps away from the word it labels.
 
     * 📝 draft.
-    * 🔴 changes requested · ✅ ready to merge (approved, nothing unresolved) ·
-      👍 approved but with open threads.
+    * 🔴 changes requested · 🟠 ready for review (out of draft, nobody has
+      reviewed it yet) · ✅ ready to merge (approved, nothing unresolved) ·
+      👍 approved but with open threads.  A coloured disc for the
+      awaiting-review state so it reads down the column alongside the red and
+      green ones, rather than as an empty cell.
     * 💬N — N review threads still open.
     * ❗ auto-merge enabled but held (a failing check, missing approval, or
       conflict is stalling it).  A PR sitting in the merge queue is a transient
@@ -443,7 +485,9 @@ def status_badges(pr):
         dec = pr["review_decision"]
         if dec == "CHANGES_REQUESTED":
             badges.append(tip("🔴", "Changes requested"))
-        elif dec != "REVIEW_REQUIRED":  # APPROVED, or None (no required review — rare here)
+        elif dec == "REVIEW_REQUIRED":
+            badges.append(tip("🟠", "Ready for review — nobody has reviewed it yet"))
+        else:  # APPROVED, or None (no required review — rare here)
             badges.append(tip("✅", "Ready to merge — approved, nothing unresolved")
                           if pr["unresolved"] == 0
                           else tip("👍", "Approved, but with open review threads"))
@@ -509,9 +553,29 @@ def branch_link(short, slug, maxlen=None, href=None):
     return f"[`{display}`]({href}{title})"
 
 
+def pr_ref(short, prs, slug):
+    """A compact `#N` reference to the open PR on branch `short`, linked to the
+    **PR** (not the branch) and carrying `branch — PR title` as its hover text.
+
+    This is what the Overlaps column names its neighbours with: the numbers keep
+    a cell listing several overlaps narrow, the tooltip still says which branch
+    and what the PR is about, and a click lands on the conversation the reader
+    actually wants.  Falls back to the branch link for a branch with no open PR
+    (which the table's overlap sets never contain today, but the file tables
+    could grow to)."""
+    pr = prs.get(short)
+    if not pr:
+        return branch_link(short, slug)
+    # Markdown link titles are double-quoted, so a quote in a PR title would end
+    # it early; swap in a single quote.
+    hover = f"{short} — {pr['title']}".replace('"', "'")
+    return f'[#{pr["num"]}]({pr["url"]} "{hover}")'
+
+
 def notes_cell(pr):
-    """The `#Note: …` reviewers left on a PR, separated by a middot and left to
-    wrap — or an empty cell when there are none (or no PR).  A middot rather
+    """The `#Note: …` reviewers left on a PR — in the conversation and in
+    unresolved review threads on the files — separated by a middot and left to
+    wrap, or an empty cell when there are none (or no PR).  A middot rather
     than a `<br>` per note: forced line breaks buy no vertical space (the cell's
     block line-height fixes the leading regardless), so flowing them onto shared
     lines keeps the row shorter."""
@@ -519,6 +583,34 @@ def notes_cell(pr):
     if not notes:
         return ""
     return " · ".join(notes)
+
+
+def age_phrase(delta):
+    """A coarse "how long has this been open" phrase for a tooltip: hours below
+    a couple of days, whole days above."""
+    hours = int(delta.total_seconds() // 3600)
+    if hours < 48:
+        return f"{hours} hours"
+    return f"{hours // 24} days"
+
+
+def stale_badge(pr, now):
+    """A dark-red **Stale** badge for a PR open longer than `STALE_HOURS`, else
+    an empty string.
+
+    Rendered as a shields.io image rather than coloured text because neither
+    route to colour survives a GitHub table cell: inline CSS is stripped and
+    `$\\color{…}$` math is dropped there (the same limitation the group dividers
+    work around).  The badge is an image, so it comes through — and its alt text
+    still reads "Stale" if the image itself fails to load."""
+    created = pr.get("created") if pr else None
+    if not created:
+        return ""
+    age = now - created
+    if age.total_seconds() < STALE_HOURS * 3600:
+        return ""
+    return (f'![Stale](https://img.shields.io/badge/Stale-8B0000 '
+            f'"Open {age_phrase(age)} — more than {STALE_HOURS} hours")')
 
 
 def files_cell(files, churn):
@@ -570,7 +662,8 @@ def render(branches, conf, prs, have_token, slug):
     clean_files = {f: rs for f, rs in hot.items() if not file_conflicts(rs)}
     single_files = {f: rs for f, rs in fmap.items() if len(rs) == 1}
 
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.strftime("%Y-%m-%d %H:%M UTC")
 
     def _blob(path, text=None):
         text = text or path
@@ -612,9 +705,11 @@ def render(branches, conf, prs, have_token, slug):
         # ⚠️, not several.  `A ⊂ B` names the superseded branches A first, then
         # the container B whose commits already include them; the ⚠️ (real merge
         # conflict) is shown once, on the container.
-        # Each overlap icon carries a tooltip and is glued to its branch link
-        # with a non-breaking space, so the symbol never wraps away from the
-        # name it qualifies.
+        # Overlaps are named by PR number (`#N`, linked to the PR, hovering to
+        # its branch name and title) rather than by branch name: a row that
+        # touches three others stays one short cell.  Each overlap icon carries
+        # a tooltip and is glued to its reference with a non-breaking space, so
+        # the symbol never wraps away from the number it qualifies.
         warn = tip("⚠️", "Real merge conflict")
         sup = tip("⊃", "Contains that branch's commits")
         sub = tip("⊂", "Contained in that branch")
@@ -623,17 +718,17 @@ def render(branches, conf, prs, have_token, slug):
         for h in heads:
             subs = sorted(o for o in rest if o != h and contains(h, o))
             prefix = f"{warn}&nbsp;" if h in conf[r] else ""
-            h_link = branch_link(active[h]["short"], slug)
+            h_link = pr_ref(active[h]["short"], prs, slug)
             if subs:
                 sub_links = ", ".join(
-                    branch_link(active[o]["short"], slug) for o in subs)
+                    pr_ref(active[o]["short"], prs, slug) for o in subs)
                 piece = f"{prefix}{sub_links}&nbsp;{sub}&nbsp;{h_link}"
             else:
                 piece = prefix + h_link
             pieces.append(piece)
-        pieces += [f"{sup}&nbsp;" + branch_link(active[o]["short"], slug)
+        pieces += [f"{sup}&nbsp;" + pr_ref(active[o]["short"], prs, slug)
                    for o in contains_o]
-        pieces += [f"{sub}&nbsp;" + branch_link(active[o]["short"], slug)
+        pieces += [f"{sub}&nbsp;" + pr_ref(active[o]["short"], prs, slug)
                    for o in contained_by]
         ov = ", ".join(pieces)
         pr = prs.get(b["short"])
@@ -656,8 +751,11 @@ def render(branches, conf, prs, have_token, slug):
             status += " " + tip("⚠️&nbsp;main", "No longer merges cleanly with main")
         # `#Note`s flow middot-separated (see notes_cell); `<sub>` is used purely
         # for smaller glyphs — the block line-height fixes the leading regardless.
+        # The Stale badge leads the cell at full size, outside that `<sub>`, so
+        # ageing PRs stay visible at a glance down the column.
         notes = notes_cell(pr)
         notes = f"<sub>{notes}</sub>" if notes else ""
+        notes = " ".join(x for x in (stale_badge(pr, now_dt), notes) if x)
         row = (f"| {first} | {status} | {ov} | "
                f"{files_cell(b['files'], b['churn'])} | {notes} |")
         # Drafts are their own section at the bottom; among the rest, ready-to-
@@ -672,7 +770,7 @@ def render(branches, conf, prs, have_token, slug):
     # actionable — ready first, then in progress, then drafts last.  When only
     # one group has rows, skip the labels (the table needs no signposting).
     groups = [("✅ Ready to merge", ready_rows),
-              ("🛠️ Ready for review", other_rows),
+              ("🛠️ Under review", other_rows),
               ("✏️ Drafts", draft_rows)]
     present = [(label, rows) for label, rows in groups if rows]
     if len(present) > 1:
@@ -713,11 +811,16 @@ def render(branches, conf, prs, have_token, slug):
     if active:
         out.append(
             "<sub>**Status** ✅&nbsp;ready · 👍&nbsp;approved, threads open · "
-            "🔴&nbsp;changes requested · 💬&nbsp;open threads · "
+            "🔴&nbsp;changes requested · 🟠&nbsp;ready for review · "
+            "💬&nbsp;open threads · "
             "✏️&nbsp;draft · ❗&nbsp;auto-merge "
             "held · 🔗&nbsp;fixes issue · ⚠️&nbsp;main conflicts with `main`. "
-            "&nbsp; **Overlaps** plain = clean co-edit · ⚠️&nbsp;real conflict "
-            "· ⊃&nbsp;contains · ⊂&nbsp;contained in.</sub>")
+            "&nbsp; **Overlaps** PRs sharing files (hover for the branch and "
+            "title) · plain = clean co-edit · ⚠️&nbsp;real conflict "
+            "· ⊃&nbsp;contains · ⊂&nbsp;contained in. "
+            f"&nbsp; **`#Note`s** Stale&nbsp;=&nbsp;open more than "
+            f"{STALE_HOURS}&nbsp;hours; notes come from PR comments and "
+            "unresolved review threads.</sub>")
         out.append("")
 
     # ---- files: conflicting first, then clean co-edits, then single-branch ----


### PR DESCRIPTION
Branch-watcher improvements, split out of `bcp/misc` for individual review:

- PRs open more than 48 hours get a dark-red **Stale** badge in the `#Note` column.
- `#Note: …` lines are now also collected from *unresolved* review threads on the files, not just the PR conversation — resolving a thread retires its notes from the table. Repeated notes (quoted replies) are deduped.
- New 🟠 badge for out-of-draft PRs that nobody has reviewed yet, so the awaiting-review state reads down the Status column alongside the red and green discs instead of as an empty cell.
- The Overlaps column now names other PRs as `#N` links, with branch name and PR title on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)