### PR TITLE
Claude: all_goals fix

### DIFF
--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -66,6 +66,14 @@ to two arguments of type {name}`Nat`."
 :::slidebreak
 :::
 
+:::dev "Mike Hicks (@mwhicks1)"
+I would have expected us to have `namespace NatProd` here when defining
+the following functions, so we don't need qualifiers. We've already
+full explained namespaces back in Basics. Some of the text below
+mentions using the `NatProd` prefix specifically, but I think you can
+drop it and it will stick work.
+:::
+
 Functions for extracting the first and second components of a pair
 can then be defined by pattern matching.
 
@@ -168,26 +176,12 @@ Invalid `⟨...⟩` notation: The expected type `Nat` has more than one construc
 Note: This notation can only be used when the expected type is an inductive type with a single constructor
 ```
 
-These extensions to pattern matching also mean that the rewrite laws
-we define for each function may not always match one-to-one with the cases of our match
-constructs.
+As with the multi-argument `match n, m with` style used above in `sub`,
+matching jointly on several values can combine what would otherwise be
+several separate cases into a single match arm. This means the
+simplification rules we define for such a function may not always match
+one-to-one with the cases of its match construct.
 ::::
-
-Lean also provides a convenient way to define `inductive` structures like pairs
-that have a single constructor but multiple ways to access their data,
-using the `structure` keyword. The definition of `NatProd'` below is equivalent
-to the {name}`NatProd` definition from earlier, except that Lean automatically
-generates the `fst` and `snd` accessors.
-
-```lean
-structure NatProd' where
-  fst : Nat
-  snd : Nat
-
-#check (NatProd'.mk 3 5)
-example : (NatProd'.mk 3 5).fst = 3 := by rfl
-example : (⟨3, 5⟩ : NatProd').fst = 3 := by rfl
-```
 
 :::slidebreak
 :::
@@ -246,6 +240,34 @@ theorem fst_swap_is_snd (p : NatProd) :
 
 ::::::
 
+:::slidebreak
+:::
+
+# Structures
+
+:::full
+Lean also provides a convenient way to define `inductive` structures like pairs
+that have a single constructor but multiple ways to access their data,
+using the `structure` keyword. The definition of `NatProd'` below is equivalent
+to the {name}`NatProd` definition from earlier, except that Lean automatically
+generates the `fst` and `snd` accessors.
+:::
+
+:::terse
+Lean's `structure` is shorthand for a single-constructor
+`inductive` with the accessors auto-generated.
+:::
+
+```lean
+structure NatProd' where
+  fst : Nat
+  snd : Nat
+
+#check (NatProd'.mk 3 5)
+example : (NatProd'.mk 3 5).fst = 3 := by rfl
+example : (⟨3, 5⟩ : NatProd').fst = 3 := by rfl
+```
+
 # Lists of Numbers
 
 ::::full
@@ -285,7 +307,14 @@ for constructing lists.
 Some notation for lists to make our lives easier:
 :::
 
-Don't worry too much about what this is doing:
+Don't worry too much about how this works.
+
+:::details "List syntax"
+We first define `::` as right-associative notation for {name}`cons`,
+and then define list notation as a _macro_,
+allowing us to write {lean}`[1, 2]` instead of {lean}`1 :: 2 :: []`.
+The _unexpander_ reverses the macro, translating list syntax back to
+cons syntax.
 
 ```lean
 scoped infixr:65 (priority := high) " :: " => cons
@@ -302,10 +331,7 @@ def unexpandCons : Lean.PrettyPrinter.Unexpander
   | `($_ $x [$xs,*]) => `([$x, $xs,*])
   | _ => throw ()
 ```
-
-We first define `::` as right-associative _notation_ for {name}`cons`,
-and then define list notation _macro_ with _unexpander_,
-allowing us to write {lean}`[1, 2]` instead of {lean}`1 :: 2 :: []`.
+:::
 
 Now these all mean exactly the same thing:
 
@@ -335,6 +361,14 @@ def myRepeat (n count : Nat) : NatList :=
 ```
 
 Some simple facts about repetition:
+
+:::dev "Mike Hicks (@mwhicks1)"
+This is the first time we've seen implicit arguments like `{n : Nat}`, and
+they're used pervasively from here on (`cons_append`, `head_cons`, `count_nil`,
+etc.). We should either introduce implicit
+arguments explicitly here (or earlier, e.g., an exercise in UsingLean) or restructure so their proper explanation —
+currently in Poly — comes before this chapter.
+:::
 
 ```lean
 theorem repeat_zero {n : Nat} : myRepeat n 0 = [] := rfl

--- a/SFLMeta/Exercise.lean
+++ b/SFLMeta/Exercise.lean
@@ -224,6 +224,55 @@ private def recordStudentRepls (repls : Array Replacement) : IO Unit := do
     if h : repls.size > 0 then
       studentEditRef.modify (·.push ⟨repls, h⟩)
 
+/-- Drop up to `n` leading space characters from a list of characters. -/
+private def dropLeadingSpaces : Nat → List Char → List Char
+  | 0, cs => cs
+  | _+1, [] => []
+  | n+1, c :: cs => if c = ' ' then dropLeadingSpaces n cs else c :: cs
+
+private def dedentLine (delta : Nat) (line : String) : String :=
+  (dropLeadingSpaces delta line.toList).foldl String.push ""
+
+private def leadingSpaceCount (line : String) : Nat :=
+  (line.takeWhile (· = ' ')).toString.length
+
+/-- The literal source text of tactic block `t`, for splicing in place of the
+`solution!`/`workinclass!`/`suggested!` keyword at `tk` in a build where the
+wrapped proof should be shown verbatim rather than stubbed. `t` is usually an
+indented block starting on the line after `tk` (required by
+`tacticSeqIndentGt`), one indent level deeper — in which case every line but
+the first is dedented by that level, so the spliced text parses as a sibling
+of whatever precedes/follows the marker in its enclosing tactic sequence
+rather than staying orphaned at `t`'s original, deeper column. But `t` can
+also be a single parenthesized tactic group starting right after `tk` on the
+same line (the `solution!( … )` idiom borrowed from the term form); there the
+column gap from `tk` reflects nothing about the body's own indentation, so
+dedenting by it would flatten the group's internal structure. To cover both,
+the dedent amount is derived from the body's own minimum indentation among
+its continuation lines relative to `tk`'s column, not from `t`'s start
+column — which comes out to the same "one indent level" in the first case,
+and to zero (no rewrite) in the second, since a parenthesized group's own
+lines are already indented well past `tk`. -/
+private def dedentSpliceText (tk t : Syntax) : CoreM String := do
+  let fileMap ← getFileMap
+  match tk.getRange?, t.getRange? with
+  | some tkR, some tR =>
+    if h : tR.start.IsValid fileMap.source ∧ tR.stop.IsValid fileMap.source then
+      let text := (fileMap.source.slice! ⟨tR.start, h.1⟩ ⟨tR.stop, h.2⟩).toString
+      match text.splitOn "\n" with
+      | [] => pure text
+      | first :: rest =>
+        let tkCol := (fileMap.toPosition tkR.start).column
+        let nonBlank := rest.filter fun l => !l.trimAscii.toString.isEmpty
+        let delta := match nonBlank with
+          | [] => 0
+          | l :: ls =>
+            (ls.foldl (fun acc l => min acc (leadingSpaceCount l)) (leadingSpaceCount l)) - tkCol
+        pure <| "\n".intercalate (first :: rest.map (dedentLine delta))
+    else
+      throwError "dedentSpliceText: invalid source range"
+  | _, _ => throwError "dedentSpliceText: missing source range"
+
 syntax (name := solutionTerm) "solution!" "(" term ")" : term
 
 @[term_elab solutionTerm]
@@ -246,7 +295,7 @@ def evalSolutionTac : Tactic := fun stx => do
   | `(tactic| solution!%$tk $t:tacticSeq ) =>
     recordStudentEdit #[(stx, "sorry")]
     recordTerseEdit #[(stx, "sorry")]
-    recordTeacherEdit #[(tk, "all_goals")]
+    recordTeacherEdit #[(stx, ← dedentSpliceText tk t.raw)]
     evalTactic t
   | _ => throwUnsupportedSyntax
 
@@ -264,8 +313,9 @@ def evalWorkinclassTac : Tactic := fun stx => do
   match stx with
   | `(tactic| workinclass!%$tk $t:tacticSeq ) =>
     recordTerseEdit #[(stx, "sorry")]
-    recordStudentEdit #[(tk, "all_goals")]
-    recordTeacherEdit #[(tk, "all_goals")]
+    let shown ← dedentSpliceText tk t.raw
+    recordStudentEdit #[(stx, shown)]
+    recordTeacherEdit #[(stx, shown)]
     evalTactic t
   | _ => throwUnsupportedSyntax
 
@@ -286,8 +336,9 @@ def evalSuggestedTac : Tactic := fun stx => do
   match stx with
   | `(tactic| suggested!%$tk $t:tacticSeq ) =>
     -- Teacher and terse builds keep the suggested proof live and shown.
-    recordTeacherEdit #[(tk, "all_goals")]
-    recordTerseEdit #[(tk, "all_goals")]
+    let shown ← dedentSpliceText tk t.raw
+    recordTeacherEdit #[(stx, shown)]
+    recordTerseEdit #[(stx, shown)]
     -- Student build: close the goal with `sorry`, then wrap the suggested proof
     -- in a block comment so it survives verbatim for the student to uncomment.
     -- The opening `/-` replaces the `suggested!` keyword (indented to its

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -680,14 +680,14 @@ theorem false_or (b : Bool) : (.false || b) = b := by
 ````
 
 The tactical and its term or proof is replaced either by `sorry` or by
-the term or proof itself. For proofs, they are preceded by `all_goals`,
-since the tactics are indented. The replacements are summarized below.
+the term or proof itself, dedented to sit at the tactical's own column. The
+replacements are summarized below.
 
 | Tactical       | `solutions` | `student` | `terse`     | Usage |
 | -------------- | ----------- | --------- | ----------- | ----- |
-| `solution!`    | `all_goals` | `sorry`   | `sorry`     | For homework exercises |
-| `workinclass!` | `all_goals` | `sorry`   | `all_goals` | For work in class |
-| `suggested!`   | `all_goals` | `sorry` with proof in comment | `all_goals` | For exercises with a suggested proof to modify |
+| `solution!`    | shown       | `sorry`   | `sorry`     | For homework exercises |
+| `workinclass!` | shown       | shown     | `sorry`     | For work in class |
+| `suggested!`   | shown       | `sorry` with proof in comment | shown | For exercises with a suggested proof to modify |
 
 #### `-- SOLUTION`
 

--- a/TS/Slang.lean
+++ b/TS/Slang.lean
@@ -649,12 +649,6 @@ theorem Aexp.evalR_iff_eval (a : Aexp) (n : Nat) :
 We can make the proof quite a bit shorter using more automation like we did in
 the previous section.
 
-:::dev "Michael Hicks (mwhicks1)" BeforeNextRelease
-the `workinclass!` marker should signal this live in-class exercise.
-But it is not rendering properly on the HTML. In fact it replaces `workinclass!` with
-the `all_goals` tactic, which we don't need.
-:::
-
 ```lean
 theorem Aexp.evalR_iff_eval' (a : Aexp) (n : Nat) :
     a ⇓ n ↔ a.eval = n := by


### PR DESCRIPTION
To not have to explain its appearance in the text, I asked Claude to reinterpret the `workinclass!`, `solution!`, and `suggested!` tacticals. Now they de-dent the text instead. All of the code here was Claude generated, no content is user-facing. See the commit message for details on how it works.