### PR TITLE
Fix Logic quizzes and small reader-facing errors

### DIFF
--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -559,7 +559,7 @@ And (a b : Prop) : Prop
 ## Disjunction
 
 Another important connective is the _disjunction_, or _logical or_,
-of two propositions: {lean}`a ∨ b` is true when either {lean}`a` or lean`b` is.
+of two propositions: {lean}`a ∨ b` is true when either {lean}`a` or {lean}`b` is.
 This infix notation stands for {lean}`Or a b`, where
 `Or : Prop -> Prop -> Prop`.
 
@@ -651,7 +651,7 @@ Up to this point, we have mostly been concerned with proving
 is associative, etc.  We are sometimes also interested in negative
 results, demonstrating that some proposition is _not_ true. Such
 statements are expressed with the logical negation operator `¬`,
-which a prefix notation for {lean}`Not`.
+which is a prefix notation for {lean}`Not`.
 
 To see how negation works, recall the _principle of explosion_
 from the `Tactics` chapter, which asserts that, if we assume a
@@ -1329,7 +1329,7 @@ example : Even 4 := by exists 2
 ```
 
 Conversely, if we have an existential hypothesis {lean}`∃ x, a` in the context,
-can destrucure it to obtain a witness {lean}`x` and a hypothesis stating that {lean}`a`
+we can destructure it to obtain a witness {lean}`x` and a hypothesis stating that {lean}`a`
 holds of {lean}`x`.
 
 ```lean
@@ -1340,8 +1340,8 @@ example n : (∃ m, n = m + 4) → (∃ o, n = o + 2) := by
 
 ::::::full
 :::::exercise (rating := 1) (name := "dist_not_exists")
-Prove that "{lean}`a` holds for all {lean}`x` implies "there is no {lean}`x` for which
-{lean}`a` does not hold." (Hint: `cases` and `obtain` work on existential assumptions!)
+Prove that if {lean}`a` holds for all {lean}`x`, then there is no {lean}`x` for which
+{lean}`a` does not hold. (Hint: `cases` and `obtain` work on existential assumptions!)
 
 ```lean
 theorem dist_not_exists (α : Type) (p : α → Prop) (h : ∀ x, p x) :
@@ -1477,7 +1477,7 @@ What does it mean to say that
 ::::
 
 We can translate this directly into a straightforward recursive function
-taken an element and a list and returning... a proposition!
+taking an element and a list and returning... a proposition!
 
 ```lean
 def List.In {α : Type} (x : α) (xs : List α) : Prop :=
@@ -1491,7 +1491,7 @@ theorem List.In_nil {α : Type} {x : α} : ¬ (List.In x []) := by
 theorem List.In_cons {α : Type} {x x' : α} {xs : List α} : List.In x (x' :: xs) = (x = x' ∨ List.In x xs) := rfl
 ```
 
-When {lean}`List.In` is applied to a concrete list, it exapnds into a concrete sequence
+When {lean}`List.In` is applied to a concrete list, it expands into a concrete sequence
 of nested disjunctions.
 
 ```lean
@@ -1739,8 +1739,8 @@ The type of an ordinary function tells us what we can do with it.
     two {lean}`Nat`s as arguments and get a {lean}`Nat` back.
 Similarly, the statement of a theorem tells us what we can use
 that theorem for.
-  - If we have a term of type {lean}`∀ n m : Nat, n = m → n + n = m + n`,
-    and we provide it two numbers {lean}`n` and {lean}`m` and a third "arugment"
+  - If we have a term of type {lean}`∀ n m : Nat, n = m → n + n = m + m`,
+    and we provide it two numbers {lean}`n` and {lean}`m` and a third "argument"
     of type {lean}`n = m`, we get back a proof object of type {lean}`n + n = m + m`.
 
 ::::full
@@ -1748,7 +1748,7 @@ Operationally, this analogy goes even further: by applying a theorem
 as if it were a function, i.e., applying it to values and hypotheses
 with matching types, we can specialize its result without having to
 resort to intermediate assertions. For example, suppose we wanted
-to prove the follwing result:
+to prove the following result:
 ::::
 
 ::::terse
@@ -1786,7 +1786,7 @@ x y z : Nat
 ```
 
 It appears at first sight that we ought to be able to prove this
-be rewriting with {lean}`Nat.add_comm` twice to make the two sides match.
+by rewriting with {lean}`Nat.add_comm` twice to make the two sides match.
 The problem is that the second rewrite undoes the effect
 of the first, leaving us back where we started...
 
@@ -1831,7 +1831,7 @@ Suppose we have
 ```display
 n m : Nat
 h₁ : n = m
-h₂ : b = 42
+h₂ : m = 42
 trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z
 ```
 
@@ -1849,9 +1849,8 @@ What is the type of this "proof object"?
 :::quizSolution
 ```lean
 example (n m : Nat) (h₁ : n = m) (h₂ : m = 42)
-   (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : True := by
-  have : n = 42 := @trans_eq Nat n m 42 h₁ h₂
-  sorry
+    (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : n = 42 :=
+  @trans_eq Nat n m 42 h₁ h₂
 ```
 :::
 ::::
@@ -1862,7 +1861,7 @@ Suppose, again, we have
 ```display
 n m : Nat
 h₁ : n = m
-h₂ : b = 42
+h₂ : m = 42
 trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z
 ```
 
@@ -1880,9 +1879,8 @@ trans_eq h₁ h₂
 :::quizSolution
 ```lean
 example (n m : Nat) (h₁ : n = m) (h₂ : m = 42)
-   (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : True := by
-    have : n = 42 := trans_eq h₁ h₂
-    sorry
+    (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : n = 42 :=
+  trans_eq h₁ h₂
 ```
 :::
 ::::
@@ -1893,7 +1891,7 @@ Suppose, again, we have
 ```display
 n m : Nat
 h₁ : n = m
-h₂ : b = 42
+h₂ : m = 42
 trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z
 ```
 
@@ -1911,9 +1909,9 @@ What is the type of this proof object?
 :::quizSolution
 ```lean
 example (n m : Nat) (h₁ : n = m) (h₂ : m = 42)
-   (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : True := by
-   have : 42 = n → m = n := @trans_eq Nat m 42 n h₂
-   sorry
+    (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) :
+    42 = n → m = n :=
+  @trans_eq Nat m 42 n h₂
 ```
 :::
 ::::
@@ -1924,7 +1922,7 @@ Suppose, again, we have
 ```display
 n m : Nat
 h₁ : n = m
-h₂ : b = 42
+h₂ : m = 42
 trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z
 ```
 
@@ -1942,9 +1940,9 @@ What is the type of this proof object?
 :::quizSolution
 ```lean
 example (n m : Nat) (h₁ : n = m) (h₂ : m = 42)
-   (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : True := by
-    have : 42 = n → n = m → 42 = m := @trans_eq _ 42 n m
-    sorry
+    (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) :
+    42 = n → n = m → 42 = m :=
+  @trans_eq _ 42 n m
 ```
 :::
 ::::
@@ -1955,7 +1953,7 @@ Suppose, again, we have
 ```display
 n m : Nat
 h₁ : n = m
-h₂ : b = 42
+h₂ : m = 42
 trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z
 ```
 
@@ -1965,16 +1963,16 @@ What is the type of this proof object?
 trans_eq h₂ h₁
 ```
 
-1. `b = a`
-2. `42 = a`
-3. `a = 42`
+1. `m = n`
+2. `42 = n`
+3. `n = 42`
 4. Does not typecheck
 
 :::quizSolution
 ```lean +error (name := qe)
 example (n m : Nat) (h₁ : n = m) (h₂ : m = 42)
-   (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : True := by
-    have := trans_eq h₂ h₁
+    (trans_eq : ∀ {α : Type} {x y z : α}, x = y → y = z → x = z) : True := by
+  have := trans_eq h₂ h₁
 ```
 
 ```leanOutput qe
@@ -2206,12 +2204,12 @@ because we don't have to invent the witness {lean}`50`:
 computation does it for us!
 
 ```lean
-example : Nat.even 100 := rfl
+example : Nat.even 100 = true := rfl
 ```
 
 Now, the useful observation is that, since the two notions are equivalent,
 we can use the boolean formulation to prove the other one
-without mentioning the value 500 explicitly:
+without mentioning the value 50 explicitly:
 
 ```lean
 example : Nat.Even 100 := by
@@ -2224,12 +2222,12 @@ in this case, larger proofs can often be made considerably simpler
 by the use of reflection.
 
 As an extreme example, a famous mechanized proof of the even more famous
-_four colour theorem_ uses reflection ot reduce the analysis of hundreds
+_four colour theorem_ uses reflection to reduce the analysis of hundreds
 of different cases to a boolean computation.
 
 Another advantage of booleans is that the _negation_ of a claim about
 booleans is straightforward to state and (when true) to prove:
-simply slip the expected boolean result.
+simply flip the expected boolean result.
 
 ```lean
 example : Nat.even 101 = false := rfl
@@ -2322,7 +2320,7 @@ theorem orb_true_iff (b1 b2 : Bool) :
 Given a boolean operator `beq` for testing equality of elements
 of some type {lean}`α`, we can define a function `beqList` for testing
 equality of lists with elements in {lean}`α`. Complete the definition
-of the `beqList` function below. to make sure that your definition
+of the `beqList` function below. To make sure that your definition
 is correct, prove the lemma `beqList_true_iff`.
 
 ```lean
@@ -2434,7 +2432,7 @@ theorem List.allb_true_iff α {test : α → Bool} {l : List α} :
       · intro ⟨h₁', h₂'⟩; exact h₂ ⟨h₁', ih₂ h₂'⟩
 ```
 
-(Ungraded thought question) Are there any important properties often
+(Ungraded thought question) Are there any important properties of
 the function {lean}`List.allb` which are not captured by this specification?
 
 :::solution
@@ -2471,7 +2469,7 @@ but a few points are useful to understand.
 
 ## Propositional Extensionality
 
-Lean's logic is quite minimalistic. This means that on occasionally
+Lean's logic is quite minimalistic. This means that one occasionally
 encounters cases where translating standard mathematical reasoning
 into Lean is cumbersome - or even impossible - unless we enrich
 its core logic with additional axioms.
@@ -2602,8 +2600,8 @@ theorem and_assoc_eq (a b c : Prop) : ((a ∧ b) ∧ c) = (a ∧ (b ∧ c)) := b
 Here is an example of where using `=` instead of `↔` is more convenient:
 we show that it's possible to "flip" three conjoined propositions.
 
-This can be proven by constructing the `↔`, then destructing the `↔`
-in {lean}`Nat.add_comm` and {lean}`Nat.add_assoc`, then applying them a few times.
+One way to prove this is to construct the `↔`, destruct the `↔`s provided by
+{lean}`and_comm` and {lean}`and_assoc`, and apply the resulting implications a few times.
 But this is a lot of hassle, when the proof is conceptually simple:
 we flip {lean}`b` and {lean}`c`, then we flip that conjunction with {lean}`a`, and we
 finish by associativity. By using {lean}`and_comm_eq`, this is easily done
@@ -2837,7 +2835,7 @@ holds. But the universally quantified {lean}`a` in {lean}`ExcludedMiddle` is an
 _arbitrary_ proposition, which we know nothing about. We don't have enough
 information to choose which of {tactic}`left` or {tactic}`right` to apply.
 
-However, in the special case where we happen to know that{lean}`a` is reflected
+However, in the special case where we happen to know that {lean}`a` is reflected
 in some boolean term {lean}`b`, knowing whether it holds or not is trivial:
 we just have to check the value of {lean}`b`.
 
@@ -2849,7 +2847,7 @@ theorem restricted_excluded_middle (a : Prop) (b : Bool) (h : a ↔ b = true) :
   | true => left; rw [h]
 ```
 
-In partiuclar, the excluded middle is valid for equations {lean}`n = m` between
+In particular, the excluded middle is valid for equations {lean}`n = m` between
 natural numbers {lean}`n` and {lean}`m`.
 
 ```lean
@@ -2982,10 +2980,10 @@ Classical.not_not {a : Prop} : ¬¬a ↔ a
 ```
 
 :::::exercise (rating := 3) (name := "excluded_middle_irrefutable")
-The following theorem implies that it is always save to assume
+The following theorem implies that it is always safe to assume
 a decidability axiom (i.e., an instance of excluded middle) for any
 _particular_ proposition {lean}`a`. Why? Because the negation of such an axiom
-leands to a contradiction. If {lean}`¬ (a ∨ ¬ a)` were provable, then by
+leads to a contradiction. If {lean}`¬ (a ∨ ¬ a)` were provable, then by
 {lean}`de_morgan_not_or` as proven above, {lean}`a ∧ ¬ a` would be provable,
 which would be a contradiction. So, it is safe to add {lean}`a ∨ ¬ a` as an axiom
 for any particular {lean}`a`.


### PR DESCRIPTION
While reading through Logic, I noticed that the theorem-application quizzes still used an old variable name, making their displayed contexts inconsistent with the examples. This fixes those contexts and answer choices, and makes the solutions state the inferred types directly instead of ending with `sorry`.

I also fixed a mismatched theorem type and several small typos, stale names, and incorrect numbers I encountered throughout the chapter.