### PR TITLE
`recall` and  `recallSource` blocks

### DIFF
--- a/LF/Typeclasses.lean
+++ b/LF/Typeclasses.lean
@@ -12,6 +12,7 @@ import SFLMeta.Instructors
 import SFLMeta.SlideBreak
 import SFLMeta.Solution
 import SFLMeta.Terse
+import SFLMeta.RecallBlock
 
 set_option autoImplicit false
 
@@ -342,10 +343,21 @@ BEq.beq 1 2 : Bool
 Rather than {name}`Nat.beq`, `==` turns out to be notation for {name}`BEq.beq`, a field of exactly
 the kind of typeclass we just learned to define:
 
-```
-class BEq (α : Type u) where
-  /-- Boolean equality, notated as `a == b`. -/
-  beq : α → α → Bool
+```recallSource
+/--
+  `BEq α` is a typeclass for supplying a boolean-valued equality relation on
+  `α`, notated as `a == b`. Unlike `DecidableEq α` (which uses `a = b`), this
+  is `Bool` valued instead of `Prop` valued, and it also does not have any
+  axioms like being reflexive or agreeing with `=`. It is mainly intended for
+  programming applications. See `LawfulBEq` for a version that requires that
+  `==` and `=` coincide.
+
+  Typically we prefer to put the "more variable" term on the left,
+  and the "more constant" term on the right.
+  -/
+  class BEq (α : Type u) where
+    /-- Boolean equality, notated as `a == b`. -/
+    beq : α → α → Bool
 ```
 
 Writing `a == b` makes Lean search for an *instance* of {name}`BEq` for the type of `a` and `b`, the same
@@ -624,22 +636,24 @@ In this section, we'll use the type variable `α` for the type of keys and `β` 
 In addition to {name}`BEq`, which we have already seen, our key type `α` requires instances of the
 {name}`ReflBEq` and {name}`LawfulBEq` typeclasses:
 
-```
+```recallSource
 /-- `ReflBEq α` says that the `BEq` implementation is reflexive. -/
-class ReflBEq (α : Type) [BEq α] : Prop where
-  /-- `==` is reflexive, that is, `(a == a) = true`. -/
-  protected rfl {a : α} : a == a
+  class ReflBEq (α) [BEq α] : Prop where
+    /-- `==` is reflexive, that is, `(a == a) = true`. -/
+    protected rfl {a : α} : a == a
+```
 
+```recallSource
 /--
-A Boolean equality test coincides with propositional equality.
+  A Boolean equality test coincides with propositional equality.
 
-In other words:
- * `a == b` implies `a = b`.
- * `a == a` is true.
--/
-class LawfulBEq (α : Type) [BEq α] : Prop extends ReflBEq α where
-  /-- If `a == b` evaluates to `true`, then `a` and `b` are equal in the logic. -/
-  eq_of_beq : {a b : α} → a == b → a = b
+  In other words:
+   * `a == b` implies `a = b`.
+   * `a == a` is true.
+  -/
+  class LawfulBEq (α : Type u) [BEq α] : Prop extends ReflBEq α where
+    /-- If `a == b` evaluates to `true`, then `a` and `b` are equal in the logic. -/
+    eq_of_beq : {a b : α} → a == b → a = b
 ```
 
 These classes refine `BEq`, specifying that (`==`) is reflexive and coincides with

--- a/SFLMeta/RecallBlock.lean
+++ b/SFLMeta/RecallBlock.lean
@@ -1,0 +1,145 @@
+import VersoManual
+import SFLMeta.RecallSource
+import SFLMeta.RecallCheck
+
+/-!
+# Recall as a code block
+
+In a rendered book, a recalled definition should look like any other code
+block. The `recall` and `recallSource` code blocks parse their contents as
+a plain declaration, wrap it in the corresponding checking command, and
+elaborate that in the document's Lean environment. The rendered block shows
+only the declaration, so the checking is invisible in the output, and the
+source needs no marker beyond the code block's own name. The wrapped node
+is built directly, so the commands' scoped syntax never needs to be in
+scope in a document.
+-/
+
+open Lean Elab
+open Verso Doc Elab ArgParse
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean (reportMessages saveOutputs)
+open Verso.Genre.Manual.InlineLean.Scopes (getScopes)
+open Verso.SyntaxUtils (parseStrLitAsCategory)
+open SubVerso.Highlighting
+
+/--
+Configuration for the recall code blocks: `+error` expects the check to
+fail, `+statement` restates only a theorem statement, and `name` saves the
+block's messages for a `leanOutput` block.
+-/
+structure RecallBlockConfig where
+  /-- Whether the check is expected to fail. -/
+  error : Bool := false
+  /-- Whether the contents restate only a theorem statement. -/
+  statement : Bool := false
+  /-- A name under which the block's messages are saved for `leanOutput`. -/
+  name : Option Name := none
+
+def RecallBlockConfig.parse [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m]
+    [MonadError m] : ArgParse m RecallBlockConfig :=
+  RecallBlockConfig.mk <$> .flag `error false <*> .flag `statement false <*>
+    .named `name .name true
+
+instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] :
+    FromArgs RecallBlockConfig m := ⟨RecallBlockConfig.parse⟩
+
+/-- The contents of a statement-mode recall block: a theorem name and its
+restated statement. -/
+declare_syntax_cat recallStmtSpec
+
+syntax ident " : " term : recallStmtSpec
+
+/--
+Sets `linter.unusedVariables` to `false` in the recorded info trees, so the
+document's own linter pass does not re-report warnings the inner
+elaboration already handled.
+-/
+private partial def disableUnusedVarLinter : InfoTree → InfoTree
+  | .context (.commandCtx ci) child =>
+    .context (.commandCtx { ci with options := Linter.linter.unusedVariables.set ci.options false })
+      (disableUnusedVarLinter child)
+  | .context pci child => .context pci (disableUnusedVarLinter child)
+  | .node info children => .node info (children.map disableUnusedVarLinter)
+  | .hole id => .hole id
+
+/--
+Elaborates a code block's contents wrapped in a recall command, in the
+document's Lean environment, then renders the block as the plain contents.
+The contents are a declaration wrapped by the command of kind `cmdKind`,
+or, in statement mode, a theorem name and statement wrapped by the command
+of kind `stmtKind`; a block without a statement form passes `none` and
+rejects `+statement`. When `highlighted` is `true`, the rendered block
+carries the elaboration's highlighting; the byte-for-byte block passes
+`false`, since its contents are never elaborated and the only recorded
+information is the block-wide reference to the recalled constant, which
+would give every token the same hover.
+-/
+def recallBlock (config : RecallBlockConfig) (str : StrLit)
+    (cmdKind : SyntaxNodeKind) (stmtKind : Option SyntaxNodeKind)
+    (highlighted : Bool := true) : DocElabM Term := withoutAsync do
+  let col? := (← getRef).getPos? |>.map (← getFileMap).utf8PosToLspPos |>.map (·.character)
+  let (cmdStx, wrapped) ←
+    if config.statement then
+      let some stmtKind := stmtKind
+        | throwError "this block has no statement form"
+      let spec ← parseStrLitAsCategory `recallStmtSpec str
+      pure (spec,
+        (mkNode stmtKind #[mkAtom "recall", mkAtom "statement", spec[0], mkAtom ":", spec[2]]).raw)
+    else
+      let cmdStx ← parseStrLitAsCategory `command str
+      pure (cmdStx, (mkNode cmdKind #[mkAtom "recall", cmdStx]).raw)
+  -- The same adjustments the `lean` code block makes: synchronous
+  -- elaboration so info trees are available for highlighting, and public
+  -- names so the document sees what it declares.
+  let scopes := (← getScopes).modifyHead fun sc =>
+    { sc with opts := pp.tagAppFns.set (Elab.async.set sc.opts false) true, isPublic := true }
+  let cctx : Command.Context :=
+    { fileName := ← getFileName, fileMap := ← getFileMap, snap? := none, cancelTk? := none }
+  let st : Command.State :=
+    { env := ← getEnv, maxRecDepth := ← MonadRecDepth.getMaxRecDepth, scopes }
+  let st ←
+    match ← liftM <| EIO.toIO' <| ((Command.elabCommandTopLevel wrapped).run cctx).run st with
+    | .error e => logError e.toMessageData; pure st
+    | .ok ((), st) => pure st
+  for t in st.infoState.trees do
+    pushInfoTree (disableUnusedVarLinter t)
+  if let some name := config.name then
+    let outMsgs ← st.messages.toList.filter (!·.isSilent) |>.mapM fun msg => do
+      let head := if msg.caption != "" then msg.caption ++ ":\n" else ""
+      let msg ← highlightMessage msg
+      pure { msg with contents := .append #[.text head, msg.contents] }
+    saveOutputs name outMsgs
+  reportMessages (if config.error then some true else none) str st.messages
+  unless highlighted do
+    return ← ``(Verso.Doc.Block.code $(quote str.getString))
+  let hls ← highlight cmdStx (st.messages.toArray.filter (!·.isSilent)) st.infoState.trees
+  let hls := match col? with
+    | none => hls
+    | some col => hls.deIndent col
+  let range := (Syntax.getRange? str).map (← getFileMap).utf8RangeToLspRange
+  ``(Verso.Doc.Block.other
+      (Verso.Genre.Manual.InlineLean.Block.lean $(quote hls)
+        (some $(quote (← getFileName))) $(quote range))
+      #[Verso.Doc.Block.code $(quote str.getString)])
+
+/--
+A code block whose contents restate an earlier definition, checked up to
+definitional equality by the `recall` command. With `+statement`, the
+contents restate only a theorem statement.
+-/
+@[code_block]
+def recall : CodeBlockExpanderOf RecallBlockConfig
+  | config, str =>
+    recallBlock config str ``RecallCheck.recallChk (some ``RecallCheck.recallChkStmt)
+
+/--
+A code block whose contents restate an earlier definition, checked byte for
+byte by the `recall_source` command, which compares whole declarations
+only. The block renders as plain code: the contents are never elaborated,
+so there is no per-token information to show.
+-/
+@[code_block]
+def recallSource : CodeBlockExpanderOf RecallBlockConfig
+  | config, str =>
+    recallBlock config str ``RecallSource.recallSrc none (highlighted := false)

--- a/SFLMeta/RecallCheck.lean
+++ b/SFLMeta/RecallCheck.lean
@@ -1,0 +1,502 @@
+import Lean
+import SFLMeta.RecallSource
+
+/-!
+# Recall, checked by elaboration
+
+`recall` lets a chapter restate a definition from earlier in the
+development while the build checks that the restatement means the same
+thing. The restated declaration is elaborated for real, inside a hidden
+namespace, and compared with the original up to definitional equality; the
+temporary declaration is then rolled back.
+
+Two forms:
+
+```
+recall
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+
+recall statement twice_id : twice id 3 = 3
+```
+
+What is compared:
+
+* types, always;
+* a `def`'s value;
+* an inductive's constructors, one by one (names, parameter and index
+  counts, and each constructor's type);
+* a theorem's statement, never its proof.
+
+So a recalled definition may be reformatted or rephrased into something
+definitionally equal, and a theorem may be reproved differently or, with
+the `statement` form, restated without any proof. The syntax is scoped:
+the command is available inside `RecallCheck` and wherever it is opened,
+and `recall` is not a keyword elsewhere.
+-/
+
+open Lean Elab Command Meta
+
+namespace RecallCheck
+
+/-- All `declId` nodes in a command, in source order. -/
+partial def declIds (stx : Syntax) : Array Syntax :=
+  let inner := stx.getArgs.flatMap declIds
+  if stx.isOfKind ``Lean.Parser.Command.declId then #[stx] ++ inner else inner
+
+/--
+The `declId` node of a declaration command, together with the name written
+in it. A command that declares several names (a `mutual` block) or none (an
+anonymous `instance`, an `example`) is rejected.
+-/
+def declaredName (cmd : Syntax) : CommandElabM (Syntax × Name) := do
+  let defined := declIds cmd
+  match h : defined.size with
+  | 0 =>
+    throwErrorAt cmd "the restated command does not declare a name"
+  | 1 =>
+    let declId := defined[0]
+    return (declId, declId[0].getId)
+  | n + 2 =>
+    for h : i in 0...(n + 1) do
+      logErrorAt defined[i]
+        "the restated command declares several names; recall one declaration at a time"
+    throwErrorAt defined[n + 1]
+      "the restated command declares several names; recall one declaration at a time"
+
+/--
+Replaces the name prefix `chk` with `orig` in every constant that `e`
+mentions: `chk` itself becomes `orig`, and a longer name such as a hidden
+constructor `chk.mk` becomes `orig.mk`. Constructor types mention the
+hidden inductive type's name in argument and resulting positions, so this
+rewrite is what makes a re-elaborated declaration comparable with the
+original.
+-/
+def renameBack (chk orig : Name) (e : Expr) : Expr :=
+  e.replace fun
+    | .const n us =>
+      if chk.isPrefixOf n then some (.const (n.replacePrefix chk orig) us) else none
+    | _ => none
+
+/--
+Applies `renameBack` to the expressions recorded in an info tree. The info
+recorded while elaborating the hidden copy mentions the hidden constants,
+so hovers over a recalled declaration would otherwise display the hidden
+names; rewriting before the trees are stored makes them display the
+originals, which also exist after the hidden copy is rolled back.
+-/
+partial def renameBackInfoTree (chk orig : Name) (t : InfoTree) : InfoTree :=
+  match t with
+  | .context ctx t' => .context ctx (renameBackInfoTree chk orig t')
+  | .node i children =>
+    let i := match i with
+      | .ofTermInfo ti => .ofTermInfo (reTerm ti)
+      | .ofDelabTermInfo dti => .ofDelabTermInfo { dti with toTermInfo := reTerm dti.toTermInfo }
+      | other => other
+    .node i (children.map (renameBackInfoTree chk orig))
+  | .hole m => .hole m
+where
+  reTerm (ti : TermInfo) : TermInfo :=
+    { ti with
+      expr := renameBack chk orig ti.expr
+      expectedType? := ti.expectedType?.map (renameBack chk orig) }
+
+/--
+Checks that the types of the original constant `x` and its re-elaborated
+counterpart `chk` agree, definitionally. The restated type is first
+rewritten by `renameBack renChk renOrig`; the defaults compare a
+declaration against its own hidden copy, and the constructor check
+overrides them with the enclosing inductive types, whose names the
+constructor types mention. The restatement's universe parameters are
+instantiated with the original's.
+-/
+def checkTypesMatch (x chk : Name) (ref : Syntax)
+    (renChk : Name := chk) (renOrig : Name := x) (hint : MessageData := .nil) :
+    TermElabM Unit := do
+  let origInfo ← getConstInfo x
+  let chkInfo ← getConstInfo chk
+  unless origInfo.levelParams.length == chkInfo.levelParams.length do
+    throwErrorAt ref (m!"universe parameters of '{x}' do not match" ++ hint)
+  let chkType := (renameBack renChk renOrig chkInfo.type).instantiateLevelParams
+    chkInfo.levelParams (origInfo.levelParams.map .param)
+  unless ← isDefEq chkType origInfo.type do
+    throwErrorAt ref
+      (m!"the statement of '{x}' does not match.\n\
+          Original:{indentD origInfo.type}\nRestated:{indentD chkType}" ++ hint)
+
+/--
+All constructor syntax nodes of a command, in source order: an inductive
+type's `| name : ...` alternatives and a structure's `name ::` header.
+-/
+partial def ctorStxs (stx : Syntax) : Array Syntax :=
+  let inner := stx.getArgs.flatMap ctorStxs
+  if stx.isOfKind ``Lean.Parser.Command.ctor
+      || stx.isOfKind ``Lean.Parser.Command.structCtor then
+    #[stx] ++ inner
+  else inner
+
+/-- Does the syntax contain a doc comment? -/
+def hasDocComment (stx : Syntax) : Bool :=
+  (stx.find? (·.isOfKind ``Lean.Parser.Command.docComment)).isSome
+
+/--
+Suggestions localized to a mismatched constructor, returned as a pair of
+hints for name errors and for type errors. An inductive type's `| name : ...` alternative is replaced
+with the original constructor's own source. A structure's `name ::` header
+can carry a name fix but not a field fix, so its type errors keep `outer`,
+the suggestion that replaces the whole restatement. A constructor without
+syntax also falls back to `outer`.
+-/
+def ctorHints (ctorRef : Syntax) (origCtor origShort : Name) (outer : MessageData) :
+    TermElabM (MessageData × MessageData) := do
+  try
+    if ctorRef.isOfKind ``Lean.Parser.Command.ctor then
+      let origSrc := RecallSource.dedent (← RecallSource.sourceOf origCtor)
+      -- A restatement without a doc comment gets a suggestion without one;
+      -- the meaning check does not compare documentation.
+      let origSrc := if hasDocComment ctorRef then origSrc
+        else RecallSource.stripLeadingComments origSrc
+      let restatedSrc ← RecallSource.sourceOfSyntax ctorRef
+      let h ← RecallSource.replaceWithOriginalHint ctorRef origSrc restatedSrc
+      return (h, h)
+    if ctorRef.isOfKind ``Lean.Parser.Command.structCtor then
+      let restatedSrc ← RecallSource.sourceOfSyntax ctorRef
+      let h ← RecallSource.replaceWithOriginalHint ctorRef s!"{origShort} ::" restatedSrc
+      return (h, outer)
+    return (outer, outer)
+  catch _ => return (outer, outer)
+
+/--
+Checks a re-elaborated declaration against the original, definitionally.
+Errors point at `ref`, the restated command, except for constructor
+mismatches, which point at the offending constructor within it.
+-/
+def checkMatch (x chk : Name) (ref : Syntax) (hint : MessageData := .nil) :
+    TermElabM Unit := do
+  checkTypesMatch x chk ref (hint := hint)
+  let origInfo ← getConstInfo x
+  let chkInfo ← getConstInfo chk
+  match origInfo, chkInfo with
+  | .defnInfo orig, .defnInfo restated =>
+    let chkVal := (renameBack chk x restated.value).instantiateLevelParams
+      restated.levelParams (orig.levelParams.map .param)
+    unless ← isDefEq chkVal orig.value do
+      throwErrorAt ref
+        (m!"the value of '{x}' does not match.\n\
+            Original:{indentD orig.value}\nRestated:{indentD chkVal}" ++ hint)
+  | .inductInfo orig, .inductInfo restated =>
+    unless orig.numParams == restated.numParams && orig.numIndices == restated.numIndices do
+      throwErrorAt ref (m!"parameters or indices of '{x}' do not match" ++ hint)
+    unless orig.ctors.length == restated.ctors.length do
+      throwErrorAt ref
+        (m!"'{x}' has {orig.ctors.length} constructors, \
+            the restatement has {restated.ctors.length}" ++ hint)
+    -- A `structure` that writes no `name ::` header has a constructor
+    -- without syntax; the whole command remains the fallback position.
+    let ctorRefs := ctorStxs ref
+    let mut i := 0
+    for origCtor in orig.ctors, chkCtor in restated.ctors do
+      let ctorRef := ctorRefs[i]?.getD ref
+      let origShort := origCtor.replacePrefix x .anonymous
+      let (nameHint, typeHint) ← ctorHints ctorRef origCtor origShort hint
+      unless origCtor == chkCtor.replacePrefix chk x do
+        throwErrorAt ctorRef
+          (m!"constructor '{chkCtor.replacePrefix chk x}' does not match '{origCtor}'" ++ nameHint)
+      checkTypesMatch origCtor chkCtor ctorRef (renChk := chk) (renOrig := x) (hint := typeHint)
+      i := i + 1
+    -- A structure's field names are part of its interface, and the
+    -- constructor's type does not record them, so they are compared
+    -- through the environment's structure information.
+    match getStructureInfo? (← getEnv) x, getStructureInfo? (← getEnv) chk with
+    | some origSi, some chkSi =>
+      unless origSi.fieldNames == chkSi.fieldNames do
+        throwErrorAt ref
+          (m!"the fields of '{x}' do not match.\n\
+              Original:{indentD (toMessageData origSi.fieldNames.toList)}\n\
+              Restated:{indentD (toMessageData chkSi.fieldNames.toList)}" ++ hint)
+    | some _, none =>
+      throwErrorAt ref (m!"'{x}' is a structure, but the restatement is not" ++ hint)
+    | none, some _ =>
+      throwErrorAt ref (m!"'{x}' is not a structure, but the restatement is one" ++ hint)
+    | none, none => pure ()
+  -- A theorem's proof is not compared; restating it as a `def` is also
+  -- accepted, since only the statement matters.
+  | .thmInfo _, .thmInfo _ => pure ()
+  | .thmInfo _, .defnInfo _ => pure ()
+  | .axiomInfo _, .axiomInfo _ => pure ()
+  | .opaqueInfo _, .opaqueInfo _ => pure ()
+  | _, _ =>
+    throwErrorAt ref (m!"'{x}' and its restatement are different kinds of declaration" ++ hint)
+
+/--
+`recall` restates a definition from earlier in the development and checks
+that the restatement means the same thing. `recall statement x : T` checks
+that `T` matches the statement of the theorem `x`.
+-/
+scoped syntax (name := recallChk) "recall " command : command
+
+@[inherit_doc recallChk]
+scoped syntax (name := recallChkStmt) "recall " &"statement " ident " : " term : command
+
+elab_rules : command
+  | `(recall $cmd:command) => do
+    let (declId, written) ← declaredName cmd
+    let x ← liftCoreM <| realizeGlobalConstNoOverload (mkIdentFrom declId written)
+    -- The restatement elaborates unchanged inside a fresh hidden namespace:
+    -- self-references (an inductive's own name in its constructor types, in
+    -- resulting-type position included) resolve to the hidden copy, and
+    -- every other name resolves as it would at the recall site. The
+    -- namespace comes from the name generator: `_uniq` names cannot be
+    -- written in source, so it is collision-free, and unlike a macro-scoped
+    -- name it is an ordinary component, so declarations under it keep the
+    -- prefix structure that `renameBack` and the constructor comparison
+    -- rely on.
+    let ns ← liftCoreM (mkFreshId : CoreM Name)
+    let chk := (← getScope).currNamespace ++ ns ++ written
+    -- Any mismatch gets a clickable fix: replace the restatement with the
+    -- original's source text, indented like the restatement. The helpers
+    -- for recovering and re-indenting source are shared with the
+    -- byte-for-byte variant.
+    -- A failed hint must not fail the check: not every constant has a
+    -- declaration range or sources on the search path.
+    let hint ←
+      try
+        let original := RecallSource.dedent (← RecallSource.sourceOf x)
+        let original := if hasDocComment cmd then original
+          else RecallSource.stripLeadingComments original
+        let restated ← RecallSource.sourceOfSyntax cmd
+        liftCoreM <| RecallSource.replaceWithOriginalHint cmd original restated
+      catch _ => pure .nil
+    let envBefore ← getEnv
+    try
+      withScope (fun sc => { sc with currNamespace := sc.currNamespace ++ ns }) do
+        let saved ← getResetInfoTrees
+        try
+          elabCommand cmd
+        finally
+          let inner ← getResetInfoTrees
+          modifyInfoState fun s =>
+            { s with trees := saved ++ inner.map (renameBackInfoTree chk x) }
+      unless (← getEnv).contains chk do
+        throwErrorAt cmd (m!"the restatement of '{x}' failed to elaborate" ++ hint)
+      runTermElabM fun _ => checkMatch x chk cmd (hint := hint)
+    finally
+      setEnv envBefore
+  | `(recall statement $x:ident : $stmt:term) => do
+    let xName ← liftCoreM <| realizeGlobalConstNoOverload x
+    addConstInfo x xName
+    let region := mkNullNode #[x.raw, stmt.raw]
+    let restated ← RecallSource.sourceOfSyntax region
+    runTermElabM fun _ => do
+      -- The suggestion restates the original's type as the pretty-printer
+      -- renders it. The statement cannot be carved out of the original's
+      -- source, since finding its boundary would require parsing the
+      -- source in the elaboration context of its declaration site.
+      let hint ←
+        try
+          let origInfo ← getConstInfo xName
+          let printed ← ppExpr origInfo.type
+          RecallSource.replaceWithOriginalHint region
+            s!"{x.getId} : {printed}" restated
+        catch _ => pure .nil
+      let t ← Term.elabType stmt
+      Term.synthesizeSyntheticMVarsNoPostponing
+      -- Remaining level metavariables become parameters, so the restatement
+      -- must carry as many universe parameters as the original; comparing
+      -- against fresh level metavariables instead would let a fixed
+      -- universe pass for a polymorphic original.
+      let t ← instantiateMVars (← Term.levelMVarToParam t)
+      let origInfo ← getConstInfo xName
+      let stParams := (collectLevelParams {} t).params
+      unless stParams.size == origInfo.levelParams.length do
+        throwErrorAt stmt
+          (m!"universe parameters of '{xName}' do not match" ++ hint)
+      let t := t.instantiateLevelParams stParams.toList
+        (origInfo.levelParams.map .param)
+      unless ← isDefEq t origInfo.type do
+        throwErrorAt stmt
+          (m!"the restated statement of '{xName}' does not match.\n\
+              Original:{indentD origInfo.type}\nRestated:{indentD t}" ++ hint)
+
+end RecallCheck
+
+/-! ## Tests -/
+
+namespace RecallCheck.Test
+
+recall
+  inductive Nat where
+  | zero
+  | succ (n : Nat) : Nat
+
+-- A constructor mismatch is reported at the offending constructor, not at
+-- the whole restatement.
+/--
+@ +4:2...26
+error: the statement of 'Nat.succ' does not match.
+Original:
+  Nat → Nat
+Restated:
+  Nat → Nat → Nat
+
+Hint: Replace the restatement with the original:
+  | succ (̲n̲ ̲: N̲a̲t̲)̲ ̲:̲ ̲Nat ̵→̵ ̵N̵a̵t̵ ̵→̵ ̵N̵a̵t̵
+-/
+#guard_msgs (positions := true) in
+recall
+  inductive Nat where
+  | zero
+  | succ : Nat → Nat → Nat
+
+inductive Palette where
+  | red | green | blue
+
+def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+
+theorem twice_id : twice id 3 = 3 := rfl
+
+recall
+  inductive Palette where
+    | red | green | blue
+
+-- A misnamed constructor's suggestion replaces just that constructor.
+/--
+@ +3:18...24
+error: constructor 'RecallCheck.Test.Palette.blau' does not match 'RecallCheck.Test.Palette.blue'
+
+Hint: Replace the restatement with the original:
+  | b̵l̵a̵u̵b̲l̲u̲e̲
+-/
+#guard_msgs (positions := true) in
+recall
+  inductive Palette where
+    | red | green | blau
+
+-- Definitionally equal reformulations are accepted.
+recall
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+
+recall statement twice_id : twice id 3 = 3
+
+-- Imported names can be recalled too.
+recall statement Nat.add_comm : ∀ (n m : Nat), n + m = m + n
+
+-- The statement form counts universe parameters: a placeholder universe
+-- becomes a parameter and matches, and a fixed universe is rejected.
+theorem poly_refl.{u} : ∀ {α : Sort u} (a : α), a = a := fun _ => rfl
+
+recall statement poly_refl : ∀ {α : Sort _} (a : α), a = a
+
+/--
+error: universe parameters of 'RecallCheck.Test.poly_refl' do not match
+
+Hint: Replace the restatement with the original:
+  poly_refl : ∀ {α : T̵y̵p̵e̵}̵S̲o̲r̲t̲ ̲u̲}̲ (a : α), a = a
+-/
+#guard_msgs in
+recall statement poly_refl : ∀ {α : Type} (a : α), a = a
+
+-- A standard library structure with the default constructor name.
+recall
+  structure Prod (α : Type u) (β : Type v) where
+    fst : α
+    snd : β
+
+-- A standard library structure with a custom constructor name.
+recall
+  structure ULift.{r, s} (α : Type s) : Type (max s r) where
+    up ::
+    down : α
+
+-- A wrong constructor name written as a `name ::` header is reported at
+-- that header.
+/--
+@ +3:4...13
+error: constructor 'ULift.uuuppp' does not match 'ULift.up'
+
+Hint: Replace the restatement with the original:
+  u̵u̵u̵p̵p̵p̵u̲p̲ ::
+-/
+#guard_msgs (positions := true) in
+recall
+  structure ULift.{r, s} (α : Type s) : Type (max s r) where
+    uuuppp ::
+    down : α
+
+-- A renamed field is rejected: the constructor's type does not change,
+-- but the projections readers use would.
+/--
+error: the fields of 'Prod' do not match.
+Original:
+  [fst, snd]
+Restated:
+  [fst, other]
+
+Hint: Replace the restatement with the original:
+  s̵t̵r̵u̵c̵t̵u̵r̵e̵ ̵P̵r̵o̵d̵ ̵(̵α̵ ̵:̵ ̵T̵y̵p̵e̵ ̵u̵)̵ ̵(̵β̵ ̵:̵ ̵T̵y̵p̵e̵ ̵v̵)̵ ̵w̵h̵e̵r̵e̵
+  ̵ ̵ ̵ ̵ ̵f̵s̵t̵ ̵:̵ ̵α̵
+  ̵ ̵ ̵ ̵ ̵o̵t̵h̵e̵r̵ ̵:̵ ̵β̵s̲t̲r̲u̲c̲t̲u̲r̲e̲ ̲P̲r̲o̲d̲ ̲(̲α̲ ̲:̲ ̲T̲y̲p̲e̲ ̲u̲)̲ ̲(̲β̲ ̲:̲ ̲T̲y̲p̲e̲ ̲v̲)̲ ̲w̲h̲e̲r̲e̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲/̲-̲-̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲C̲o̲n̲s̲t̲r̲u̲c̲t̲s̲ ̲a̲ ̲p̲a̲i̲r̲.̲ ̲T̲h̲i̲s̲ ̲i̲s̲ ̲u̲s̲u̲a̲l̲l̲y̲ ̲w̲r̲i̲t̲t̲e̲n̲ ̲`̲(̲x̲,̲ ̲y̲)̲`̲ ̲i̲n̲s̲t̲e̲a̲d̲ ̲o̲f̲ ̲`̲P̲r̲o̲d̲.̲m̲k̲ ̲x̲ ̲y̲`̲.̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲-̲/̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲m̲k̲ ̲:̲:̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲/̲-̲-̲ ̲T̲h̲e̲ ̲f̲i̲r̲s̲t̲ ̲e̲l̲e̲m̲e̲n̲t̲ ̲o̲f̲ ̲a̲ ̲p̲a̲i̲r̲.̲ ̲-̲/̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲f̲s̲t̲ ̲:̲ ̲α̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲/̲-̲-̲ ̲T̲h̲e̲ ̲s̲e̲c̲o̲n̲d̲ ̲e̲l̲e̲m̲e̲n̲t̲ ̲o̲f̲ ̲a̲ ̲p̲a̲i̲r̲.̲ ̲-̲/̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲s̲n̲d̲ ̲:̲ ̲β̲
+-/
+#guard_msgs in
+recall
+  structure Prod (α : Type u) (β : Type v) where
+    fst : α
+    other : β
+
+-- Restating it with the default constructor name is rejected. A structure
+-- has no constructor syntax node, so the error is on the whole command.
+/--
+error: constructor 'ULift.mk' does not match 'ULift.up'
+
+Hint: Replace the restatement with the original:
+  s̵t̵r̵u̵c̵t̵u̵r̵e̵ ̵U̵L̵i̵f̵t̵.̵{̵r̵,̵ ̵s̵}̵ ̵(̵α̵ ̵:̵ ̵T̵y̵p̵e̵ ̵s̵)̵ ̵:̵ ̵T̵y̵p̵e̵ ̵(̵m̵a̵x̵ ̵s̵ ̵r̵)̵ ̵w̵h̵e̵r̵e̵
+  ̵ ̵ ̵ ̵ ̵d̵o̵w̵n̵ ̵:̵ ̵α̵s̲t̲r̲u̲c̲t̲u̲r̲e̲ ̲U̲L̲i̲f̲t̲.̲{̲r̲,̲ ̲s̲}̲ ̲(̲α̲ ̲:̲ ̲T̲y̲p̲e̲ ̲s̲)̲ ̲:̲ ̲T̲y̲p̲e̲ ̲(̲m̲a̲x̲ ̲s̲ ̲r̲)̲ ̲w̲h̲e̲r̲e̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲/̲-̲-̲ ̲W̲r̲a̲p̲s̲ ̲a̲ ̲v̲a̲l̲u̲e̲ ̲t̲o̲ ̲i̲n̲c̲r̲e̲a̲s̲e̲ ̲i̲t̲s̲ ̲t̲y̲p̲e̲'̲s̲ ̲u̲n̲i̲v̲e̲r̲s̲e̲ ̲l̲e̲v̲e̲l̲.̲ ̲-̲/̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲u̲p̲ ̲:̲:̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲/̲-̲-̲ ̲E̲x̲t̲r̲a̲c̲t̲s̲ ̲a̲ ̲w̲r̲a̲p̲p̲e̲d̲ ̲v̲a̲l̲u̲e̲ ̲f̲r̲o̲m̲ ̲a̲ ̲u̲n̲i̲v̲e̲r̲s̲e̲-̲l̲i̲f̲t̲e̲d̲ ̲t̲y̲p̲e̲.̲ ̲-̲/̲
+  ̲ ̲ ̲ ̲ ̲ ̲ ̲d̲o̲w̲n̲ ̲:̲ ̲α̲
+-/
+#guard_msgs in
+recall
+  structure ULift.{r, s} (α : Type s) : Type (max s r) where
+    down : α
+
+/--
+error: the value of 'RecallCheck.Test.twice' does not match.
+Original:
+  fun f n => f (f n)
+Restated:
+  fun f n => f n
+
+Hint: Replace the restatement with the original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (̲f̲ ̲n)̲
+-/
+#guard_msgs in
+recall
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f n
+
+/--
+error: the restated command declares several names; recall one declaration at a time
+---
+error: the restated command declares several names; recall one declaration at a time
+-/
+#guard_msgs in
+recall
+  mutual
+    def one : Nat := 1
+    def two : Nat := 2
+  end
+
+open List in
+recall
+  def List.map (f : α → β) : (l : List α) → List β
+    | [] => []
+    | x :: xs => f x :: map f xs
+end RecallCheck.Test

--- a/SFLMeta/RecallSource.lean
+++ b/SFLMeta/RecallSource.lean
@@ -1,0 +1,270 @@
+import Lean
+
+/-!
+# Recall, checked byte for byte
+
+`recall_source` lets a chapter restate a definition from earlier in the
+development while the build checks that the restatement matches the
+original's source text, byte for byte. The restated text is what the
+reader already saw, and it can never drift from the original.
+
+```
+recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+```
+
+The syntax is scoped: the command is available inside `RecallSource` and
+wherever it is opened, and `recall_source` is not a keyword elsewhere.
+
+The restated declaration is parsed but never elaborated; the check is
+purely textual: after the block indentation is removed from each side, the
+two texts must be equal, byte for byte. The restatement may sit at a
+different indentation depth, but it may not be reflowed or respaced.
+
+The comparison covers whole declarations only. Carving a statement out of
+the original's source would require parsing it, which is only possible in
+the elaboration context of its declaration site; restating only a theorem
+statement is therefore the province of `recall statement`, which compares
+elaborated types.
+-/
+
+open Lean Elab Command
+
+namespace RecallSource
+
+/-- All `declId` nodes in a command, in source order. -/
+partial def declIds (stx : Syntax) : Array Syntax :=
+  let inner := stx.getArgs.flatMap declIds
+  if stx.isOfKind ``Lean.Parser.Command.declId then #[stx] ++ inner else inner
+
+/--
+The `declId` node of a declaration command, together with the name written
+in it. A command that declares several names (a `mutual` block) or none (an
+anonymous `instance`, an `example`) is rejected.
+-/
+def declaredName (cmd : Syntax) : CommandElabM (Syntax × Name) := do
+  let defined := declIds cmd
+  match h : defined.size with
+  | 0 => throwErrorAt cmd "the restated command does not declare a name"
+  | 1 =>
+    let declId := defined[0]
+    return (declId, declId[0].getId)
+  | n + 2 =>
+    for h : i in 0...(n + 1) do
+      logErrorAt defined[i]
+        "the restated command declares several names; recall one declaration at a time"
+    throwErrorAt defined[n + 1]
+      "the restated command declares several names; recall one declaration at a time"
+
+/--
+Removes the block indentation of a declaration's source text. The first
+line starts at the declaration's first token and has no indentation of its
+own; each following line is stripped of the smallest indentation found
+among the non-blank ones. Restatements of the same text at different block
+depths dedent to identical strings, and every other difference survives
+dedenting.
+-/
+def dedent (s : String) : String :=
+  match indentWidth s, s.splitOn "\n" with
+  | some n, first :: rest =>
+    "\n".intercalate (first :: rest.map (fun l => String.ofList (l.toList.drop n)))
+  | _, _ => s
+where
+  /-- The smallest indentation among the non-blank continuation lines. -/
+  indentWidth (s : String) : Option Nat :=
+    s.splitOn "\n" |>.drop 1 |>.map (·.toList)
+      |>.filter (fun l => !l.all (·.isWhitespace))
+      |>.map (fun l => (l.takeWhile (· == ' ')).length)
+      |>.min?
+
+/--
+Indents the continuation lines of dedented source text by `n` spaces, so
+that the text reads correctly at the block depth of a restatement.
+-/
+def reindent (s : String) (n : Nat) : String :=
+  match s.splitOn "\n" with
+  | [] => s
+  | first :: rest =>
+    let pad := String.ofList (List.replicate n ' ')
+    "\n".intercalate (first :: rest.map fun l =>
+      if l.toList.all (·.isWhitespace) then l else pad ++ l)
+
+/--
+Removes the comments from the front of dedented source text, together with
+the whitespace around them, so that a suggestion offered for a restatement
+that carries no comments does not introduce any. The text of a declaration
+or of a constructor begins with its doc comment when it has one, possibly
+accompanied by ordinary comments, and a leading block comment ends at its
+depth-balanced closing delimiter, so a character scan recognizes the
+leading run of comments exactly. A comment elsewhere in the text cannot be
+recognized without lexing and is left in place.
+-/
+def stripLeadingComments (s : String) : String := Id.run do
+  let mut cs := s.toList.dropWhile (·.isWhitespace)
+  repeat
+    if cs.take 2 == ['/', '-'] then
+      cs := cs.drop 2
+      let mut depth := 1
+      while depth > 0 do
+        match cs with
+        | [] => return s
+        | '/' :: '-' :: rest => depth := depth + 1; cs := rest
+        | '-' :: '/' :: rest => depth := depth - 1; cs := rest
+        | _ :: rest => cs := rest
+    else if cs.take 2 == ['-', '-'] then
+      cs := cs.dropWhile (· != '\n')
+    else
+      break
+    cs := cs.dropWhile (·.isWhitespace)
+  return String.ofList cs
+
+/--
+A clickable suggestion that replaces the restated text at `span` with
+`original`, which must already be dedented. The original's indentation is
+moved to match the restatement's: the restatement's own indentation width
+when it has continuation lines, one step past the span's start column when
+it does not.
+-/
+def replaceWithOriginalHint [Monad m] [MonadFileMap m] [MonadLiftT CoreM m]
+    (span : Syntax) (original restated : String) : m MessageData := do
+  let fileMap ← getFileMap
+  let k := match dedent.indentWidth restated, span.getRange? with
+    | some k, _ => k
+    | none, some r => (fileMap.toPosition r.start).column + 2
+    | none, none => 2
+  MessageData.hint m!"Replace the restatement with the original:"
+    #[{ suggestion := .string (reindent original k), span? := some span }]
+
+/--
+The source text of the declaration of `x`, from the file that declared it.
+
+The location comes from the declaration range that Lean records for every
+constant. A declaration from the current file is read out of the file map;
+one from an imported module is read from its source file, found on the
+source search path. In a book build the whole project's sources are on that
+path, so definitions can be recalled across chapters.
+-/
+def sourceOf [Monad m] [MonadEnv m] [MonadError m] [MonadFileMap m]
+    [MonadLiftT IO m] [MonadLiftT BaseIO m] (x : Name) : m String := do
+  let some ranges ← findDeclarationRanges? x
+    | throwError "no declaration range recorded for '{x}'"
+  let env ← getEnv
+  let text ←
+    match env.getModuleIdxFor? x with
+    | none => pure (← getFileMap)
+    | some idx => do
+      let modName := env.allImportedModuleNames[idx.toNat]!
+      let sp ← getSrcSearchPath
+      let some path ← sp.findModuleWithExt "lean" modName
+        | throwError "source for module '{modName}' is not on the search path"
+      pure (FileMap.ofString (← IO.FS.readFile path))
+  return String.Pos.Raw.extract text.source
+    (text.ofPosition ranges.range.pos) (text.ofPosition ranges.range.endPos)
+
+/-- The source text of a piece of syntax in the current file. -/
+def sourceOfSyntax [Monad m] [MonadError m] [MonadFileMap m]
+    (stx : Syntax) : m String := do
+  let some r := stx.getRange?
+    | throwErrorAt stx "no source range"
+  return String.Pos.Raw.extract (← getFileMap).source r.start r.stop
+
+/--
+`recall_source` restates a definition from earlier in the development and
+checks that the restatement matches the original's source text, byte for
+byte, modulo block indentation.
+-/
+scoped syntax (name := recallSrc) "recall_source " command : command
+
+elab_rules : command
+  | `(recall_source $cmd:command) => do
+    let (declId, written) ← declaredName cmd
+    let x ← liftCoreM <| realizeGlobalConstNoOverload (mkIdentFrom declId written)
+    -- The restatement is never elaborated, so it produces no info of its
+    -- own. The whole compared region is one big reference to the original:
+    -- hovering anywhere in it shows the original, and go-to-definition
+    -- jumps to it.
+    addConstInfo cmd x
+    let restated ← sourceOfSyntax cmd
+    let original ← sourceOf x
+    unless dedent restated == dedent original do
+      throwErrorAt cmd
+        (m!"the restatement of '{x}' does not match its source.\n\
+            Original:{indentD original}\nRestated:{indentD restated}"
+          ++ (← liftCoreM <| replaceWithOriginalHint cmd (dedent original) restated))
+
+end RecallSource
+
+/-! ## Tests -/
+
+namespace RecallSource.Test
+
+inductive Palette where
+  | red | green | blue
+
+def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+
+theorem twice_id : twice id 3 = 3 := rfl
+
+recall_source
+  inductive Palette where
+    | red | green | blue
+
+recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+
+-- Leading comments are removed exactly, including the one-line, nested,
+-- and line-comment forms; text without them is untouched.
+#guard RecallSource.stripLeadingComments
+  "/-- d -/ theorem foo : True := trivial" == "theorem foo : True := trivial"
+#guard RecallSource.stripLeadingComments
+  "/-- a /- b -/ c -/\ndef x := 1" == "def x := 1"
+#guard RecallSource.stripLeadingComments
+  "/-- d -/\n-- note\n-- more\ndef x := 1" == "def x := 1"
+#guard RecallSource.stripLeadingComments "def x := 1" == "def x := 1"
+
+/--
+error: the restatement of 'RecallSource.Test.twice' does not match its source.
+Original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+Restated:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+
+Hint: Replace the restatement with the original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <̵|̵ ̵(̲f n)̲
+-/
+#guard_msgs in
+recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+
+-- Reflowing the original is rejected even though the tokens agree.
+/--
+error: the restatement of 'RecallSource.Test.twice' does not match its source.
+Original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+Restated:
+  def twice (f : Nat → Nat) (n : Nat) : Nat :=
+      f (f n)
+
+Hint: Replace the restatement with the original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat :=
+  ̵  ̵ ̵ ̵f (f n)
+-/
+#guard_msgs in
+recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat :=
+    f (f n)
+
+/--
+error: the restated command declares several names; recall one declaration at a time
+---
+error: the restated command declares several names; recall one declaration at a time
+-/
+#guard_msgs in
+recall_source
+  mutual
+    def one : Nat := 1
+    def two : Nat := 2
+  end
+
+end RecallSource.Test
+


### PR DESCRIPTION
This adds the `recall` and `recallSource` blocks that David developed for us. These should be the standard way to refer to a preexisting definition from now on. I moved over a couple of places in the typeclasses chapter to use this, but did not check comprehensively for places we recall definitions. Feel free to push more to this PR or do so in a follow-up.

The only limitations I notice are that these don't get syntax highlighting in the HTML, and that you might not always want the accompanying docstring(s).

Co-authored-by: David Thrane Christiansen <[david@davidchristiansen.dk](mailto:david@davidchristiansen.dk)>