### PR TITLE
Factor custom commands to SFLCompat library

### DIFF
--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -1236,7 +1236,7 @@ Another handy higher-order function is called `map`.
 ::::
 
 ```lean
-def map {α : Type} {β : Type} (f : α → β) (l : List α) : List β :=
+def map {α β : Type} (f : α → β) (l : List α) : List β :=
   match l with
   | [] => []
   | head :: tail => f head :: map f tail
@@ -1278,7 +1278,7 @@ example : map (fun n => [n.even, n.odd]) [2, 1, 2, 5]
 Recall the definition of {name}`map`:
 
 ```recall
-def map (f : α → β) (l : List α) : List β :=
+def map {α β : Type} (f : α → β) (l : List α) : List β :=
   match l with
   | [] => []
   | head :: tail => f head :: map f tail
@@ -1751,7 +1751,7 @@ theorem curry_uncurry {α β γ : Type} {p : α × β} {f : α × β → γ} :
 Recall the definition of the {name}`nth?` function:
 
 ```recall
-def nth? (l : List α) (n : Nat) : Option α :=
+def nth? {α : Type} (l : List α) (n : Nat) : Option α :=
   match l with
   | [] => none
   | x :: l' => match n with

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -1277,7 +1277,7 @@ example : map (fun n => [n.even, n.odd]) [2, 1, 2, 5]
 ::::quiz
 Recall the definition of {name}`map`:
 
-```display
+```recall
 def map (f : α → β) (l : List α) : List β :=
   match l with
   | [] => []
@@ -1453,7 +1453,7 @@ theorem fold_cons {α : Type} {β : Type} {f : α → β → β} {a : α} {l : L
 ::::quiz
 Here is the definition of `fold` again:
 
-```display
+```recall
 def fold {α β : Type} (f : α → β → β) (l : List α) (b : β) : β :=
   match l with
   | [] => b
@@ -1750,7 +1750,7 @@ theorem curry_uncurry {α β γ : Type} {p : α × β} {f : α × β → γ} :
 :::::exercise (rating := 2) (name := "nth_error_informal") (level := Advanced) (optional := true) (manual := true)
 Recall the definition of the {name}`nth?` function:
 
-```display
+```recall
 def nth? (l : List α) (n : Nat) : Option α :=
   match l with
   | [] => none

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1573,7 +1573,7 @@ Here is an implementation of the {name}`unzip` function mentioned in
 chapter {ref "Poly"}[Poly]:
 
 ```recall
-def unzip {α : Type} {β : Type} (l : List (α × β)) : List α × List β := solution!(
+def unzip {α β : Type} (l : List (α × β)) : List α × List β := solution!(
   match l with
   | [] => ([], [])
   | (x, y) :: t =>
@@ -1820,7 +1820,7 @@ theorem append_left_cancel {α : Type} (l₁ l₂ l₃ : List α)
 Recall the {name}`map` we've defined in {ref "Poly"}[Poly]:
 
 ```recall
-def map {α : Type} {β : Type} (f : α → β) (l : List α) : List β :=
+def map {α β : Type} (f : α → β) (l : List α) : List β :=
   match l with
   | [] => []
   | head :: tail => f head :: map f tail

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1568,36 +1568,36 @@ get the first and second projections of `v` using this tactic:
 let ⟨a, β⟩ := v
 ```
 
-:::::exercise (rating := 3) (name := "zip_unzip")
+:::::exercise (rating := 3) (name := "zip_unzip'")
 Here is an implementation of the {name}`unzip` function mentioned in
 chapter {ref "Poly"}[Poly]:
 
-```recall
-def unzip {α β : Type} (l : List (α × β)) : List α × List β := solution!(
+```lean
+def unzip' {α β : Type} (l : List (α × β)) : List α × List β := solution!(
   match l with
   | [] => ([], [])
   | (x, y) :: t =>
-    let (lx, ly) := unzip t
+    let (lx, ly) := unzip' t
     (x :: lx, y :: ly))
 ```
 
-Prove that {name}`unzip` and {name}`zip` are inverses in the following sense:
+Prove that {name}`unzip'` and {name}`zip` are inverses in the following sense:
 
 ```lean
-theorem zip_unzip {α β : Type} (l : List (α × β))
+theorem zip_unzip' {α β : Type} (l : List (α × β))
     (l₁ : List α) (l₂ : List β)
-    (h : unzip l = (l₁, l₂)) :
+    (h : unzip' l = (l₁, l₂)) :
     zip l₁ l₂ = l := by
   solution!
     induction l generalizing l₁ l₂ with
     | nil =>
-      rw [unzip_nil] at h
+      dsimp [unzip'] at h
       injections h₁ h₂
       rw [← h₁, ← h₂]
       rfl
     | cons x xs ih =>
       let ⟨a, b⟩ := x
-      dsimp [unzip] at h
+      dsimp [unzip'] at h
       injections h₁ h₂
       rw [← h₁, ← h₂]
       dsimp [zip]
@@ -1605,7 +1605,7 @@ theorem zip_unzip {α β : Type} (l : List (α × β))
       rfl
 ```
 
-:::gradeTheorem 3 zip_unzip
+:::gradeTheorem 3 zip_unzip'
 :::
 
 :::::
@@ -1859,7 +1859,8 @@ theorem map_injective_of_injective {α β : Type}
 
 
 :::::exercise (rating := 3) (name := "unzip_zip") (level := Advanced) (manual := true)
-We proved {name}`zip_unzip` that {name}`zip`ping the result of {name}`unzip` recovers the original list. What about the other direction?  Complete and prove the following `unzip_zip`:
+We proved {name}`zip_unzip'` that {name}`zip`ping the result of {name}`unzip` recovers the original list.
+What about the other direction?  Complete and prove the following `unzip_zip`:
 
 ```display
 theorem unzip_zip {α β : Type}

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -395,8 +395,8 @@ theorem trans_eq_exercise (n m o p : Nat)
 ::::full
 Recall the definition of natural numbers:
 
-```display
-inductive Nat : Type :=
+```recall
+inductive Nat : Type where
   | zero
   | succ (n : Nat)
 ```
@@ -626,12 +626,15 @@ theorem disjoint_ex3 {α : Type} (x y z : α) (l : List α)
 ## Quizzes
 
 Recall our {name}`RGB` and {name}`Color` types:
-```display
+
+```recall
 inductive RGB : Type where
   | red
   | green
   | blue
+```
 
+```recall
 inductive Color : Type where
   | black
   | white
@@ -1065,11 +1068,11 @@ variable (m n m' n' : Nat)
 Recall this function for doubling a natural number from the
 {ref "Induction"}[Induction] chapter:
 
-```display
+```recall
 def Nat.double (n : Nat) : Nat :=
   match n with
   | 0 => 0
-  | n' + 1 => (n'.double) + 2
+  | n' + 1 => double n' + 2
 ```
 
 ::::terse
@@ -1569,7 +1572,7 @@ let ⟨a, β⟩ := v
 Here is an implementation of the {name}`unzip` function mentioned in
 chapter {ref "Poly"}[Poly]:
 
-```display
+```recall
 def unzip {α : Type} {β : Type} (l : List (α × β)) : List α × List β := solution!(
   match l with
   | [] => ([], [])
@@ -1816,7 +1819,7 @@ theorem append_left_cancel {α : Type} (l₁ l₂ l₃ : List α)
 
 Recall the {name}`map` we've defined in {ref "Poly"}[Poly]:
 
-```display
+```recall
 def map {α : Type} {β : Type} (f : α → β) (l : List α) : List β :=
   match l with
   | [] => []

--- a/LF/Typeclasses.lean
+++ b/LF/Typeclasses.lean
@@ -1,18 +1,4 @@
-import VersoManual
-import VersoManual.InlineLean
-import Illuminate
-import SFLMeta.Bnf
-import SFLMeta.Ignore
-import SFLMeta.Save
-import SFLMeta.Comment
-import SFLMeta.Exercise
-import SFLMeta.Grade
-import SFLMeta.Hide
-import SFLMeta.Instructors
-import SFLMeta.SlideBreak
-import SFLMeta.Solution
-import SFLMeta.Terse
-import SFLMeta.RecallBlock
+import SFLMeta
 
 set_option autoImplicit false
 

--- a/SFLCompat.lean
+++ b/SFLCompat.lean
@@ -1,0 +1,9 @@
+module
+
+-- This will let the code actions spread to extracted projects
+public import Batteries.CodeAction
+
+public meta import SFLCompat.Experiment
+public meta import SFLCompat.Recall.Common
+public meta import SFLCompat.Recall.Check
+public meta import SFLCompat.Recall.Source

--- a/SFLCompat/Experiment.lean
+++ b/SFLCompat/Experiment.lean
@@ -2,7 +2,7 @@ module
 
 public meta import Lean.Elab.BuiltinCommand
 
-namespace SFLCompat.Experiement
+namespace SFLCompat.Experiment
 
 open Lean Elab Command
 
@@ -208,7 +208,7 @@ sf_expect_failure?
 #check Nat
 
 /--
-info: SFLCompat.Experiement.Tests.x : Nat
+info: SFLCompat.Experiment.Tests.x : Nat
 ---
 info: 3
 -/
@@ -249,4 +249,4 @@ sf_experiment
 
 end Tests
 
-end SFLCompat.Experiement
+end SFLCompat.Experiment

--- a/SFLCompat/Experiment.lean
+++ b/SFLCompat/Experiment.lean
@@ -1,10 +1,8 @@
 module
 
--- This will let the code actions spread to extracted projects
-public import Batteries.CodeAction
 public meta import Lean.Elab.BuiltinCommand
 
-namespace SLFCommand
+namespace SFLCompat.Experiement
 
 open Lean Elab Command
 
@@ -210,7 +208,7 @@ sf_expect_failure?
 #check Nat
 
 /--
-info: SLFCommand.Tests.x : Nat
+info: SFLCompat.Experiement.Tests.x : Nat
 ---
 info: 3
 -/
@@ -251,4 +249,4 @@ sf_experiment
 
 end Tests
 
-end SLFCommand
+end SFLCompat.Experiement

--- a/SFLCompat/Recall/Check.lean
+++ b/SFLCompat/Recall/Check.lean
@@ -1,10 +1,13 @@
-import Lean
-import SFLMeta.RecallSource
+module
+
+-- For testing cases in this file
+meta import all Init.Prelude
+public meta import SFLCompat.Recall.Common
 
 /-!
 # Recall, checked by elaboration
 
-`recall` lets a chapter restate a definition from earlier in the
+`sf_recall` lets a chapter restate a definition from earlier in the
 development while the build checks that the restatement means the same
 thing. The restated declaration is elaborated for real, inside a hidden
 namespace, and compared with the original up to definitional equality; the
@@ -13,55 +16,57 @@ temporary declaration is then rolled back.
 Two forms:
 
 ```
-recall
+sf_recall
   def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
 
-recall statement twice_id : twice id 3 = 3
+sf_recall statement twice_id : twice id 3 = 3
 ```
 
 What is compared:
 
 * types, always;
-* a `def`'s value;
+* a `def`'s value, safety, and abbreviation status;
 * an inductive's constructors, one by one (names, parameter and index
   counts, and each constructor's type);
+* a structure's fields, field defaults, and type-class registration;
 * a theorem's statement, never its proof.
 
 So a recalled definition may be reformatted or rephrased into something
 definitionally equal, and a theorem may be reproved differently or, with
-the `statement` form, restated without any proof. The syntax is scoped:
-the command is available inside `RecallCheck` and wherever it is opened,
-and `recall` is not a keyword elsewhere.
+the `statement` form, restated without any proof. The command is global and
+available wherever this module is imported.
 -/
+
+
+namespace SFLCompat.Recall.Check
 
 open Lean Elab Command Meta
 
-namespace RecallCheck
+meta section
 
-/-- All `declId` nodes in a command, in source order. -/
-partial def declIds (stx : Syntax) : Array Syntax :=
-  let inner := stx.getArgs.flatMap declIds
-  if stx.isOfKind ``Lean.Parser.Command.declId then #[stx] ++ inner else inner
+structure DeclId where
+  /-- This could be a private name. -/
+  actual : Name
+  display : Name
 
-/--
-The `declId` node of a declaration command, together with the name written
-in it. A command that declares several names (a `mutual` block) or none (an
-anonymous `instance`, an `example`) is rejected.
--/
-def declaredName (cmd : Syntax) : CommandElabM (Syntax × Name) := do
-  let defined := declIds cmd
-  match h : defined.size with
-  | 0 =>
-    throwErrorAt cmd "the restated command does not declare a name"
-  | 1 =>
-    let declId := defined[0]
-    return (declId, declId[0].getId)
-  | n + 2 =>
-    for h : i in 0...(n + 1) do
-      logErrorAt defined[i]
-        "the restated command declares several names; recall one declaration at a time"
-    throwErrorAt defined[n + 1]
-      "the restated command declares several names; recall one declaration at a time"
+def DeclId.ofActual (actual : Name) : DeclId :=
+  { actual, display := privateToUserName actual }
+
+/-- Look up the actual name in temp elaboration namespace -/
+def tempDeclId (userName : Name) : CommandElabM DeclId := do
+  let env ← getEnv
+  let privateName := mkPrivateName env userName
+  let actual ←
+    if env.contains privateName then pure privateName
+    else if env.contains userName then pure userName
+    else throwError "the re-elaborated declaration '{userName}' was not found"
+  return .ofActual actual
+
+def renameBackName (chk orig n : Name) : Name :=
+  if chk.isPrefixOf n then n.replacePrefix chk orig
+  else
+    let chk := privateToUserName chk
+    if chk.isPrefixOf n then n.replacePrefix chk orig else n
 
 /--
 Replaces the name prefix `chk` with `orig` in every constant that `e`
@@ -71,10 +76,11 @@ hidden inductive type's name in argument and resulting positions, so this
 rewrite is what makes a re-elaborated declaration comparable with the
 original.
 -/
-def renameBack (chk orig : Name) (e : Expr) : Expr :=
+def renameBack (chk orig : DeclId) (e : Expr) : Expr :=
   e.replace fun
     | .const n us =>
-      if chk.isPrefixOf n then some (.const (n.replacePrefix chk orig) us) else none
+      let n' := renameBackName chk.actual orig.actual n
+      if n == n' then none else some (.const n' us)
     | _ => none
 
 /--
@@ -84,8 +90,11 @@ so hovers over a recalled declaration would otherwise display the hidden
 names; rewriting before the trees are stored makes them display the
 originals, which also exist after the hidden copy is rolled back.
 -/
-partial def renameBackInfoTree (chk orig : Name) (t : InfoTree) : InfoTree :=
+partial def renameBackInfoTree (chk orig : DeclId) (t : InfoTree) : InfoTree :=
   match t with
+  | .context (.parentDeclCtx n) t' =>
+    .context (.parentDeclCtx (renameBackName chk.actual orig.actual n))
+      (renameBackInfoTree chk orig t')
   | .context ctx t' => .context ctx (renameBackInfoTree chk orig t')
   | .node i children =>
     let i := match i with
@@ -109,18 +118,18 @@ overrides them with the enclosing inductive types, whose names the
 constructor types mention. The restatement's universe parameters are
 instantiated with the original's.
 -/
-def checkTypesMatch (x chk : Name) (ref : Syntax)
-    (renChk : Name := chk) (renOrig : Name := x) (hint : MessageData := .nil) :
+def checkTypesMatch (x chk : DeclId) (ref : Syntax)
+    (renChk : DeclId := chk) (renOrig : DeclId := x) (hint : MessageData := .nil) :
     TermElabM Unit := do
-  let origInfo ← getConstInfo x
-  let chkInfo ← getConstInfo chk
+  let origInfo ← getConstInfo x.actual
+  let chkInfo ← getConstInfo chk.actual
   unless origInfo.levelParams.length == chkInfo.levelParams.length do
-    throwErrorAt ref (m!"universe parameters of '{x}' do not match" ++ hint)
+    throwErrorAt ref (m!"universe parameters of '{x.display}' do not match" ++ hint)
   let chkType := (renameBack renChk renOrig chkInfo.type).instantiateLevelParams
     chkInfo.levelParams (origInfo.levelParams.map .param)
   unless ← isDefEq chkType origInfo.type do
     throwErrorAt ref
-      (m!"the statement of '{x}' does not match.\n\
+      (m!"the statement of '{x.display}' does not match.\n\
           Original:{indentD origInfo.type}\nRestated:{indentD chkType}" ++ hint)
 
 /--
@@ -150,17 +159,17 @@ def ctorHints (ctorRef : Syntax) (origCtor origShort : Name) (outer : MessageDat
     TermElabM (MessageData × MessageData) := do
   try
     if ctorRef.isOfKind ``Lean.Parser.Command.ctor then
-      let origSrc := RecallSource.dedent (← RecallSource.sourceOf origCtor)
+      let origSrc := dedent (← sourceOf origCtor)
       -- A restatement without a doc comment gets a suggestion without one;
       -- the meaning check does not compare documentation.
       let origSrc := if hasDocComment ctorRef then origSrc
-        else RecallSource.stripLeadingComments origSrc
-      let restatedSrc ← RecallSource.sourceOfSyntax ctorRef
-      let h ← RecallSource.replaceWithOriginalHint ctorRef origSrc restatedSrc
+        else stripLeadingComments origSrc
+      let restatedSrc ← sourceOfSyntax ctorRef
+      let h ← replaceWithOriginalHint ctorRef origSrc restatedSrc
       return (h, h)
     if ctorRef.isOfKind ``Lean.Parser.Command.structCtor then
-      let restatedSrc ← RecallSource.sourceOfSyntax ctorRef
-      let h ← RecallSource.replaceWithOriginalHint ctorRef s!"{origShort} ::" restatedSrc
+      let restatedSrc ← sourceOfSyntax ctorRef
+      let h ← replaceWithOriginalHint ctorRef s!"{origShort} ::" restatedSrc
       return (h, outer)
     return (outer, outer)
   catch _ => return (outer, outer)
@@ -170,53 +179,64 @@ Checks a re-elaborated declaration against the original, definitionally.
 Errors point at `ref`, the restated command, except for constructor
 mismatches, which point at the offending constructor within it.
 -/
-def checkMatch (x chk : Name) (ref : Syntax) (hint : MessageData := .nil) :
+def checkMatch (x chk : DeclId) (ref : Syntax) (hint : MessageData := .nil) :
     TermElabM Unit := do
   checkTypesMatch x chk ref (hint := hint)
-  let origInfo ← getConstInfo x
-  let chkInfo ← getConstInfo chk
+  let origInfo ← getConstInfo x.actual
+  let chkInfo ← getConstInfo chk.actual
   match origInfo, chkInfo with
   | .defnInfo orig, .defnInfo restated =>
     let chkVal := (renameBack chk x restated.value).instantiateLevelParams
       restated.levelParams (orig.levelParams.map .param)
     unless ← isDefEq chkVal orig.value do
       throwErrorAt ref
-        (m!"the value of '{x}' does not match.\n\
+        (m!"the value of '{x.display}' does not match.\n\
             Original:{indentD orig.value}\nRestated:{indentD chkVal}" ++ hint)
   | .inductInfo orig, .inductInfo restated =>
     unless orig.numParams == restated.numParams && orig.numIndices == restated.numIndices do
-      throwErrorAt ref (m!"parameters or indices of '{x}' do not match" ++ hint)
+      throwErrorAt ref (m!"parameters or indices of '{x.display}' do not match" ++ hint)
     unless orig.ctors.length == restated.ctors.length do
       throwErrorAt ref
-        (m!"'{x}' has {orig.ctors.length} constructors, \
+        (m!"'{x.display}' has {orig.ctors.length} constructors, \
             the restatement has {restated.ctors.length}" ++ hint)
     -- A `structure` that writes no `name ::` header has a constructor
     -- without syntax; the whole command remains the fallback position.
     let ctorRefs := ctorStxs ref
     let mut i := 0
-    for origCtor in orig.ctors, chkCtor in restated.ctors do
+    for origCtorActual in orig.ctors, chkCtorActual in restated.ctors do
+      let origCtor := DeclId.ofActual origCtorActual
+      let chkCtor := DeclId.ofActual chkCtorActual
       let ctorRef := ctorRefs[i]?.getD ref
-      let origShort := origCtor.replacePrefix x .anonymous
-      let (nameHint, typeHint) ← ctorHints ctorRef origCtor origShort hint
-      unless origCtor == chkCtor.replacePrefix chk x do
+      let origShort := origCtor.actual.replacePrefix x.actual .anonymous
+      let (nameHint, typeHint) ← ctorHints ctorRef origCtor.actual origShort hint
+      let renamedChkCtor := DeclId.ofActual <|
+        chkCtor.actual.replacePrefix chk.actual x.actual
+      unless origCtor.actual == renamedChkCtor.actual do
         throwErrorAt ctorRef
-          (m!"constructor '{chkCtor.replacePrefix chk x}' does not match '{origCtor}'" ++ nameHint)
+          (m!"constructor '{renamedChkCtor.display}' does not match \
+              '{origCtor.display}'" ++ nameHint)
       checkTypesMatch origCtor chkCtor ctorRef (renChk := chk) (renOrig := x) (hint := typeHint)
       i := i + 1
     -- A structure's field names are part of its interface, and the
     -- constructor's type does not record them, so they are compared
     -- through the environment's structure information.
-    match getStructureInfo? (← getEnv) x, getStructureInfo? (← getEnv) chk with
+    let env ← getEnv
+    match getStructureInfo? env x.actual, getStructureInfo? env chk.actual with
     | some origSi, some chkSi =>
-      unless origSi.fieldNames == chkSi.fieldNames do
+      let origFields := origSi.fieldNames.map DeclId.ofActual
+      let chkFields := chkSi.fieldNames.map DeclId.ofActual
+      unless origFields.map (·.actual) == chkFields.map (·.actual) do
         throwErrorAt ref
-          (m!"the fields of '{x}' do not match.\n\
-              Original:{indentD (toMessageData origSi.fieldNames.toList)}\n\
-              Restated:{indentD (toMessageData chkSi.fieldNames.toList)}" ++ hint)
+          (m!"the fields of '{x.display}' do not match.\n\
+              Original:{indentD (toMessageData (origFields.map (·.display)).toList)}\n\
+              Restated:{indentD (toMessageData (chkFields.map (·.display)).toList)}" ++ hint)
+      unless getOutParamPositions? env x.actual == getOutParamPositions? env chk.actual
+          && getOutLevelParamPositions? env x.actual == getOutLevelParamPositions? env chk.actual do
+        throwErrorAt ref (m!"the type-class metadata of '{x.display}' does not match" ++ hint)
     | some _, none =>
-      throwErrorAt ref (m!"'{x}' is a structure, but the restatement is not" ++ hint)
+      throwErrorAt ref (m!"'{x.display}' is a structure, but the restatement is not" ++ hint)
     | none, some _ =>
-      throwErrorAt ref (m!"'{x}' is not a structure, but the restatement is one" ++ hint)
+      throwErrorAt ref (m!"'{x.display}' is not a structure, but the restatement is one" ++ hint)
     | none, none => pure ()
   -- A theorem's proof is not compared; restating it as a `def` is also
   -- accepted, since only the statement matters.
@@ -225,22 +245,25 @@ def checkMatch (x chk : Name) (ref : Syntax) (hint : MessageData := .nil) :
   | .axiomInfo _, .axiomInfo _ => pure ()
   | .opaqueInfo _, .opaqueInfo _ => pure ()
   | _, _ =>
-    throwErrorAt ref (m!"'{x}' and its restatement are different kinds of declaration" ++ hint)
+    throwErrorAt ref
+      (m!"'{x.display}' and its restatement are different kinds of declaration" ++ hint)
 
 /--
-`recall` restates a definition from earlier in the development and checks
-that the restatement means the same thing. `recall statement x : T` checks
+`sf_recall` restates a definition from earlier in the development and checks
+that the restatement means the same thing. `sf_recall statement x : T` checks
 that `T` matches the statement of the theorem `x`.
 -/
-scoped syntax (name := recallChk) "recall " command : command
+syntax (name := recallChk) "sf_recall " command : command
 
 @[inherit_doc recallChk]
-scoped syntax (name := recallChkStmt) "recall " &"statement " ident " : " term : command
+syntax (name := recallChkStmt) "sf_recall " &"statement " ident " : " term : command
 
 elab_rules : command
-  | `(recall $cmd:command) => do
-    let (declId, written) ← declaredName cmd
-    let x ← liftCoreM <| realizeGlobalConstNoOverload (mkIdentFrom declId written)
+  | `(sf_recall $cmd:command) => do
+    let decl ← declaredName cmd
+    let xActual ← liftCoreM <| withoutExporting <|
+      realizeGlobalConstNoOverloadWithInfo decl.ident
+    let x := DeclId.ofActual xActual
     -- The restatement elaborates unchanged inside a fresh hidden namespace:
     -- self-references (an inductive's own name in its constructor types, in
     -- resulting-type position included) resolve to the hidden copy, and
@@ -251,7 +274,6 @@ elab_rules : command
     -- prefix structure that `renameBack` and the constructor comparison
     -- rely on.
     let ns ← liftCoreM (mkFreshId : CoreM Name)
-    let chk := (← getScope).currNamespace ++ ns ++ written
     -- Any mismatch gets a clickable fix: replace the restatement with the
     -- original's source text, indented like the restatement. The helpers
     -- for recovering and re-indenting source are shared with the
@@ -260,32 +282,38 @@ elab_rules : command
     -- declaration range or sources on the search path.
     let hint ←
       try
-        let original := RecallSource.dedent (← RecallSource.sourceOf x)
+        let original := dedent (← sourceOf x.actual)
         let original := if hasDocComment cmd then original
-          else RecallSource.stripLeadingComments original
-        let restated ← RecallSource.sourceOfSyntax cmd
-        liftCoreM <| RecallSource.replaceWithOriginalHint cmd original restated
+          else stripLeadingComments original
+        let restated ← sourceOfSyntax cmd
+        liftCoreM <| replaceWithOriginalHint cmd original restated
       catch _ => pure .nil
     let envBefore ← getEnv
     try
-      withScope (fun sc => { sc with currNamespace := sc.currNamespace ++ ns }) do
+      let chk ← withScope (fun sc => { sc with currNamespace := sc.currNamespace ++ ns }) do
         let saved ← getResetInfoTrees
         try
           elabCommand cmd
-        finally
+          -- this could be a private name
+          let userName := (← getScope).currNamespace ++ decl.written
+          let chk ← tempDeclId userName
           let inner ← getResetInfoTrees
-          modifyInfoState fun s =>
-            { s with trees := saved ++ inner.map (renameBackInfoTree chk x) }
-      unless (← getEnv).contains chk do
-        throwErrorAt cmd (m!"the restatement of '{x}' failed to elaborate" ++ hint)
+          modifyInfoState fun s => { s with trees := saved ++ inner.map (renameBackInfoTree chk x) }
+          return chk
+        catch e =>
+          let inner ← getResetInfoTrees
+          modifyInfoState fun s => { s with trees := saved ++ inner }
+          throw e
       runTermElabM fun _ => checkMatch x chk cmd (hint := hint)
     finally
       setEnv envBefore
-  | `(recall statement $x:ident : $stmt:term) => do
-    let xName ← liftCoreM <| realizeGlobalConstNoOverload x
-    addConstInfo x xName
-    let region := mkNullNode #[x.raw, stmt.raw]
-    let restated ← RecallSource.sourceOfSyntax region
+  | `(sf_recall statement $ident:ident : $stmt:term) => do
+    let xActual ← liftCoreM <| withoutExporting <|
+      realizeGlobalConstNoOverloadWithInfo ident
+    let x := DeclId.ofActual xActual
+    addConstInfo ident x.actual
+    let region := mkNullNode #[ident.raw, stmt.raw]
+    let restated ← sourceOfSyntax region
     runTermElabM fun _ => do
       -- The suggestion restates the original's type as the pretty-printer
       -- renders it. The statement cannot be carved out of the original's
@@ -293,10 +321,10 @@ elab_rules : command
       -- source in the elaboration context of its declaration site.
       let hint ←
         try
-          let origInfo ← getConstInfo xName
+          let origInfo ← getConstInfo x.actual
           let printed ← ppExpr origInfo.type
-          RecallSource.replaceWithOriginalHint region
-            s!"{x.getId} : {printed}" restated
+          replaceWithOriginalHint region
+            s!"{ident.getId} : {printed}" restated
         catch _ => pure .nil
       let t ← Term.elabType stmt
       Term.synthesizeSyntheticMVarsNoPostponing
@@ -305,25 +333,22 @@ elab_rules : command
       -- against fresh level metavariables instead would let a fixed
       -- universe pass for a polymorphic original.
       let t ← instantiateMVars (← Term.levelMVarToParam t)
-      let origInfo ← getConstInfo xName
+      let origInfo ← getConstInfo x.actual
       let stParams := (collectLevelParams {} t).params
       unless stParams.size == origInfo.levelParams.length do
         throwErrorAt stmt
-          (m!"universe parameters of '{xName}' do not match" ++ hint)
+          (m!"universe parameters of '{x.display}' do not match" ++ hint)
       let t := t.instantiateLevelParams stParams.toList
         (origInfo.levelParams.map .param)
       unless ← isDefEq t origInfo.type do
         throwErrorAt stmt
-          (m!"the restated statement of '{xName}' does not match.\n\
+          (m!"the restated statement of '{x.display}' does not match.\n\
               Original:{indentD origInfo.type}\nRestated:{indentD t}" ++ hint)
 
-end RecallCheck
+end
+namespace Tests
 
-/-! ## Tests -/
-
-namespace RecallCheck.Test
-
-recall
+sf_recall
   inductive Nat where
   | zero
   | succ (n : Nat) : Nat
@@ -342,7 +367,7 @@ Hint: Replace the restatement with the original:
   | succ (̲n̲ ̲: N̲a̲t̲)̲ ̲:̲ ̲Nat ̵→̵ ̵N̵a̵t̵ ̵→̵ ̵N̵a̵t̵
 -/
 #guard_msgs (positions := true) in
-recall
+sf_recall
   inductive Nat where
   | zero
   | succ : Nat → Nat → Nat
@@ -354,55 +379,55 @@ def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
 
 theorem twice_id : twice id 3 = 3 := rfl
 
-recall
+sf_recall
   inductive Palette where
     | red | green | blue
 
 -- A misnamed constructor's suggestion replaces just that constructor.
 /--
 @ +3:18...24
-error: constructor 'RecallCheck.Test.Palette.blau' does not match 'RecallCheck.Test.Palette.blue'
+error: constructor 'SFLCompat.Recall.Check.Tests.Palette.blau' does not match 'SFLCompat.Recall.Check.Tests.Palette.blue'
 
 Hint: Replace the restatement with the original:
   | b̵l̵a̵u̵b̲l̲u̲e̲
 -/
 #guard_msgs (positions := true) in
-recall
+sf_recall
   inductive Palette where
     | red | green | blau
 
 -- Definitionally equal reformulations are accepted.
-recall
+sf_recall
   def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
 
-recall statement twice_id : twice id 3 = 3
+sf_recall statement twice_id : twice id 3 = 3
 
 -- Imported names can be recalled too.
-recall statement Nat.add_comm : ∀ (n m : Nat), n + m = m + n
+sf_recall statement Nat.add_comm : ∀ (n m : Nat), n + m = m + n
 
 -- The statement form counts universe parameters: a placeholder universe
 -- becomes a parameter and matches, and a fixed universe is rejected.
 theorem poly_refl.{u} : ∀ {α : Sort u} (a : α), a = a := fun _ => rfl
 
-recall statement poly_refl : ∀ {α : Sort _} (a : α), a = a
+sf_recall statement poly_refl : ∀ {α : Sort _} (a : α), a = a
 
 /--
-error: universe parameters of 'RecallCheck.Test.poly_refl' do not match
+error: universe parameters of 'SFLCompat.Recall.Check.Tests.poly_refl' do not match
 
 Hint: Replace the restatement with the original:
   poly_refl : ∀ {α : T̵y̵p̵e̵}̵S̲o̲r̲t̲ ̲u̲}̲ (a : α), a = a
 -/
 #guard_msgs in
-recall statement poly_refl : ∀ {α : Type} (a : α), a = a
+sf_recall statement poly_refl : ∀ {α : Type} (a : α), a = a
 
 -- A standard library structure with the default constructor name.
-recall
+sf_recall
   structure Prod (α : Type u) (β : Type v) where
     fst : α
     snd : β
 
 -- A standard library structure with a custom constructor name.
-recall
+sf_recall
   structure ULift.{r, s} (α : Type s) : Type (max s r) where
     up ::
     down : α
@@ -417,7 +442,7 @@ Hint: Replace the restatement with the original:
   u̵u̵u̵p̵p̵p̵u̲p̲ ::
 -/
 #guard_msgs (positions := true) in
-recall
+sf_recall
   structure ULift.{r, s} (α : Type s) : Type (max s r) where
     uuuppp ::
     down : α
@@ -445,7 +470,7 @@ Hint: Replace the restatement with the original:
   ̲ ̲ ̲ ̲ ̲ ̲ ̲s̲n̲d̲ ̲:̲ ̲β̲
 -/
 #guard_msgs in
-recall
+sf_recall
   structure Prod (α : Type u) (β : Type v) where
     fst : α
     other : β
@@ -464,12 +489,12 @@ Hint: Replace the restatement with the original:
   ̲ ̲ ̲ ̲ ̲ ̲ ̲d̲o̲w̲n̲ ̲:̲ ̲α̲
 -/
 #guard_msgs in
-recall
+sf_recall
   structure ULift.{r, s} (α : Type s) : Type (max s r) where
     down : α
 
 /--
-error: the value of 'RecallCheck.Test.twice' does not match.
+error: the value of 'SFLCompat.Recall.Check.Tests.twice' does not match.
 Original:
   fun f n => f (f n)
 Restated:
@@ -479,7 +504,7 @@ Hint: Replace the restatement with the original:
   def twice (f : Nat → Nat) (n : Nat) : Nat := f (̲f̲ ̲n)̲
 -/
 #guard_msgs in
-recall
+sf_recall
   def twice (f : Nat → Nat) (n : Nat) : Nat := f n
 
 /--
@@ -488,15 +513,18 @@ error: the restated command declares several names; recall one declaration at a 
 error: the restated command declares several names; recall one declaration at a time
 -/
 #guard_msgs in
-recall
+sf_recall
   mutual
     def one : Nat := 1
     def two : Nat := 2
   end
 
 open List in
-recall
+sf_recall
   def List.map (f : α → β) : (l : List α) → List β
     | [] => []
     | x :: xs => f x :: map f xs
-end RecallCheck.Test
+
+end Tests
+
+end  SFLCompat.Recall.Check

--- a/SFLCompat/Recall/Check.lean
+++ b/SFLCompat/Recall/Check.lean
@@ -525,6 +525,39 @@ sf_recall
     | [] => []
     | x :: xs => f x :: map f xs
 
+
+-- `sorry` doesn't work
+
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+def Foo : Nat := sorry
+/--
+error: the value of 'SFLCompat.Recall.Check.Tests.Foo' does not match.
+Original:
+  sorry
+Restated:
+  sorry
+
+Hint: Replace the restatement with the original:
+  def Foo : Nat := sorry
+---
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+sf_recall
+  def Foo : Nat := sorry
+
+-- field visibility is not checked
+
+structure Bar where
+  private x : Nat
+  y : Bool
+
+sf_recall
+  structure Bar where
+    x : Nat
+    y : Bool
+
 end Tests
 
 end  SFLCompat.Recall.Check

--- a/SFLCompat/Recall/Check.lean
+++ b/SFLCompat/Recall/Check.lean
@@ -530,7 +530,7 @@ sf_recall
 
 /-- warning: declaration uses `sorry` -/
 #guard_msgs in
-def Foo : Nat := sorry
+noncomputable def Foo : Nat := by sorry
 /--
 error: the value of 'SFLCompat.Recall.Check.Tests.Foo' does not match.
 Original:
@@ -539,13 +539,13 @@ Restated:
   sorry
 
 Hint: Replace the restatement with the original:
-  def Foo : Nat := sorry
+  noncomputable def Foo : Nat := by sorry
 ---
 warning: declaration uses `sorry`
 -/
 #guard_msgs in
 sf_recall
-  def Foo : Nat := sorry
+  noncomputable def Foo : Nat := by sorry
 
 -- field visibility is not checked
 

--- a/SFLCompat/Recall/Common.lean
+++ b/SFLCompat/Recall/Common.lean
@@ -1,54 +1,34 @@
-import Lean
+module
 
-/-!
-# Recall, checked byte for byte
+public meta import Lean.Elab.Command
 
-`recall_source` lets a chapter restate a definition from earlier in the
-development while the build checks that the restatement matches the
-original's source text, byte for byte. The restated text is what the
-reader already saw, and it can never drift from the original.
-
-```
-recall_source
-  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
-```
-
-The syntax is scoped: the command is available inside `RecallSource` and
-wherever it is opened, and `recall_source` is not a keyword elsewhere.
-
-The restated declaration is parsed but never elaborated; the check is
-purely textual: after the block indentation is removed from each side, the
-two texts must be equal, byte for byte. The restatement may sit at a
-different indentation depth, but it may not be reflowed or respaced.
-
-The comparison covers whole declarations only. Carving a statement out of
-the original's source would require parsing it, which is only possible in
-the elaboration context of its declaration site; restating only a theorem
-statement is therefore the province of `recall statement`, which compares
-elaborated types.
--/
+namespace SFLCompat.Recall
 
 open Lean Elab Command
-
-namespace RecallSource
+public meta section
 
 /-- All `declId` nodes in a command, in source order. -/
 partial def declIds (stx : Syntax) : Array Syntax :=
   let inner := stx.getArgs.flatMap declIds
   if stx.isOfKind ``Lean.Parser.Command.declId then #[stx] ++ inner else inner
 
+/-- The syntax and written name of the single declaration in a recall command. -/
+structure DeclSyntax where
+  ident : Syntax
+  written : Name
+
 /--
 The `declId` node of a declaration command, together with the name written
 in it. A command that declares several names (a `mutual` block) or none (an
 anonymous `instance`, an `example`) is rejected.
 -/
-def declaredName (cmd : Syntax) : CommandElabM (Syntax × Name) := do
+def declaredName (cmd : Syntax) : CommandElabM DeclSyntax := do
   let defined := declIds cmd
   match h : defined.size with
   | 0 => throwErrorAt cmd "the restated command does not declare a name"
   | 1 =>
     let declId := defined[0]
-    return (declId, declId[0].getId)
+    return { ident := declId[0], written := declId[0].getId }
   | n + 2 =>
     for h : i in 0...(n + 1) do
       logErrorAt defined[i]
@@ -168,103 +148,6 @@ def sourceOfSyntax [Monad m] [MonadError m] [MonadFileMap m]
     | throwErrorAt stx "no source range"
   return String.Pos.Raw.extract (← getFileMap).source r.start r.stop
 
-/--
-`recall_source` restates a definition from earlier in the development and
-checks that the restatement matches the original's source text, byte for
-byte, modulo block indentation.
--/
-scoped syntax (name := recallSrc) "recall_source " command : command
+end
 
-elab_rules : command
-  | `(recall_source $cmd:command) => do
-    let (declId, written) ← declaredName cmd
-    let x ← liftCoreM <| realizeGlobalConstNoOverload (mkIdentFrom declId written)
-    -- The restatement is never elaborated, so it produces no info of its
-    -- own. The whole compared region is one big reference to the original:
-    -- hovering anywhere in it shows the original, and go-to-definition
-    -- jumps to it.
-    addConstInfo cmd x
-    let restated ← sourceOfSyntax cmd
-    let original ← sourceOf x
-    unless dedent restated == dedent original do
-      throwErrorAt cmd
-        (m!"the restatement of '{x}' does not match its source.\n\
-            Original:{indentD original}\nRestated:{indentD restated}"
-          ++ (← liftCoreM <| replaceWithOriginalHint cmd (dedent original) restated))
-
-end RecallSource
-
-/-! ## Tests -/
-
-namespace RecallSource.Test
-
-inductive Palette where
-  | red | green | blue
-
-def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
-
-theorem twice_id : twice id 3 = 3 := rfl
-
-recall_source
-  inductive Palette where
-    | red | green | blue
-
-recall_source
-  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
-
--- Leading comments are removed exactly, including the one-line, nested,
--- and line-comment forms; text without them is untouched.
-#guard RecallSource.stripLeadingComments
-  "/-- d -/ theorem foo : True := trivial" == "theorem foo : True := trivial"
-#guard RecallSource.stripLeadingComments
-  "/-- a /- b -/ c -/\ndef x := 1" == "def x := 1"
-#guard RecallSource.stripLeadingComments
-  "/-- d -/\n-- note\n-- more\ndef x := 1" == "def x := 1"
-#guard RecallSource.stripLeadingComments "def x := 1" == "def x := 1"
-
-/--
-error: the restatement of 'RecallSource.Test.twice' does not match its source.
-Original:
-  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
-Restated:
-  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
-
-Hint: Replace the restatement with the original:
-  def twice (f : Nat → Nat) (n : Nat) : Nat := f <̵|̵ ̵(̲f n)̲
--/
-#guard_msgs in
-recall_source
-  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
-
--- Reflowing the original is rejected even though the tokens agree.
-/--
-error: the restatement of 'RecallSource.Test.twice' does not match its source.
-Original:
-  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
-Restated:
-  def twice (f : Nat → Nat) (n : Nat) : Nat :=
-      f (f n)
-
-Hint: Replace the restatement with the original:
-  def twice (f : Nat → Nat) (n : Nat) : Nat :=
-  ̵  ̵ ̵ ̵f (f n)
--/
-#guard_msgs in
-recall_source
-  def twice (f : Nat → Nat) (n : Nat) : Nat :=
-    f (f n)
-
-/--
-error: the restated command declares several names; recall one declaration at a time
----
-error: the restated command declares several names; recall one declaration at a time
--/
-#guard_msgs in
-recall_source
-  mutual
-    def one : Nat := 1
-    def two : Nat := 2
-  end
-
-end RecallSource.Test
-
+end SFLCompat.Recall

--- a/SFLCompat/Recall/Source.lean
+++ b/SFLCompat/Recall/Source.lean
@@ -1,0 +1,131 @@
+module
+
+public meta import SFLCompat.Recall.Common
+
+/-!
+# Recall, checked byte for byte
+
+`sf_recall_source` lets a chapter restate a definition from earlier in the
+development while the build checks that the restatement matches the
+original's source text, byte for byte. The restated text is what the
+reader already saw, and it can never drift from the original.
+
+```
+sf_recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+```
+
+The restated declaration is parsed but never elaborated; the check is
+purely textual: after the block indentation is removed from each side, the
+two texts must be equal, byte for byte. The restatement may sit at a
+different indentation depth, but it may not be reflowed or respaced.
+
+The comparison covers whole declarations only. Carving a statement out of
+the original's source would require parsing it, which is only possible in
+the elaboration context of its declaration site; restating only a theorem
+statement is therefore the province of `sf_recall statement`, which compares
+elaborated types.
+-/
+
+namespace SFLCompat.Recall.Source
+
+open Lean Elab Command
+
+/--
+`recall_source` restates a definition from earlier in the development and
+checks that the restatement matches the original's source text, byte for
+byte, modulo block indentation.
+-/
+syntax (name := recallSrc) "sf_recall_source " command : command
+
+elab_rules : command
+  | `(sf_recall_source $cmd:command) => do
+    let decl ← declaredName cmd
+    let x ← liftCoreM <| withoutExporting <|
+      realizeGlobalConstNoOverloadWithInfo decl.ident
+    -- The restatement is never elaborated, so it produces no info of its
+    -- own. The whole compared region is one big reference to the original:
+    -- hovering anywhere in it shows the original, and go-to-definition
+    -- jumps to it.
+    addConstInfo cmd x
+    let restated ← sourceOfSyntax cmd
+    let original ← sourceOf x
+    unless dedent restated == dedent original do
+      throwErrorAt cmd
+        (m!"the restatement of '{privateToUserName x}' does not match its source.\n\
+            Original:{indentD original}\nRestated:{indentD restated}"
+          ++ (← liftCoreM <| replaceWithOriginalHint cmd (dedent original) restated))
+
+namespace Tests
+
+inductive Palette where
+  | red | green | blue
+
+def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+
+theorem twice_id : twice id 3 = 3 := rfl
+
+sf_recall_source
+  inductive Palette where
+    | red | green | blue
+
+sf_recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+
+-- Leading comments are removed exactly, including the one-line, nested,
+-- and line-comment forms; text without them is untouched.
+#guard SFLCompat.Recall.stripLeadingComments
+  "/-- d -/ theorem foo : True := trivial" == "theorem foo : True := trivial"
+#guard SFLCompat.Recall.stripLeadingComments
+  "/-- a /- b -/ c -/\ndef x := 1" == "def x := 1"
+#guard SFLCompat.Recall.stripLeadingComments
+  "/-- d -/\n-- note\n-- more\ndef x := 1" == "def x := 1"
+#guard SFLCompat.Recall.stripLeadingComments "def x := 1" == "def x := 1"
+
+/--
+error: the restatement of 'SFLCompat.Recall.Source.Tests.twice' does not match its source.
+Original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+Restated:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+
+Hint: Replace the restatement with the original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <̵|̵ ̵(̲f n)̲
+-/
+#guard_msgs in
+sf_recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+
+-- Reflowing the original is rejected even though the tokens agree.
+/--
+error: the restatement of 'SFLCompat.Recall.Source.Tests.twice' does not match its source.
+Original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+Restated:
+  def twice (f : Nat → Nat) (n : Nat) : Nat :=
+      f (f n)
+
+Hint: Replace the restatement with the original:
+  def twice (f : Nat → Nat) (n : Nat) : Nat :=
+  ̵  ̵ ̵ ̵f (f n)
+-/
+#guard_msgs in
+sf_recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat :=
+    f (f n)
+
+/--
+error: the restated command declares several names; recall one declaration at a time
+---
+error: the restated command declares several names; recall one declaration at a time
+-/
+#guard_msgs in
+sf_recall_source
+  mutual
+    def one : Nat := 1
+    def two : Nat := 2
+  end
+
+end Tests
+
+end SFLCompat.Recall.Source

--- a/SFLMeta/Recall.lean
+++ b/SFLMeta/Recall.lean
@@ -1,19 +1,9 @@
 import VersoManual
-import SFLMeta.RecallSource
-import SFLMeta.RecallCheck
 
-/-!
-# Recall as a code block
+import SFLCompat.Recall.Check
+import SFLCompat.Recall.Source
 
-In a rendered book, a recalled definition should look like any other code
-block. The `recall` and `recallSource` code blocks parse their contents as
-a plain declaration, wrap it in the corresponding checking command, and
-elaborate that in the document's Lean environment. The rendered block shows
-only the declaration, so the checking is invisible in the output, and the
-source needs no marker beyond the code block's own name. The wrapped node
-is built directly, so the commands' scoped syntax never needs to be in
-scope in a document.
--/
+import SubVerso.Highlighting
 
 open Lean Elab
 open Verso Doc Elab ArgParse
@@ -23,17 +13,44 @@ open Verso.Genre.Manual.InlineLean.Scopes (getScopes)
 open Verso.SyntaxUtils (parseStrLitAsCategory)
 open SubVerso.Highlighting
 
+namespace SFLMeta
+
+namespace Recall
+
+inductive Kind where
+  | semantic
+  | source
+  deriving BEq, ToJson, FromJson, Quote
+
+structure Data where
+  kind : Kind
+  statement : Bool
+  expectedError : Bool
+  source : String
+  outputName : Option Name
+  deriving ToJson, FromJson, Quote
+
+def decode? (data : Json) : Option Data :=
+  match fromJson? data with
+  | .ok recall => some recall
+  | .error _ => none
+
+end Recall
+
+block_extension Block.recall (saved : Recall.Data) where
+  data := toJson saved
+  traverse _ _ _ := pure none
+  toHtml := some fun _ goB _ _ contents => contents.mapM goB
+  toTeX := some fun _ goB _ _ contents => contents.mapM goB
+
 /--
-Configuration for the recall code blocks: `+error` expects the check to
-fail, `+statement` restates only a theorem statement, and `name` saves the
-block's messages for a `leanOutput` block.
+Configuration shared by `recall` and `recallSource`: `+error` expects the
+check to fail, `+statement` restates only a theorem statement, and `name`
+saves the block's messages for `leanOutput`.
 -/
 structure RecallBlockConfig where
-  /-- Whether the check is expected to fail. -/
   error : Bool := false
-  /-- Whether the contents restate only a theorem statement. -/
   statement : Bool := false
-  /-- A name under which the block's messages are saved for `leanOutput`. -/
   name : Option Name := none
 
 def RecallBlockConfig.parse [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m]
@@ -44,8 +61,7 @@ def RecallBlockConfig.parse [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [Mo
 instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] :
     FromArgs RecallBlockConfig m := ⟨RecallBlockConfig.parse⟩
 
-/-- The contents of a statement-mode recall block: a theorem name and its
-restated statement. -/
+/-- The contents of a statement-mode recall block. -/
 declare_syntax_cat recallStmtSpec
 
 syntax ident " : " term : recallStmtSpec
@@ -64,20 +80,12 @@ private partial def disableUnusedVarLinter : InfoTree → InfoTree
   | .hole id => .hole id
 
 /--
-Elaborates a code block's contents wrapped in a recall command, in the
-document's Lean environment, then renders the block as the plain contents.
-The contents are a declaration wrapped by the command of kind `cmdKind`,
-or, in statement mode, a theorem name and statement wrapped by the command
-of kind `stmtKind`; a block without a statement form passes `none` and
-rejects `+statement`. When `highlighted` is `true`, the rendered block
-carries the elaboration's highlighting; the byte-for-byte block passes
-`false`, since its contents are never elaborated and the only recorded
-information is the block-wide reference to the recalled constant, which
-would give every token the same hover.
+Elaborate a recall block synchronously in the document environment, render its
+plain contents, and preserve explicit recall metadata for later extraction.
 -/
-def recallBlock (config : RecallBlockConfig) (str : StrLit)
-    (cmdKind : SyntaxNodeKind) (stmtKind : Option SyntaxNodeKind)
-    (highlighted : Bool := true) : DocElabM Term := withoutAsync do
+def recallBlock (config : RecallBlockConfig) (str : StrLit) (kind : Recall.Kind)
+    (cmdKind : SyntaxNodeKind) (stmtKind : Option SyntaxNodeKind) (highlighted : Bool := true) :
+    DocElabM Term := withoutAsync do
   let col? := (← getRef).getPos? |>.map (← getFileMap).utf8PosToLspPos |>.map (·.character)
   let (cmdStx, wrapped) ←
     if config.statement then
@@ -85,13 +93,10 @@ def recallBlock (config : RecallBlockConfig) (str : StrLit)
         | throwError "this block has no statement form"
       let spec ← parseStrLitAsCategory `recallStmtSpec str
       pure (spec,
-        (mkNode stmtKind #[mkAtom "recall", mkAtom "statement", spec[0], mkAtom ":", spec[2]]).raw)
+        (mkNode stmtKind #[mkAtom "sf_recall", mkAtom "statement", spec[0], mkAtom ":", spec[2]]).raw)
     else
       let cmdStx ← parseStrLitAsCategory `command str
-      pure (cmdStx, (mkNode cmdKind #[mkAtom "recall", cmdStx]).raw)
-  -- The same adjustments the `lean` code block makes: synchronous
-  -- elaboration so info trees are available for highlighting, and public
-  -- names so the document sees what it declares.
+      pure (cmdStx, (mkNode cmdKind #[mkAtom (if kind == .semantic then "sf_recall" else "sf_recall_source"), cmdStx]).raw)
   let scopes := (← getScopes).modifyHead fun sc =>
     { sc with opts := pp.tagAppFns.set (Elab.async.set sc.opts false) true, isPublic := true }
   let cctx : Command.Context :=
@@ -111,35 +116,44 @@ def recallBlock (config : RecallBlockConfig) (str : StrLit)
       pure { msg with contents := .append #[.text head, msg.contents] }
     saveOutputs name outMsgs
   reportMessages (if config.error then some true else none) str st.messages
-  unless highlighted do
-    return ← ``(Verso.Doc.Block.code $(quote str.getString))
+  let saved : Recall.Data := {
+      kind
+      statement := config.statement
+      expectedError := config.error
+      source := str.getString
+      outputName := config.name
+    }
+  if !highlighted then
+    return ← ``(Verso.Doc.Block.other (SFLMeta.Block.recall $(quote saved))
+      #[Verso.Doc.Block.code $(quote str.getString)])
   let hls ← highlight cmdStx (st.messages.toArray.filter (!·.isSilent)) st.infoState.trees
   let hls := match col? with
     | none => hls
     | some col => hls.deIndent col
   let range := (Syntax.getRange? str).map (← getFileMap).utf8RangeToLspRange
-  ``(Verso.Doc.Block.other
-      (Verso.Genre.Manual.InlineLean.Block.lean $(quote hls)
-        (some $(quote (← getFileName))) $(quote range))
-      #[Verso.Doc.Block.code $(quote str.getString)])
+  let child ← ``(Verso.Doc.Block.other
+    (Verso.Genre.Manual.InlineLean.Block.lean $(quote hls)
+      (some $(quote (← getFileName))) $(quote range))
+    #[Verso.Doc.Block.code $(quote str.getString)])
+  ``(Verso.Doc.Block.other (SFLMeta.Block.recall $(quote saved)) #[$child])
 
 /--
-A code block whose contents restate an earlier definition, checked up to
-definitional equality by the `recall` command. With `+statement`, the
-contents restate only a theorem statement.
+A `recall` code block checks a declaration up to definitional equality. With
+`+statement`, it checks only a theorem statement.
 -/
 @[code_block]
 def recall : CodeBlockExpanderOf RecallBlockConfig
   | config, str =>
-    recallBlock config str ``RecallCheck.recallChk (some ``RecallCheck.recallChkStmt)
+    recallBlock config str .semantic ``SFLCompat.Recall.Check.recallChk
+      (some ``SFLCompat.Recall.Check.recallChkStmt)
 
 /--
-A code block whose contents restate an earlier definition, checked byte for
-byte by the `recall_source` command, which compares whole declarations
-only. The block renders as plain code: the contents are never elaborated,
-so there is no per-token information to show.
+A `recallSource` code block checks a whole declaration byte for byte. Its
+contents are not elaborated, so it renders without per-token highlighting.
 -/
 @[code_block]
 def recallSource : CodeBlockExpanderOf RecallBlockConfig
   | config, str =>
-    recallBlock config str ``RecallSource.recallSrc none (highlighted := false)
+    recallBlock config str .source ``SFLCompat.Recall.Source.recallSrc none (highlighted := false)
+
+end SFLMeta

--- a/SFLMeta/Save/Extract.lean
+++ b/SFLMeta/Save/Extract.lean
@@ -8,6 +8,7 @@ import SFLMeta.Quiz
 import SFLMeta.Terse
 import SFLMeta.SlideBreak
 import SFLMeta.Grade
+import SFLMeta.Recall
 
 import SFLMeta.Save.SourceRewrite
 import SFLMeta.Save.Lean
@@ -236,7 +237,7 @@ def findAlt? (contents : Array (Verso.Doc.Block Manual)) : Option String :=
     | .code s => some s
     | _ => none
 
-/-- For wrapping code in `sf_experiment` and `sf_expect_failure` -/
+/-- For wrapping code in our commands -/
 def wrapIndented (startText body : String) : String :=
   let body := body.trimAscii.toString.splitOn "\n" |>.map ("  " ++ ·) |> String.intercalate "\n"
   startText ++ "\n" ++ body ++ "\n\n"
@@ -265,22 +266,6 @@ def chapterModule (vol : String) (p : Part Manual) : String :=
   let base := chapterFileBase p
   if base.all (fun c => c.isAlphanum || c == '_') then vol ++ "." ++ base
   else vol ++ ".«" ++ base ++ "»"
-
-end
-
-/-! ## Support module template
-  Create `SFLCompat.lean` with custom commands used in generated projects.
--/
-
-section
-
-def supportModuleName (vol : String) : String :=
-  vol ++ ".SFLCompat"
-
-def supportModulePath (vol : String) : String :=
-  vol ++ "/SFLCompat.lean"
-
-def readSFLCompat : IO String := IO.FS.readFile "SFLMeta/SFLCompat.lean"
 
 end
 
@@ -339,6 +324,17 @@ partial def walkBlock (width : Nat) (file : String) (b : Verso.Doc.Block Manual)
         | .expectFailure =>
           return buf.append file <| saved.variants.map (wrapIndented "sf_expect_failure")
       return buf
+    if name == ``SFLMeta.Block.recall then
+      if let some saved := SFLMeta.Recall.decode? which.data then
+        let {kind, statement, expectedError, source, ..} := saved
+        let command := match kind with
+          | .semantic =>
+            if statement then "sf_recall statement " ++ source.trimAscii.toString
+            else wrapIndented "sf_recall" source
+          | .source => wrapIndented "sf_recall_source" source
+        if expectedError then
+          return buf.appendAll file <| wrapIndented "sf_expect_failure" command
+        return buf.appendAll file <| command.trimAscii.toString ++ "\n\n"
     if name == ``Block.importBlock then
       -- Cross-chapter `import` lines shown to the reader.  The extracted
       -- files get their import lines from the chapter source's header
@@ -509,6 +505,6 @@ def walkOuter (width : Nat) (vol : String) (text : Part Manual) (buf : SaveBuffe
   for p in subParts do
     let chapterFile := chapterPath vol p
     buf := buf.appendOnly chapterFile .grading s!"import AutograderLib\n"
-    buf := buf.appendAll chapterFile s!"import {supportModuleName vol}\n\n"
+    buf := buf.appendAll chapterFile s!"import SFLCompat\n\n"
     buf := walkSection width 1 chapterFile p buf
   return buf

--- a/SFLMeta/Save/Project.lean
+++ b/SFLMeta/Save/Project.lean
@@ -183,11 +183,10 @@ private def emitSavedImpl (config : ExtractConfig)
     for (vol, part) in crossVol do
       let file := chapterPath vol part
       buf := buf.appendOnly file .grading "import AutograderLib\n"
-      buf := buf.appendAll file s!"import {supportModuleName config.modPrefix}\n\n"
+      buf := buf.appendAll file s!"import SFLCompat\n\n"
       buf := walkSection width 1 file part buf
 
     let toolchain ← IO.FS.readFile "lean-toolchain"
-    let supportModule ← readSFLCompat
     let requires ← projectRequires config.variant
     let rootFile := config.modPrefix ++ ".lean"
 
@@ -199,10 +198,9 @@ private def emitSavedImpl (config : ExtractConfig)
     let generatedModules := entries.map fun (file, _) =>
       ((file.dropEnd 5).toString).replace "/" "."
 
-    let mut files : Array (String × String) :=
-      #[(supportModulePath config.modPrefix, supportModule)]
+    let mut files : Array (String × String) := #[]
 
-    let mut seeds : List String := []
+    let mut seeds : List String := ["SFLCompat"]
 
     for (file, variants) in entries do
       let chosen := mergeAdjacentModuleDocs <| variants.get config.variant
@@ -225,7 +223,9 @@ private def emitSavedImpl (config : ExtractConfig)
     -- Using a chapter in another volume makes that volume an additional library
     let extraLibs :=
       bundleFiles.foldl (init := crossVol.map (·.1) |>.toArray) fun libs (path, _) =>
-        let lib := (path.splitOn "/").headD ""
+        let lib :=
+          if path == "SFLCompat.lean" then "SFLCompat"
+          else (path.splitOn "/").headD ""
         if lib == config.modPrefix || libs.contains lib then
           libs
         else

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -516,6 +516,10 @@ sf_recall_source
     f (f n)
 ```
 
+> Do not `recall` a previous definition that is wrapped in `solution!`: 
+> since the definition body is replaced to `sorry` in student projects,
+> doing so would cause a mismatch.
+
 ### BNF grammar blocks
 
 Fenced `bnf` blocks render as typeset object-language grammars.

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -351,6 +351,39 @@ For example, `Imp` checks its custom delaborator this way:
 ```
 ````
 
+### Recall earlier definitions
+
+Use a ` ```recall ` or ` ```recall_srouce ` code block instead of ` ```lean ` block
+if a chapter needs to repeat a definition introduced earlier.
+
+`recall` accepts the repeated declaration in a definitional equal way,
+and it elaborates the declaration and compares it with the original definition.
+
+````lean
+```recall
+def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
+```
+````
+
+Use ` ```recall +statement ` only when the theorem statement should be repeated:
+
+
+````lean
+```recall +statement
+twice_id : twice id 3 = 3
+```
+````
+
+Use ` ```reallSrouce ` only when a byte for byte source matching except the
+block's indentation is required. This can be useful for showing the exact syntax of the definition.
+
+Prefer ` ```recall ` by default. Both blocks accept `+error` flag when the check itself
+is expected to fail. They also accept `name := ...` like the `lean` block. 
+
+Extraction emits `sf_recall`, `sf_recall statement`, or `sf_recall_srouce`;
+and block marked with `+error` is wrapped in `sf_expect_failure`.
+
+
 ### Notation and simplification
 
 When notation is implemented via typeclass instances, `dsimp [add]` does *not*

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -351,39 +351,6 @@ For example, `Imp` checks its custom delaborator this way:
 ```
 ````
 
-### Recall earlier definitions
-
-Use a ` ```recall ` or ` ```recall_srouce ` code block instead of ` ```lean ` block
-if a chapter needs to repeat a definition introduced earlier.
-
-`recall` accepts the repeated declaration in a definitional equal way,
-and it elaborates the declaration and compares it with the original definition.
-
-````lean
-```recall
-def twice (f : Nat → Nat) (n : Nat) : Nat := f (f n)
-```
-````
-
-Use ` ```recall +statement ` only when the theorem statement should be repeated:
-
-
-````lean
-```recall +statement
-twice_id : twice id 3 = 3
-```
-````
-
-Use ` ```reallSrouce ` only when a byte for byte source matching except the
-block's indentation is required. This can be useful for showing the exact syntax of the definition.
-
-Prefer ` ```recall ` by default. Both blocks accept `+error` flag when the check itself
-is expected to fail. They also accept `name := ...` like the `lean` block. 
-
-Extraction emits `sf_recall`, `sf_recall statement`, or `sf_recall_srouce`;
-and block marked with `+error` is wrapped in `sf_expect_failure`.
-
-
 ### Notation and simplification
 
 When notation is implemented via typeclass instances, `dsimp [add]` does *not*
@@ -489,6 +456,65 @@ and whose declarations don't affect later blocks.
 Combine `+error` and `(name := <identifier>)` to produce a block whose error
 message gets checked by ` ```leanOutput <identifier> `.
 See the previous sections for more detailed usage guidelines.
+
+### Recall blocks
+
+Fenced `recall` and `recallSource` blocks are type checked Lean blocks
+consisting of a single declaration that must match an earlier declaration,
+which allows restating the declaration for pedagogical purposes,
+while ensuring correctness of the restatement. `recall` blocks are syntax
+highlighted in the HTML, while `recallSource` blocks are plain code blocks.
+
+In a `recall` block, type signatures and definitions must be definitionally
+equal, inductive types must have the same constructors, and records must have
+the same fields. With the `+statement` option, only the type signature is
+restated and not the declaration body.
+
+In a `recallSource` block, the restated
+declaration must be equal verbatim, down to indentation and line breaks;
+this is useful for showing the exact syntax of the declaration.
+
+Both may take `(name := <identifier>)` and `+error` just as for `lean` blocks,
+rendered in the HTML and extracted to Lean similarly.
+By default, prefer `recall` over `recallSource`.
+These blocks extract to Lean commands `sf_recall`, `sf_recall statement`, and
+`sf_recall_source`. For example, given the original declaration
+
+````
+```lean
+def twice (f : Nat → Nat) (n : Nat) : Nat :=
+  f (f n)
+```
+````
+
+the following three recall blocks
+
+````
+```recall
+def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+```
+
+```recall +statement
+def twice (f : Nat → Nat) (n : Nat) : Nat
+```
+
+```recallSource
+def twice (f : Nat → Nat) (n : Nat) : Nat :=
+  f (f n)
+```
+````
+
+successfully type check and are extracted to the following three commands.
+
+```lean
+sf_recall def twice (f : Nat → Nat) (n : Nat) : Nat := f <| f n
+
+sf_recall statement def twice (f : Nat → Nat) (n : Nat) : Nat
+
+sf_recall_source
+  def twice (f : Nat → Nat) (n : Nat) : Nat :=
+    f (f n)
+```
 
 ### BNF grammar blocks
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -47,6 +47,9 @@ name = "Credits"
 [[lean_lib]]
 name = "SFLMeta"
 
+[[lean_lib]]
+name = "SFLCompat"
+
 # Each volume library tells its chapters which volume they belong to; the
 # `volumes` table in `SFLMeta/Volume.lean` turns the slug into a number and a
 # title.  This has to be a per-library option rather than something a chapter


### PR DESCRIPTION
This PR introduces `SFLCompat` as a new library, which includes `sf_experiment` and `sf_expect_failure` in the old `SFLMeta/SFLCompat.lean` file, as well as the two new commands coming from #299 (renamed to `sf_recall` and `sf_recall_source`.) It also updates project extraction logic to let ` ```recall ` and ` ```recallSource ` verso code blocks extract to  `sf_recall` and  `sf_recall_source` commands respectively. More over it adds module system support to `sf_recall` command elaboration. Noting that previously the `SFLMeta/SFLCompat.lean` file would be copied to `vol/SFLCompat.lean` during extraction, but now entire `SFLCompat` library will get copied to the top-level of the extracted project.