### PR TITLE
SFLMeta: support universe-specialized recall

### DIFF
--- a/LF/Typeclasses.lean
+++ b/LF/Typeclasses.lean
@@ -329,20 +329,8 @@ BEq.beq 1 2 : Bool
 Rather than {name}`Nat.beq`, `==` turns out to be notation for {name}`BEq.beq`, a field of exactly
 the kind of typeclass we just learned to define:
 
-```recallSource
-/--
-  `BEq α` is a typeclass for supplying a boolean-valued equality relation on
-  `α`, notated as `a == b`. Unlike `DecidableEq α` (which uses `a = b`), this
-  is `Bool` valued instead of `Prop` valued, and it also does not have any
-  axioms like being reflexive or agreeing with `=`. It is mainly intended for
-  programming applications. See `LawfulBEq` for a version that requires that
-  `==` and `=` coincide.
-
-  Typically we prefer to put the "more variable" term on the left,
-  and the "more constant" term on the right.
-  -/
-  class BEq (α : Type u) where
-    /-- Boolean equality, notated as `a == b`. -/
+```recall
+  class BEq (α : Type) where
     beq : α → α → Bool
 ```
 
@@ -635,23 +623,13 @@ In this section, we'll use the type variable `α` for the type of keys and `β` 
 In addition to {name}`BEq`, which we have already seen, our key type `α` requires instances of the
 {name}`ReflBEq` and {name}`LawfulBEq` typeclasses:
 
-```recallSource
-/-- `ReflBEq α` says that the `BEq` implementation is reflexive. -/
-  class ReflBEq (α) [BEq α] : Prop where
-    /-- `==` is reflexive, that is, `(a == a) = true`. -/
-    protected rfl {a : α} : a == a
+```recall
+  class ReflBEq (α : Type) [BEq α] : Prop where
+    rfl {a : α} : a == a
 ```
 
-```recallSource
-/--
-  A Boolean equality test coincides with propositional equality.
-
-  In other words:
-   * `a == b` implies `a = b`.
-   * `a == a` is true.
-  -/
-  class LawfulBEq (α : Type u) [BEq α] : Prop extends ReflBEq α where
-    /-- If `a == b` evaluates to `true`, then `a` and `b` are equal in the logic. -/
+```recall
+  class LawfulBEq (α : Type) [BEq α] : Prop extends ReflBEq α where
     eq_of_beq : {a b : α} → a == b → a = b
 ```
 

--- a/SFLCompat/Recall/Check.lean
+++ b/SFLCompat/Recall/Check.lean
@@ -109,6 +109,31 @@ where
       expr := renameBack chk orig ti.expr
       expectedType? := ti.expectedType?.map (renameBack chk orig) }
 
+/-- A specialization of universe parameters to a declaration.
+  It stores level parameters of a `ConstantInfo` and mvars created from these parameters.
+-/
+abbrev Specialization := List Name × List Level
+
+def renameBackS (specialization? : Option Specialization)
+    (chk orig : DeclId) (e : Expr) : Expr :=
+  match specialization? with
+  | none => renameBack chk orig e
+  | some (_params, levels) =>
+    e.replace fun
+      | .const n _ =>
+        let n' := renameBackName chk.actual orig.actual n
+        if n == n' then none else some <| .const n' levels
+      | _ => none
+
+def levelsFor (specialization : Specialization) (info : ConstantInfo) :
+    TermElabM (List Level) :=
+  let (params, levels) := specialization
+  info.levelParams.mapM fun param =>
+    match params.findIdx? (· == param) with
+    | some index => pure levels[index]!
+    | none => throwError
+      "universe parameter '{param}' of '{info.name}' is not a parameter of the recalled declaration"
+
 /--
 Checks that the types of the original constant `x` and its re-elaborated
 counterpart `chk` agree, definitionally. The restated type is first
@@ -119,15 +144,23 @@ constructor types mention. The restatement's universe parameters are
 instantiated with the original's.
 -/
 def checkTypesMatch (x chk : DeclId) (ref : Syntax)
+    (specialization? : Option Specialization)
     (renChk : DeclId := chk) (renOrig : DeclId := x) (hint : MessageData := .nil) :
     TermElabM Unit := do
   let origInfo ← getConstInfo x.actual
   let chkInfo ← getConstInfo chk.actual
-  unless origInfo.levelParams.length == chkInfo.levelParams.length do
-    throwErrorAt ref (m!"universe parameters of '{x.display}' do not match" ++ hint)
-  let chkType := (renameBack renChk renOrig chkInfo.type).instantiateLevelParams
-    chkInfo.levelParams (origInfo.levelParams.map .param)
-  unless ← isDefEq chkType origInfo.type do
+  if specialization?.isNone then
+    -- no specialization, do strict check first
+    unless origInfo.levelParams.length == chkInfo.levelParams.length do
+      throwErrorAt ref (m!"universe parameters of '{x.display}' do not match" ++ hint)
+  let origType ← match specialization? with
+    | none => pure origInfo.type
+    | some s => origInfo.instantiateTypeLevelParams <$> levelsFor s origInfo
+  let chkType := match specialization? with
+    | none => (renameBackS specialization? renChk renOrig chkInfo.type).instantiateLevelParams
+        chkInfo.levelParams (origInfo.levelParams.map .param)
+    | some _ => renameBackS specialization? renChk renOrig chkInfo.type
+  unless ← isDefEq chkType origType do
     throwErrorAt ref
       (m!"the statement of '{x.display}' does not match.\n\
           Original:{indentD origInfo.type}\nRestated:{indentD chkType}" ++ hint)
@@ -179,16 +212,22 @@ Checks a re-elaborated declaration against the original, definitionally.
 Errors point at `ref`, the restated command, except for constructor
 mismatches, which point at the offending constructor within it.
 -/
-def checkMatch (x chk : DeclId) (ref : Syntax) (hint : MessageData := .nil) :
-    TermElabM Unit := do
-  checkTypesMatch x chk ref (hint := hint)
+def checkMatchCore (x chk : DeclId) (ref : Syntax)
+    (specialization? : Option (List Name × List Level))
+    (hint : MessageData := .nil) : TermElabM Unit := do
+  checkTypesMatch x chk ref specialization? (hint := hint)
   let origInfo ← getConstInfo x.actual
   let chkInfo ← getConstInfo chk.actual
   match origInfo, chkInfo with
   | .defnInfo orig, .defnInfo restated =>
-    let chkVal := (renameBack chk x restated.value).instantiateLevelParams
-      restated.levelParams (orig.levelParams.map .param)
-    unless ← isDefEq chkVal orig.value do
+    let origVal ← match specialization? with
+      | none => pure orig.value
+      | some s => origInfo.instantiateValueLevelParams! <$> levelsFor s origInfo
+    let chkVal := match specialization? with
+      | none => (renameBackS specialization? chk x restated.value).instantiateLevelParams
+          restated.levelParams (orig.levelParams.map .param)
+      | some _ => renameBackS specialization? chk x restated.value
+    unless ← isDefEq chkVal origVal do
       throwErrorAt ref
         (m!"the value of '{x.display}' does not match.\n\
             Original:{indentD orig.value}\nRestated:{indentD chkVal}" ++ hint)
@@ -215,7 +254,8 @@ def checkMatch (x chk : DeclId) (ref : Syntax) (hint : MessageData := .nil) :
         throwErrorAt ctorRef
           (m!"constructor '{renamedChkCtor.display}' does not match \
               '{origCtor.display}'" ++ nameHint)
-      checkTypesMatch origCtor chkCtor ctorRef (renChk := chk) (renOrig := x) (hint := typeHint)
+      checkTypesMatch origCtor chkCtor ctorRef specialization?
+        (renChk := chk) (renOrig := x) (hint := typeHint)
       i := i + 1
     -- A structure's field names are part of its interface, and the
     -- constructor's type does not record them, so they are compared
@@ -249,6 +289,35 @@ def checkMatch (x chk : DeclId) (ref : Syntax) (hint : MessageData := .nil) :
       (m!"'{x.display}' and its restatement are different kinds of declaration" ++ hint)
 
 /--
+Run `checkpointDefEq` in `TermElabM`.
+Note: this is only for universe level constraints solving in `isDefEq` and
+has nothing to do with the elaborator.
+-/
+def checkpointDefEq' (action : TermElabM Bool) : TermElabM Bool :=
+  controlAt MetaM fun runInBase =>
+    checkpointDefEq (mayPostpone := false) (runInBase action)
+
+def checkMatch (x chk : DeclId) (ref : Syntax)
+    (strictUniverse : Bool) (hint : MessageData := .nil) : TermElabM Unit := do
+  let origInfo ← getConstInfo x.actual
+  let chkInfo ← getConstInfo chk.actual
+  if origInfo.levelParams.length == chkInfo.levelParams.length then
+    -- if the definition being to check has exactly the same number of the parameters,
+    -- treat it as no specialization in checking
+    checkMatchCore x chk ref none hint
+  else if !strictUniverse && !origInfo.levelParams.isEmpty && chkInfo.levelParams.isEmpty then
+    -- if all parameters have been specified (monomorphic), do check with specialization
+    let succeeded ← checkpointDefEq' do
+      let levels ← mkFreshLevelMVarsFor origInfo
+      checkMatchCore x chk ref (some (origInfo.levelParams, levels)) hint
+      pure true
+    unless succeeded do
+      throwErrorAt ref (m!"the statement of '{x.display}' does not match" ++ hint)
+  else
+    throwErrorAt ref (m!"universe parameters of '{x.display}' do not match" ++ hint)
+
+
+/--
 `sf_recall` restates a definition from earlier in the development and checks
 that the restatement means the same thing. `sf_recall statement x : T` checks
 that `T` matches the statement of the theorem `x`.
@@ -256,94 +325,99 @@ that `T` matches the statement of the theorem `x`.
 syntax (name := recallChk) "sf_recall " command : command
 
 @[inherit_doc recallChk]
+syntax (name := recallChkStrict) "sf_recall" " +" noWs &"strictUniverse" ppSpace command : command
+
+@[inherit_doc recallChk]
 syntax (name := recallChkStmt) "sf_recall " &"statement " ident " : " term : command
 
-elab_rules : command
-  | `(sf_recall $cmd:command) => do
-    let decl ← declaredName cmd
-    let xActual ← liftCoreM <| withoutExporting <|
-      realizeGlobalConstNoOverloadWithInfo decl.ident
-    let x := DeclId.ofActual xActual
-    -- The restatement elaborates unchanged inside a fresh hidden namespace:
-    -- self-references (an inductive's own name in its constructor types, in
-    -- resulting-type position included) resolve to the hidden copy, and
-    -- every other name resolves as it would at the recall site. The
-    -- namespace comes from the name generator: `_uniq` names cannot be
-    -- written in source, so it is collision-free, and unlike a macro-scoped
-    -- name it is an ordinary component, so declarations under it keep the
-    -- prefix structure that `renameBack` and the constructor comparison
-    -- rely on.
-    let ns ← liftCoreM (mkFreshId : CoreM Name)
-    -- Any mismatch gets a clickable fix: replace the restatement with the
-    -- original's source text, indented like the restatement. The helpers
-    -- for recovering and re-indenting source are shared with the
-    -- byte-for-byte variant.
-    -- A failed hint must not fail the check: not every constant has a
-    -- declaration range or sources on the search path.
+
+def elabRecallCommand (cmd : Syntax) (strictUniverse : Bool) : CommandElabM Unit := do
+  let decl ← declaredName cmd
+  let xActual ← liftCoreM <| withoutExporting <|
+    realizeGlobalConstNoOverloadWithInfo decl.ident
+  let x := DeclId.ofActual xActual
+  -- The restatement elaborates unchanged inside a fresh hidden namespace:
+  -- self-references (an inductive's own name in its constructor types, in
+  -- resulting-type position included) resolve to the hidden copy, and
+  -- every other name resolves as it would at the recall site. The
+  -- namespace comes from the name generator: `_uniq` names cannot be
+  -- written in source, so it is collision-free, and unlike a macro-scoped
+  -- name it is an ordinary component, so declarations under it keep the
+  -- prefix structure that `renameBack` and the constructor comparison
+  -- rely on.
+  let ns ← liftCoreM (mkFreshId : CoreM Name)
+  -- Any mismatch gets a clickable fix: replace the restatement with the
+  -- original's source text, indented like the restatement. The helpers
+  -- for recovering and re-indenting source are shared with the
+  -- byte-for-byte variant.
+  -- A failed hint must not fail the check: not every constant has a
+  -- declaration range or sources on the search path.
+  let hint ←
+    try
+      let original := dedent (← sourceOf x.actual)
+      let original := if hasDocComment cmd then original
+        else stripLeadingComments original
+      let restated ← sourceOfSyntax cmd
+      liftCoreM <| replaceWithOriginalHint cmd original restated
+    catch _ => pure .nil
+  let envBefore ← getEnv
+  try
+    let chk ← withScope (fun sc => { sc with currNamespace := sc.currNamespace ++ ns }) do
+      let saved ← getResetInfoTrees
+      try
+        elabCommand cmd
+        -- this could be a private name
+        let userName := (← getScope).currNamespace ++ decl.written
+        let chk ← tempDeclId userName
+        let inner ← getResetInfoTrees
+        modifyInfoState fun s => { s with trees := saved ++ inner.map (renameBackInfoTree chk x) }
+        return chk
+      catch e =>
+        let inner ← getResetInfoTrees
+        modifyInfoState fun s => { s with trees := saved ++ inner }
+        throw e
+    runTermElabM fun _ => checkMatch x chk cmd strictUniverse (hint := hint)
+  finally
+    setEnv envBefore
+
+def elabRecallStatement (ident stmt : Syntax) : CommandElabM Unit := do
+  let xActual ← liftCoreM <| withoutExporting <|
+    realizeGlobalConstNoOverloadWithInfo ident
+  let x := DeclId.ofActual xActual
+  addConstInfo ident x.actual
+  let region := mkNullNode #[ident, stmt]
+  let restated ← sourceOfSyntax region
+  runTermElabM fun _ => do
+    -- The suggestion restates the original's type as the pretty-printer
+    -- renders it. The statement cannot be carved out of the original's
+    -- source, since finding its boundary would require parsing the
+    -- source in the elaboration context of its declaration site.
     let hint ←
       try
-        let original := dedent (← sourceOf x.actual)
-        let original := if hasDocComment cmd then original
-          else stripLeadingComments original
-        let restated ← sourceOfSyntax cmd
-        liftCoreM <| replaceWithOriginalHint cmd original restated
+        let origInfo ← getConstInfo x.actual
+        let printed ← ppExpr origInfo.type
+        replaceWithOriginalHint region
+          s!"{ident.getId} : {printed}" restated
       catch _ => pure .nil
-    let envBefore ← getEnv
-    try
-      let chk ← withScope (fun sc => { sc with currNamespace := sc.currNamespace ++ ns }) do
-        let saved ← getResetInfoTrees
-        try
-          elabCommand cmd
-          -- this could be a private name
-          let userName := (← getScope).currNamespace ++ decl.written
-          let chk ← tempDeclId userName
-          let inner ← getResetInfoTrees
-          modifyInfoState fun s => { s with trees := saved ++ inner.map (renameBackInfoTree chk x) }
-          return chk
-        catch e =>
-          let inner ← getResetInfoTrees
-          modifyInfoState fun s => { s with trees := saved ++ inner }
-          throw e
-      runTermElabM fun _ => checkMatch x chk cmd (hint := hint)
-    finally
-      setEnv envBefore
-  | `(sf_recall statement $ident:ident : $stmt:term) => do
-    let xActual ← liftCoreM <| withoutExporting <|
-      realizeGlobalConstNoOverloadWithInfo ident
-    let x := DeclId.ofActual xActual
-    addConstInfo ident x.actual
-    let region := mkNullNode #[ident.raw, stmt.raw]
-    let restated ← sourceOfSyntax region
-    runTermElabM fun _ => do
-      -- The suggestion restates the original's type as the pretty-printer
-      -- renders it. The statement cannot be carved out of the original's
-      -- source, since finding its boundary would require parsing the
-      -- source in the elaboration context of its declaration site.
-      let hint ←
-        try
-          let origInfo ← getConstInfo x.actual
-          let printed ← ppExpr origInfo.type
-          replaceWithOriginalHint region
-            s!"{ident.getId} : {printed}" restated
-        catch _ => pure .nil
-      let t ← Term.elabType stmt
-      Term.synthesizeSyntheticMVarsNoPostponing
-      -- Remaining level metavariables become parameters, so the restatement
-      -- must carry as many universe parameters as the original; comparing
-      -- against fresh level metavariables instead would let a fixed
-      -- universe pass for a polymorphic original.
-      let t ← instantiateMVars (← Term.levelMVarToParam t)
-      let origInfo ← getConstInfo x.actual
-      let stParams := (collectLevelParams {} t).params
-      unless stParams.size == origInfo.levelParams.length do
-        throwErrorAt stmt
-          (m!"universe parameters of '{x.display}' do not match" ++ hint)
-      let t := t.instantiateLevelParams stParams.toList
-        (origInfo.levelParams.map .param)
-      unless ← isDefEq t origInfo.type do
-        throwErrorAt stmt
-          (m!"the restated statement of '{x.display}' does not match.\n\
-              Original:{indentD origInfo.type}\nRestated:{indentD t}" ++ hint)
+    let t ← Term.elabType stmt
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let t ← instantiateMVars (← Term.levelMVarToParam t)
+    let origInfo ← getConstInfo x.actual
+    let stParams := (collectLevelParams {} t).params
+    unless stParams.size == origInfo.levelParams.length do
+      throwErrorAt stmt (m!"universe parameters of '{x.display}' do not match" ++ hint)
+    let t := t.instantiateLevelParams stParams.toList
+      (origInfo.levelParams.map .param)
+    unless ← isDefEq t origInfo.type do
+      throwErrorAt stmt
+        (m!"the restated statement of '{x.display}' does not match.\n\
+            Original:{indentD origInfo.type}\nRestated:{indentD t}" ++ hint)
+
+
+elab_rules : command
+  | `(sf_recall $cmd:command) => elabRecallCommand cmd false
+  | `(sf_recall +strictUniverse $cmd:command) => elabRecallCommand cmd true
+  | `(sf_recall statement $ident:ident : $stmt:term) => elabRecallStatement ident stmt
 
 end
 namespace Tests
@@ -557,6 +631,69 @@ sf_recall
   structure Bar where
     x : Nat
     y : Bool
+
+
+def poly_declaration.{u} {α : Type u} (a : α) : α := a
+
+-- a monomorphic recall
+sf_recall
+  def poly_declaration {α : Type} (a : α) : α := a
+
+/--
+error: universe parameters of 'SFLCompat.Recall.Check.Tests.poly_declaration' do not match
+
+Hint: Replace the restatement with the original:
+  def poly_declaration.̲{̲u̲}̲ {α : Type ̲u̲} (a : α) : α := a
+-/
+#guard_msgs in
+sf_recall +strictUniverse
+  def poly_declaration {α : Type} (a : α) : α := a
+
+def rigid_levels.{u, v} (α : Type u) (β : Type v) : Type (max u v) := α × β
+
+-- The restatement has to be monomorphic or it will be a strict check
+/--
+error: universe parameters of 'SFLCompat.Recall.Check.Tests.rigid_levels' do not match
+
+Hint: Replace the restatement with the original:
+  def r̵i̵g̵i̵d̵_̵l̵e̵v̵e̵l̵s̵.̵{̵w̵}̵r̲i̲g̲i̲d̲_̲l̲e̲v̲e̲l̲s̲.̲{̲u̲,̲ ̲v̲}̲ (α : Type w̵)̵u̲)̲ (β : Type w̵)̵v̲)̲ : Type w̵(̲m̲a̲x̲ ̲u̲ ̲v̲)̲ := α × β
+-/
+#guard_msgs in
+sf_recall
+  def rigid_levels.{w} (α : Type w) (β : Type w) : Type w := α × β
+
+-- `max`
+def max_specialization.{u, v} (α : Type u) (β : Type v) : Type (max u v) := α × β
+
+sf_recall
+  def max_specialization (α : Type) (β : Type 1) : Type 1 := α × β
+
+inductive I.{u, v} (α : Type u) (β : Type v) : Type (max u v) where
+  | left (value : ULift.{u, v} β) : I α β
+  | right (value : ULift.{v, u} α) : I α β
+
+sf_recall
+  inductive I (α : Type) (β : Type 1) : Type 1 where
+  | left (value : ULift.{0, 1} β) : I α β
+  | right (value : ULift.{1, 0} α) : I α β
+
+-- constructors need to be consistent
+
+/--
+error: the statement of 'SFLCompat.Recall.Check.Tests.I.right' does not match.
+Original:
+  {α : Type u} → {β : Type v} → ULift α → I α β
+Restated:
+  {α : Type} → {β : Type 1} → ULift α → I α β
+
+Hint: Replace the restatement with the original:
+  | right (value : ULift.{0̵v̲, 0̵u̲} α) : I α β
+-/
+#guard_msgs in
+sf_recall
+  inductive I (α : Type) (β : Type 1) : Type 1 where
+  | left (value : ULift.{0, 1} β) : I α β
+  | right (value : ULift.{0, 0} α) : I α β
 
 end Tests
 

--- a/SFLMeta/Recall.lean
+++ b/SFLMeta/Recall.lean
@@ -26,6 +26,7 @@ structure Data where
   kind : Kind
   statement : Bool
   expectedError : Bool
+  strictUniverse : Bool
   source : String
   outputName : Option Name
   deriving ToJson, FromJson, Quote
@@ -45,18 +46,20 @@ block_extension Block.recall (saved : Recall.Data) where
 
 /--
 Configuration shared by `recall` and `recallSource`: `+error` expects the
-check to fail, `+statement` restates only a theorem statement, and `name`
-saves the block's messages for `leanOutput`.
+check to fail, `+statement` restates only a theorem statement,
+`+strictUniverse` requires exact universe parameters for recall,
+and `name` saves the block's messages for `leanOutput`.
 -/
 structure RecallBlockConfig where
   error : Bool := false
   statement : Bool := false
+  strictUniverse : Bool := false
   name : Option Name := none
 
 def RecallBlockConfig.parse [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m]
     [MonadError m] : ArgParse m RecallBlockConfig :=
   RecallBlockConfig.mk <$> .flag `error false <*> .flag `statement false <*>
-    .named `name .name true
+    .flag `strictUniverse false <*> .named `name .name true
 
 instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] :
     FromArgs RecallBlockConfig m := ⟨RecallBlockConfig.parse⟩
@@ -84,19 +87,30 @@ Elaborate a recall block synchronously in the document environment, render its
 plain contents, and preserve explicit recall metadata for later extraction.
 -/
 def recallBlock (config : RecallBlockConfig) (str : StrLit) (kind : Recall.Kind)
-    (cmdKind : SyntaxNodeKind) (stmtKind : Option SyntaxNodeKind) (highlighted : Bool := true) :
+    (cmdKind : SyntaxNodeKind) (highlighted : Bool := true) :
     DocElabM Term := withoutAsync do
+  if config.strictUniverse then
+    if kind != .semantic then
+      throwError "`+strictUniverse` is supported only by `recall`"
+    if config.statement then
+      throwError "`+strictUniverse` cannot be combined with `+statement`"
+  if config.statement && kind == .source then
+    throwError "`+statement` is supported only by semantic `recall`"
   let col? := (← getRef).getPos? |>.map (← getFileMap).utf8PosToLspPos |>.map (·.character)
   let (cmdStx, wrapped) ←
-    if config.statement then
-      let some stmtKind := stmtKind
-        | throwError "this block has no statement form"
+    if config.«statement» then
       let spec ← parseStrLitAsCategory `recallStmtSpec str
       pure (spec,
-        (mkNode stmtKind #[mkAtom "sf_recall", mkAtom "statement", spec[0], mkAtom ":", spec[2]]).raw)
+        (mkNode ``SFLCompat.Recall.Check.recallChkStmt
+          #[mkAtom "sf_recall", mkAtom "statement", spec[0], mkAtom ":", spec[2]]).raw)
     else
       let cmdStx ← parseStrLitAsCategory `command str
-      pure (cmdStx, (mkNode cmdKind #[mkAtom (if kind == .semantic then "sf_recall" else "sf_recall_source"), cmdStx]).raw)
+      let cmdKind :=
+        if config.strictUniverse then ``SFLCompat.Recall.Check.recallChkStrict else cmdKind
+      let strictArgs :=
+        if config.strictUniverse then #[mkAtom "+", mkAtom "strictUniverse"] else #[]
+      pure (cmdStx, (mkNode cmdKind
+        (#[mkAtom (if kind == .semantic then "sf_recall" else "sf_recall_source")] ++ strictArgs ++ #[cmdStx])).raw)
   let scopes := (← getScopes).modifyHead fun sc =>
     { sc with opts := pp.tagAppFns.set (Elab.async.set sc.opts false) true, isPublic := true }
   let cctx : Command.Context :=
@@ -120,6 +134,7 @@ def recallBlock (config : RecallBlockConfig) (str : StrLit) (kind : Recall.Kind)
       kind
       statement := config.statement
       expectedError := config.error
+      strictUniverse := config.strictUniverse
       source := str.getString
       outputName := config.name
     }
@@ -145,7 +160,6 @@ A `recall` code block checks a declaration up to definitional equality. With
 def recall : CodeBlockExpanderOf RecallBlockConfig
   | config, str =>
     recallBlock config str .semantic ``SFLCompat.Recall.Check.recallChk
-      (some ``SFLCompat.Recall.Check.recallChkStmt)
 
 /--
 A `recallSource` code block checks a whole declaration byte for byte. Its
@@ -154,6 +168,6 @@ contents are not elaborated, so it renders without per-token highlighting.
 @[code_block]
 def recallSource : CodeBlockExpanderOf RecallBlockConfig
   | config, str =>
-    recallBlock config str .source ``SFLCompat.Recall.Source.recallSrc none (highlighted := false)
+    recallBlock config str .source ``SFLCompat.Recall.Source.recallSrc (highlighted := false)
 
 end SFLMeta

--- a/SFLMeta/Save/Extract.lean
+++ b/SFLMeta/Save/Extract.lean
@@ -373,11 +373,13 @@ partial def walkBlock (width : Nat) (isTerse : Bool) (file : String) (b : Verso.
       return buf
     if name == ``SFLMeta.Block.recall then
       if let some saved := SFLMeta.Recall.decode? which.data then
-        let {kind, statement, expectedError, source, ..} := saved
+        let {kind, statement, strictUniverse, expectedError, source, ..} := saved
         let command := match kind with
           | .semantic =>
             if statement then "sf_recall statement " ++ source.trimAscii.toString
-            else wrapIndented "sf_recall" source
+            else
+              let cmd := if strictUniverse then "sf_recall +strictUniverse" else "sf_recall"
+              wrapIndented cmd source
           | .source => wrapIndented "sf_recall_source" source
         if expectedError then
           return buf.appendAll file <| wrapIndented "sf_expect_failure_in" command

--- a/STYLE-CODE.md
+++ b/STYLE-CODE.md
@@ -470,6 +470,13 @@ equal, inductive types must have the same constructors, and records must have
 the same fields. With the `+statement` option, only the type signature is
 restated and not the declaration body.
 
+`recall` can restate a universe-polymorphic declaration without universe parameters when the
+restatement is a valid specialization.
+To enforce the restatement has the exact universe-parameters,
+use `+strictUniverse` to disable the specialization check.
+`+statement` option cannot be combined with `+strictUniverse`,
+and  `+strictUniverse` does not apply to `recallSource`.
+
 In a `recallSource` block, the restated
 declaration must be equal verbatim, down to indentation and line breaks;
 this is useful for showing the exact syntax of the declaration.


### PR DESCRIPTION
This PR allows `recall` command to accept universe-specialized definition. For simplicity, the definition being recalled has to contain zero universe parameters to use this flexibility. (The path can be disabled by `+strictUniverse`.)

- [x] Update STYLE-CODE.md