### PR TITLE
SFLMeta: remove stripGuardMsgs

### DIFF
--- a/SFLMeta/Save/Lean.lean
+++ b/SFLMeta/Save/Lean.lean
@@ -34,8 +34,8 @@ namespace LeanElab
 /--
   Go through the lines of `hls` and drop the line that is not appear in lines of `src`.
 
-  This is for reusing highlighting results from elbaoration for solution (teacher) variant: removing `-- SOLUTION`/`-- END SOLUTION` and `#guard_msgs` should not
-  cause elaboration again.
+  This is for reusing highlighting results from elbaoration for solution (teacher) variant:
+  removing `-- SOLUTION`/`-- END SOLUTION` should not cause elaboration again.
 -/
 defmethod Highlighted.filterBySource (hls : Highlighted) (src : String) : Highlighted := Id.run do
   let expected := (src.splitOn "\n").toArray
@@ -289,14 +289,14 @@ def lean : CodeBlockExpanderOf LeanSaved.Config
       let studentEdited := applyEdits src <| relativize studentEdits
       let terseEdited := applyEdits src <| relativize terseEdits
 
-      let teacher := stripGuardMsgs ∘ stripFillInMarkers <| teacherEdited
-      let student := stripGuardMsgs ∘ applyFillInForStudent <| studentEdited
-      let terse := stripGuardMsgs <| applyFillInForStudent <| terseEdited
+      let teacher := stripFillInMarkers <| teacherEdited
+      let student := applyFillInForStudent <| studentEdited
+      let terse := applyFillInForStudent <| terseEdited
 
       -- Note: this is different from `teacher`.
       -- `teacher` is for extracted projects which includes `teacherEdits`,
       -- while `teacherDisplay` is the string that will be shown in HTML.
-      let teacherDisplay := stripGuardMsgs ∘ stripFillInMarkers <| src
+      let teacherDisplay := stripFillInMarkers <| src
 
       -- Always reuse orignal elaboration for teacher
       let teacherHls :=

--- a/SFLMeta/Save/SourceRewrite.lean
+++ b/SFLMeta/Save/SourceRewrite.lean
@@ -71,49 +71,4 @@ def stripFillInMarkers (src : String) : String :=
   let kept := lines.filter fun line => !isSolutionStart line && !isSolutionEnd line
   String.intercalate "\n" kept
 
-/-! ## `#guard_msgs` stripping
-
-`#guard_msgs(…) in <cmd>` modifiers (with their preceding `/-- … -/` expected-
-message docstring) verify Lean's output to catch bitrot. They run during the
-Verso build — this only removes them from the *rendered* (`.html`) and
-*extracted* (`.lean`) forms, leaving the wrapped command in place. -/
-
-/-- Remove `#guard_msgs … in` command-modifier lines and the `/-- … -/`
-expected-message docstring immediately preceding them. -/
-def stripGuardMsgs (src : String) : String := Id.run do
-  let lines := (src.splitOn "\n").toArray
-  let n := lines.size
-  let mut out : Array String := #[]
-  let mut i := 0
-  while i < n do
-    let line := lines[i]!
-    let t := line.trimAscii.toString
-    if t.startsWith "/--" then
-      -- A docstring: scan to the line that closes it (`… -/`).
-      let mut j := i
-      while j < n && !(lines[j]!.trimAscii.toString.endsWith "-/") do
-        j := j + 1
-      if j + 1 < n && (lines[j + 1]!.trimAscii.toString.startsWith "#guard_msgs") then
-        -- Expected-message docstring for a `#guard_msgs`.  Strip the pair only
-        -- when the expectation is benign (a `warning:`/`info:` message, e.g.
-        -- `declaration uses sorry`): without the guard the command still
-        -- compiles.  An expected *error* (`error:`, `Tactic … failed`, …)
-        -- means the wrapped command deliberately fails — the guard must stay
-        -- in the extracted file or it would not build.
-        let body := ((lines[i]!.trimAscii.toString.drop 3).trimAscii).toString
-        if body.startsWith "warning" || body.startsWith "info" then
-          i := j + 2
-        else
-          for k in [i:j+2] do out := out.push lines[k]!
-          i := j + 2
-      else
-        for k in [i:j+1] do out := out.push lines[k]!
-        i := j + 1
-    else if t.startsWith "#guard_msgs" then
-      i := i + 1   -- a `#guard_msgs … in` with no docstring: drop the modifier line
-    else
-      out := out.push line
-      i := i + 1
-  return String.intercalate "\n" out.toList
-
 end SourceRewrite

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -247,8 +247,7 @@ and `#guard_msgs` for internal checks that are not student-facing.
 
 Use `sorry` when an unfinished declaration must remain available to later code,
 as with an exercise scaffold or a theorem used below. Do _not_ normally wrap it
-in `#guard_msgs`: the generic warning is not what we are testing, and the guard
-is stripped from the HTML and extracted projects.
+in `#guard_msgs`, as the generic warning is not what we are testing.
 
 ````lean
 ```lean


### PR DESCRIPTION
Closes #196 

This PR removes `#guard_msgs` stripping from our project extraction logic. I believe we've fully switched to `leanOutput`, so there's no public-facing `#guard_msgs` needed to be stripped. 