### PR TITLE
Add characterizing lemmas for `bif`

### DIFF
--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -577,6 +577,15 @@ theorem test_nonZeros : nonZeros [0, 1, 0] = [1] := by
 The next definition uses `bif`, Lean's conditional for Boolean tests.
 The expression `bif b then x else y` evaluates to `x` when `b` is
 {name}`true` and to `y` when `b` is {name}`false`.
+Its characterizing lemmas are `cond_true` and `cond_false`.
+
+```recall
+theorem cond_true {α} (x y : α) : (bif true then x else y) = x := by rfl
+```
+
+```recall
+theorem cond_false {α} (x y : α) : (bif false then x else y) = y := by rfl
+```
 
 ```lean
 def oddMembers (l : NatList) : NatList := solution!(


### PR DESCRIPTION
I noticed the solutions for `bif` exercises use `cond_true` and `cond_false` without any indication of their existence so this just restates them after introducing `bif`.