### PR TITLE
Move pp.fieldNotation out of header in Basics and Induction

### DIFF
--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -4,14 +4,16 @@ import SFLMeta
 open Verso.Genre Manual
 open SFLMeta
 
-set_option pp.fieldNotation false
-
 #doc (Manual) "Basics: Functional Programming in Lean" =>
 %%%
 tag := "Basics"
 htmlSplit := .never
 file := "Basics"
 %%%
+
+```lean
+set_option pp.fieldNotation false
+```
 
 :::instructors
 This file and Induction.lean each take about an hour to

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -6,14 +6,16 @@ import LF.Basics
 open Verso.Genre Manual
 open SFLMeta
 
-set_option pp.fieldNotation false
-
 #doc (Manual) "Induction: Proof by Induction" =>
 %%%
 tag := "Induction"
 htmlSplit := .never
 file := some "Induction"
 %%%
+
+```lean
+set_option pp.fieldNotation false
+```
 
 :::dev BeforeNextRelease
 ```


### PR DESCRIPTION
These were getting dropped by Verso extraction. This fixes that. 