### PR TITLE
Add a few doc linters

### DIFF
--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -400,7 +400,7 @@ Custom notations are defined using the `notation`, `infixl`,
 :::slidebreak
 :::
 
-::::exercise (rating := 1) (name := "nand")
+::::exercise (rating := 1) (name := "nand") (checkVisibility := false)
 The {tactic}`sorry` keyword is a placeholder for an incomplete proof or
 definition.  We use it in exercises to indicate the parts that we're
 leaving for you — i.e., your job is to replace {tactic}`sorry` with real
@@ -1949,7 +1949,7 @@ def mul (n m : Nat) : Nat :=
 scoped infixl:70 " * " => mul
 ```
 
-::::exercise (rating := 1) (name := "mul_simpl_rules")
+::::exercise (rating := 1) (name := "mul_simpl_rules") (checkVisibility := false)
 Multiplication, like any function we will prove properties about,
 also has simplification rules.
 

--- a/SFLMeta.lean
+++ b/SFLMeta.lean
@@ -11,6 +11,7 @@ import SFLMeta.Grade
 import SFLMeta.Hide
 import SFLMeta.Ignore
 import SFLMeta.Instructors
+import SFLMeta.Linter
 import SFLMeta.Quiz
 import SFLMeta.Save
 import SFLMeta.SlideBreak

--- a/SFLMeta/Exercise.lean
+++ b/SFLMeta/Exercise.lean
@@ -1,5 +1,7 @@
 import VersoManual
 
+import SFLMeta.Variant
+
 open Lean Elab
 open Verso ArgParse Doc Elab Genre.Manual
 open Verso.Output Verso.Output.Html
@@ -10,7 +12,7 @@ namespace SFLMeta
 /-! ## Exercise directive -/
 
 /-- Author-facing configuration for `:::exercise`. -/
-structure ExerciseConfig where
+structure ExerciseData where
   /-- Difficulty rating, a star count from 1 to `maxExerciseRating`. -/
   rating : Nat
   /-- A short identifier for the exercise, used in headings and cross-references. -/
@@ -24,7 +26,9 @@ structure ExerciseConfig where
   /-- Whether the exercise is graded manually rather than automatically (SF's
   `M` flag).  Written `(manual := true)`. -/
   manual : Bool
-deriving Repr
+  /-- Whether to require this exercise to be nested inside `:::full` or `:::terse`. -/
+  checkVisibility : Bool
+deriving Repr, ToJson, FromJson, Quote, TypeName
 
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
@@ -61,15 +65,16 @@ def ValDesc.exerciseRating : ValDesc m Nat where
 required; the `level` (`Advanced`), `optional` (`true`/`false`), and `manual`
 (`true`/`false`) designations are optional, the two flags defaulting to
 `false`. -/
-def ExerciseConfig.parse : ArgParse m ExerciseConfig :=
-  ExerciseConfig.mk
+def ExerciseData.parse : ArgParse m ExerciseData :=
+  ExerciseData.mk
     <$> .named `rating ValDesc.exerciseRating false
     <*> .named `name .string false
     <*> .named `level ValDesc.identText true
     <*> namedD `optional .bool false
     <*> namedD `manual .bool false
+    <*> namedD `checkVisibility .bool true
 
-instance : FromArgs ExerciseConfig m := ⟨ExerciseConfig.parse⟩
+instance : FromArgs ExerciseData m := ⟨ExerciseData.parse⟩
 
 end
 
@@ -81,7 +86,7 @@ identically. -/
 def exerciseDesignation (level : Option String) (optional manual : Bool) : String :=
   let parts := (if level == some "Advanced" then ["Advanced"] else []) ++
                (if optional then ["Optional"] else []) ++
-               (if manual then ["manually graded"] else [])
+               (if manual then ["Manually graded"] else [])
   match parts with
   | [] => ""
   | _  => " (" ++ String.intercalate ", " parts ++ ")"
@@ -90,37 +95,21 @@ def exerciseDesignation (level : Option String) (optional manual : Bool) : Strin
 contents in a styled box; TeX output emits a paragraph header; the saver emits
 a `### Exercise (rating⭐): name` module-doc heading before the contents. -/
 
-/-- Decode a `Block.exercise` payload `(rating, name, level, optional, manual)`,
-tolerating the older 4-element `(rating, name, level, manual)` and 2-element
-`(rating, name)` forms.  The two flags are both booleans, so it is the array's
-arity — not its element types — that tells the current form from the older
-one. -/
-def decodeExerciseData (data : Json) : Nat × String × Option String × Bool × Bool :=
-  let level? (j : Json) : Option String := match j with | .str s => some s | _ => none
-  match data with
-  | .arr #[.num jr, .str n, lvl, .bool opt, .bool man] =>
-    (jr.toFloat.toUInt32.toNat, n, level? lvl, opt, man)
-  | .arr #[.num jr, .str n, lvl, .bool man] =>
-    (jr.toFloat.toUInt32.toNat, n, level? lvl, false, man)
-  | .arr #[.num jr, .str n] => (jr.toFloat.toUInt32.toNat, n, none, false, false)
-  | _ => (0, "", none, false, false)
-
-block_extension Block.exercise (rating : Nat) (name : String)
-    (level : Option String) (optional : Bool) (manual : Bool) where
-  data := Json.arr #[.num (.fromNat rating), .str name, toJson level, .bool optional,
-                     .bool manual]
+block_extension Block.exercise (exercise : ExerciseData) where
+  data := toJson exercise
   traverse _ _ _ := pure none
   toHtml :=
     open Verso.Output.Html in
     some fun _ goB _ data contents => do
-      let (rating, name, level, optional, manual) := decodeExerciseData data
+      let body ← contents.foldlM (init := .empty) fun acc b =>
+        return acc ++ (← goB b)
+      let .ok ({rating, name, level, optional, manual, ..} : ExerciseData) := fromJson? data
+        | return body
       let stars := String.ofList (List.replicate rating '★')
       let desig := exerciseDesignation level optional manual
       let levelHtml : Verso.Output.Html :=
         if desig.isEmpty then .empty
         else {{ <span class="exercise-level">{{desig}}</span> }}
-      let body : Verso.Output.Html ← contents.foldlM (init := .empty) fun acc b =>
-        return acc ++ (← goB b)
       return {{
         <div class={{s!"exercise stars-{rating}"}}>
           <div class="exercise-header">
@@ -135,10 +124,11 @@ block_extension Block.exercise (rating : Nat) (name : String)
   toTeX :=
     open Verso.Output.TeX in
     some fun _ goB _ data contents => do
-      let (rating, name, level, optional, manual) := decodeExerciseData data
-      let desig := exerciseDesignation level optional manual
-      let body : Verso.Output.TeX ← contents.foldlM (init := .empty) fun acc b =>
+      let body ← contents.foldlM (init := .empty) fun acc b =>
         return acc ++ (← goB b)
+      let .ok ({rating, name, level, optional, manual, ..} : ExerciseData) := fromJson? data
+        | return body
+      let desig := exerciseDesignation level optional manual
       pure <| .seq #[
         .raw s!"\\paragraph\{Exercise ({rating} stars): {name}{desig}.}",
         body
@@ -179,12 +169,12 @@ r##"
 /-- A `:::exercise(rating := N, name := "foo")` directive wraps content as an
 exercise with the given metadata. -/
 @[directive]
-def exercise : DirectiveExpanderOf ExerciseConfig
+def exercise : DirectiveExpanderOf ExerciseData
   | cfg, contents => do
+    pushInfoLeaf <| .ofCustomInfo {stx := ← getRef, value := .mk cfg}
     let blocks ← contents.mapM elabBlock
     ``(Verso.Doc.Block.other
-        (SFLMeta.Block.exercise $(quote cfg.rating) $(quote cfg.name)
-          $(quote cfg.level) $(quote cfg.optional) $(quote cfg.manual))
+        (SFLMeta.Block.exercise $(quote cfg))
         #[$blocks,*])
 
 /-! ## `solution!` marker macros and source-range registry
@@ -207,55 +197,38 @@ structure Replacement where
   replacement : String
 deriving Repr, Inhabited
 
-structure SolutionEditRaw where
-  /-- The ranges that represent the tokens of the `solution!` form. -/
-  edits : Array Replacement
-  nonempty : edits.size > 0
-deriving Repr
-
-instance : Inhabited SolutionEditRaw where
-  default.edits := #[default]
-  default.nonempty := by simp
-
-initialize studentEditRef : IO.Ref (Array SolutionEditRaw) ← IO.mkRef #[]
-initialize teacherEditRef : IO.Ref (Array SolutionEditRaw) ← IO.mkRef #[]
+initialize studentEditRef : IO.Ref (Array Replacement) ← IO.mkRef #[]
+initialize teacherEditRef : IO.Ref (Array Replacement) ← IO.mkRef #[]
 /-- Edits producing the *terse* (lecture) source variant.  `solution!` records
 the same span-to-`sorry` edit here as for the student variant (exercises are
 stubbed on slides too); `workinclass!` records its edit *only* here (the proof
 is shown in the student and solutions builds but worked live in lecture). -/
-initialize terseEditRef : IO.Ref (Array SolutionEditRaw) ← IO.mkRef #[]
+initialize terseEditRef : IO.Ref (Array Replacement) ← IO.mkRef #[]
 
 private def recordStudentEdit (edits : Array (Syntax × String)) : IO Unit := do
     let ranges := edits.filterMap fun (stx, replacement) => do
       let range ← stx.getRange?
-      pure { range, replacement}
-    if h : ranges.size > 0 then
-      studentEditRef.modify
-        (·.push ⟨ranges, h⟩)
+      pure ({range, replacement} : Replacement)
+    studentEditRef.modify (· ++ ranges)
 
 private def recordTeacherEdit (edits : Array (Syntax × String)) : IO Unit := do
     let ranges := edits.filterMap fun (stx, replacement) => do
       let range ← stx.getRange?
-      pure { range, replacement}
-    if h : ranges.size > 0 then
-      teacherEditRef.modify
-        (·.push ⟨ranges, h⟩)
+      pure ({range, replacement} : Replacement)
+    teacherEditRef.modify (· ++ ranges)
 
 private def recordTerseEdit (edits : Array (Syntax × String)) : IO Unit := do
     let ranges := edits.filterMap fun (stx, replacement) => do
       let range ← stx.getRange?
-      pure { range, replacement}
-    if h : ranges.size > 0 then
-      terseEditRef.modify
-        (·.push ⟨ranges, h⟩)
+      pure ({range, replacement} : Replacement)
+    terseEditRef.modify (· ++ ranges)
 
 /-- Record student-variant edits given `Replacement`s directly (rather than
 deriving their ranges from syntax).  Needed by `suggested!`, whose student edit
 includes a zero-width insertion — a comment closer spliced at the body's end
 position — for which there is no corresponding syntax node. -/
-private def recordStudentRepls (repls : Array Replacement) : IO Unit := do
-    if h : repls.size > 0 then
-      studentEditRef.modify (·.push ⟨repls, h⟩)
+private def recordStudentRepls (repls : Array Replacement) : IO Unit :=
+  studentEditRef.modify (· ++ repls)
 
 /-- Drop up to `n` leading space characters from a list of characters. -/
 private def dropLeadingSpaces : Nat → List Char → List Char

--- a/SFLMeta/Grade.lean
+++ b/SFLMeta/Grade.lean
@@ -24,7 +24,7 @@ structure GradeTheoremConfig where
   points : String
   /-- The names of the graded theorems. Each is graded as specified by `points`. -/
   names : List Name
-  deriving Repr
+  deriving Repr, TypeName
 
 def ValDesc.pointsText : ValDesc m String where
   description := doc!"a point value (a number, or a quoted decimal)"
@@ -59,7 +59,8 @@ block_extension Block.gradeTheorem (points : String) (names : List Name) where
 
 @[directive]
 def gradeTheorem : DirectiveExpanderOf GradeTheoremConfig
-  | cfg, _contents =>
+  | cfg, _contents => do
+    pushInfoLeaf <| .ofCustomInfo {stx := ← getRef, value := .mk cfg}
     ``(Verso.Doc.Block.other
         (SFLMeta.Block.gradeTheorem $(quote cfg.points) $(quote cfg.names)) #[])
 
@@ -82,7 +83,7 @@ block_extension Block.autogradedHole (names : List Name) where
 structure AutogradedHoleConfig where
   /-- The names of definitions to treat as holes. -/
   names : List Name
-  deriving Repr
+  deriving Repr, TypeName
 
 def AutogradedHoleConfig.parse : ArgParse m AutogradedHoleConfig :=
   AutogradedHoleConfig.mk
@@ -94,7 +95,9 @@ instance : FromArgs AutogradedHoleConfig m := ⟨AutogradedHoleConfig.parse⟩
 
 @[directive]
 def autogradedHole : DirectiveExpanderOf AutogradedHoleConfig
-  | cfg, _contents => ``(Verso.Doc.Block.other (SFLMeta.Block.autogradedHole $(quote cfg.names)) #[])
+  | cfg, _contents => do
+    pushInfoLeaf <| .ofCustomInfo {stx := ← getRef, value := .mk cfg}
+    ``(Verso.Doc.Block.other (SFLMeta.Block.autogradedHole $(quote cfg.names)) #[])
 
 def decodeAutogradedHoleData (data : Json) : Array Name :=
   match data with

--- a/SFLMeta/Linter.lean
+++ b/SFLMeta/Linter.lean
@@ -1,0 +1,248 @@
+import VersoManual
+import Batteries.Lean.Position
+
+import SFLMeta.Exercise
+import SFLMeta.Grade
+import SFLMeta.Terse
+
+open Lean Elab Command Linter
+open Verso Doc Elab
+open Lean.Doc.Syntax
+
+/-- Checks that exercises specify their visibility through `:::full` or `:::terse`. -/
+register_option linter.sf.exerciseVisibility : Bool := {
+  defValue := true
+  descr := "if true, check that exercises are inside full or terse directives"
+}
+
+/-- Checks that `:::full` and `:::terse` do not nest. -/
+register_option linter.sf.variantNesting : Bool := {
+  defValue := true
+  descr := "if true, check that full and terse directives do not nest"
+}
+
+/-- Checks that optional exercises do not autograde declarations they contain. -/
+register_option linter.sf.optionalAutograding : Bool := {
+  defValue := true
+  descr := "if true, warn when an optional exercise autogrades a declaration in its body"
+}
+
+/-- Checks that autograder directives and their targets belong to an exercise. -/
+register_option linter.sf.autogradingScope : Bool := {
+  defValue := true
+  descr := "if true, check that autograder directives target declarations in their exercise"
+}
+
+namespace SFLMeta.Linter
+
+/-- An occurrence of a directive in a document. -/
+private structure Occurrence where
+  name : Name
+  ident : Ident
+  line : Nat
+
+/--
+The declaration a directive name refers to, as recorded in the info tree when the directive was
+elaborated. A name that resolved to several declarations, or to none, is not a directive.
+-/
+private def directiveName (name : Ident) : CommandElabM (Option Name) := do
+  let some pos := name.raw.getPos? | return none
+  let mut found : Option Name := none
+  for tree in (← get).infoState.trees do
+    let names := tree.foldInfo (init := #[]) fun _ info acc =>
+      match info with
+      | .ofTermInfo {stx, expr := .const n _, ..} =>
+        if stx.getPos? == some pos then acc.push n else acc
+      | _ => acc
+    for n in names do
+      if found.any (· != n) then return none
+      found := some n
+  return found
+
+/--
+Constructs `MessageData` that refers to a directive at a particular occurrence. Hovering the name
+shows the directive's documentation, but "go to definition" jumps to the occurrence. This makes
+linter messages more clickable.
+-/
+private def directiveAt (occ : Occurrence) : CommandElabM MessageData := do
+  let module := (← getEnv).mainModule
+  let some range ← getDeclarationRange? occ.ident | return .ofConstName occ.name
+  let location : DeclarationLocation := {module, range}
+  return .ofLazy (fun
+    | none => pure <| .mk (MessageData.ofConstName occ.name)
+    | some ctx => do
+      let ⟨fmt, infos⟩ ← ppConstNameWithInfos ctx occ.name
+      let infos := infos.foldl (init := {}) fun acc pos info =>
+        acc.insert pos <| match info with
+          | .ofTermInfo i => .ofDelabTermInfo {toTermInfo := i, location? := some location}
+          | .ofDelabTermInfo i => .ofDelabTermInfo {i with location? := some location}
+          | i => i
+      pure <| .mk (MessageData.ofFormatWithInfos ⟨fmt, infos⟩))
+    (fun _ => false)
+
+/-- The command inside any number of `set_option ... in` and `open ... in` wrappers. -/
+private partial def unwrapIn (stx : Syntax) : Syntax :=
+  if stx.getKind == ``Lean.Parser.Command.in then unwrapIn stx[2] else stx
+
+/-- The custom info value of type `α` attached to the directive containing `name`, if any. -/
+private def directiveConfig? (α : Type) [TypeName α]
+    (name : Ident) : CommandElabM (Option (Syntax × α)) := do
+  let some pos := name.raw.getPos? | return none
+  for tree in (← get).infoState.trees do
+    let values := tree.foldInfo (init := #[]) fun _ info acc =>
+      match info with
+      | .ofCustomInfo {stx, value} =>
+        if stx.getRange?.any fun range => range.start ≤ pos && pos < range.stop then
+          match value.get? α with
+          | some config => acc.push (stx, config)
+          | none => acc
+        else
+          acc
+      | _ => acc
+    if let some value := values[0]? then return some value
+  return none
+
+/-- An occurrence for `name`, including its source line. -/
+private def occurrence (name : Ident) (resolvedName : Name) : CommandElabM (Option Occurrence) := do
+  let some pos := name.raw.getPos? | return none
+  let line := (← getFileMap).toPosition pos |>.line
+  return some {name := resolvedName, ident := name, line}
+
+private partial def checkExerciseVisibility
+    (mode : Option Occurrence) : Syntax → CommandElabM Unit
+  | `(block|:::%$_ $name $_args* { $blocks* }%$_) => do
+    let mut mode := mode
+    if let some n ← directiveName name then
+      if n == ``SFLMeta.full || n == ``SFLMeta.terse then
+        mode := ← occurrence name n
+      else if n == ``SFLMeta.exercise then
+        let exerciseData ← directiveConfig? ExerciseData name
+        if mode.isNone && exerciseData.all fun (_, data) => data.checkVisibility then
+          logLint linter.sf.exerciseVisibility name
+            m!"`{.ofConstName n}` is not inside a \
+              `{.ofConstName ``SFLMeta.full}` or `{.ofConstName ``SFLMeta.terse}`"
+    for block in blocks do
+      checkExerciseVisibility mode block
+  | stx =>
+    for child in stx.getArgs do
+      checkExerciseVisibility mode child
+
+/-- Checks that exercises are inside `:::full` or `:::terse`. -/
+private def exerciseVisibility : Linter where
+  run := withSetOptionIn fun stx => do
+    unless (`Verso.Doc.Concrete).isPrefixOf (unwrapIn stx).getKind do return
+    unless getLinterValue linter.sf.exerciseVisibility (← getLinterOptions) do return
+    checkExerciseVisibility none stx
+
+initialize addLinter exerciseVisibility
+
+private partial def checkVariantNesting
+    (mode : Option Occurrence) : Syntax → CommandElabM Unit
+  | `(block|:::%$_ $name $_args* { $blocks* }%$_) => do
+    let mut mode := mode
+    if let some n ← directiveName name then
+      if n == ``SFLMeta.full || n == ``SFLMeta.terse then
+        if let some outer := mode then
+          if let some this ← occurrence name n then
+            logLint linter.sf.variantNesting name
+              m!"`{← directiveAt this}` nested inside a \
+                `{← directiveAt outer}` on line {outer.line}"
+        mode := ← occurrence name n
+    for block in blocks do
+      checkVariantNesting mode block
+  | stx =>
+    for child in stx.getArgs do
+      checkVariantNesting mode child
+
+/-- Checks that `:::full` and `:::terse` do not nest. -/
+private def variantNesting : Linter where
+  run := withSetOptionIn fun stx => do
+    unless (`Verso.Doc.Concrete).isPrefixOf (unwrapIn stx).getKind do return
+    unless getLinterValue linter.sf.variantNesting (← getLinterOptions) do return
+    checkVariantNesting none stx
+
+initialize addLinter variantNesting
+
+private def declaredWithin (range : Syntax.Range) (declName : Name) : CommandElabM Bool := do
+  let some declRange ← findDeclarationSyntaxRange? declName (fullRange := true)
+    | return false
+  return range.includes declRange true true
+
+private def autogradingTargets? (directive : Name) (name : Ident) :
+    CommandElabM (Option (Array Name)) := do
+  if directive == ``SFLMeta.gradeTheorem then
+    return (← directiveConfig? GradeTheoremConfig name).map fun (_, cfg) => (cfg.names.toArray)
+  if directive == ``SFLMeta.autogradedHole then
+    return (← directiveConfig? AutogradedHoleConfig name).map fun (_, cfg) => (cfg.names.toArray)
+  return none
+
+private partial def checkOptionalAutograding
+    (optionalExercise : Option (Occurrence × Syntax.Range)) : Syntax → CommandElabM Unit
+  | `(block|:::%$_ $name $_args* { $blocks* }%$_) => do
+    let mut optionalExercise := optionalExercise
+    if let some n ← directiveName name then
+      if n == ``SFLMeta.exercise then
+        optionalExercise := match ← occurrence name n, ← directiveConfig? ExerciseData name with
+          | some exercise, some (stx, data) =>
+            if data.optional then stx.getRange?.map (exercise, ·) else none
+          | _, _ => none
+      else if let some (exercise, range) := optionalExercise then
+        if let some targets ← autogradingTargets? n name then
+          for targetName in targets do
+            if ← declaredWithin range targetName then
+              logLint linter.sf.optionalAutograding name
+                m!"optional `{← directiveAt exercise}` autogrades \
+                  declaration `{.ofConstName targetName}` from its body"
+    for block in blocks do
+      checkOptionalAutograding optionalExercise block
+  | stx =>
+    for child in stx.getArgs do
+      checkOptionalAutograding optionalExercise child
+
+/-- Checks that optional exercises do not autograde declarations in their bodies. -/
+private def optionalAutograding : Linter where
+  run := withSetOptionIn fun stx => do
+    unless (`Verso.Doc.Concrete).isPrefixOf (unwrapIn stx).getKind do return
+    unless getLinterValue linter.sf.optionalAutograding (← getLinterOptions) do return
+    checkOptionalAutograding none stx
+
+initialize addLinter optionalAutograding
+
+/-- Checks that autograder directives and their targets belong to an exercise. -/
+private partial def checkAutogradingScope
+    (exercise : Option (Occurrence × Syntax.Range)) : Syntax → CommandElabM Unit
+  | `(block|:::%$_ $name $_args* { $blocks* }%$_) => do
+    let mut exercise := exercise
+    if let some n ← directiveName name then
+      if n == ``SFLMeta.exercise then
+        exercise := match ← occurrence name n, ← directiveConfig? ExerciseData name with
+          | some exercise, some (stx, _) => stx.getRange?.map (exercise, ·)
+          | _, _ => none
+      else if let some targets ← autogradingTargets? n name then
+        match exercise with
+        | none =>
+          logLint linter.sf.autogradingScope name
+            m!"`{.ofConstName n}` is not inside an \
+              `{.ofConstName ``SFLMeta.exercise}`"
+        | some (exerciseOcc, range) =>
+          for targetName in targets do
+            unless ← declaredWithin range targetName do
+              logLint linter.sf.autogradingScope name
+                m!"`{.ofConstName n}` target `{.ofConstName targetName}` was not declared \
+                  inside `{← directiveAt exerciseOcc}`"
+    for block in blocks do
+      checkAutogradingScope exercise block
+  | stx =>
+    for child in stx.getArgs do
+      checkAutogradingScope exercise child
+
+/-- Checks that autograder directives target declarations in their exercise. -/
+private def autogradingScope : Linter where
+  run := withSetOptionIn fun stx => do
+    unless (`Verso.Doc.Concrete).isPrefixOf (unwrapIn stx).getKind do return
+    unless getLinterValue linter.sf.autogradingScope (← getLinterOptions) do return
+    checkAutogradingScope none stx
+
+initialize addLinter autogradingScope
+
+end SFLMeta.Linter

--- a/SFLMeta/Save/Extract.lean
+++ b/SFLMeta/Save/Extract.lean
@@ -333,15 +333,6 @@ def decodeBnfSource? (data : Json) : Option String :=
     | .error _      => some src
   | _ => none
 
-/-- Decode a `Block.exercise` payload `(rating, name, level, optional, manual)`,
-tolerating the older 4- and 2-element forms.  (See
-`SFLMeta.decodeExerciseData`.) -/
-def decodeExercise? (data : Json) : Option (Nat × String × Option String × Bool × Bool) :=
-  match data with
-  | .arr #[.num _, .str _, _, _, _] | .arr #[.num _, .str _, _, _]
-  | .arr #[.num _, .str _] => some (decodeExerciseData data)
-  | _ => none
-
 /-- Does one of `blocks` contain a `Block.suppressPreviousHeaderWhenTerse`
 marker?  The marker is emitted at a section's top level, but elaboration wraps
 each source block in `.concat` layers, so look through those (only — the marker
@@ -485,14 +476,15 @@ partial def walkBlock (width : Nat) (isTerse : Bool) (file : String) (b : Verso.
     if name == ``Block.exercise then
       -- Emit a `### Exercise (N⭐): name` heading; the contained `lean`
       -- blocks render normally via recursion below.
-      if let some (rating, exName, level, optional, manual) := decodeExercise? which.data then
+      if let .ok (exercise : ExerciseData) := fromJson? which.data then
+        let {rating, name := exName, level, optional, manual, ..} := exercise
         let stars := String.ofList (List.replicate rating '⭐')
         let desig := exerciseDesignation level optional manual
         let header := s!"### Exercise ({rating} star{if rating == 1 then "" else "s"}): {exName}{desig} {stars}"
         let mut buf := buf.appendAll file (asModuleDoc header)
         buf := walkBlocks width isTerse file contents buf
         return buf
-      return buf
+      return walkBlocks width isTerse file contents buf
     if name == ``Block.bnf then
       if let some src := decodeBnfSource? which.data then
         return buf.appendAll file (asModuleDoc src.trimAscii.toString)

--- a/SFLMeta/Save/Lean.lean
+++ b/SFLMeta/Save/Lean.lean
@@ -284,8 +284,8 @@ def lean : CodeBlockExpanderOf LeanSaved.Config
       -- `strLitInputContext` parses starting at `str.getPos?`, so the byte
       -- indices recorded by the elaborator are absolute file offsets. The
       -- string-literal contents begin one byte past the opening quote.
-      let relativize (edits : Array SolutionEditRaw) : Array Replacement :=
-        edits.flatMap (·.edits) |>.map fun r =>
+      let relativize (edits : Array Replacement) : Array Replacement :=
+        edits |>.map fun r =>
           { r with
             range.start.byteIdx := r.range.start.byteIdx - str.raw.getPos!.byteIdx
             range.stop.byteIdx := r.range.stop.byteIdx - str.raw.getPos!.byteIdx


### PR DESCRIPTION
This PR adds four linters that generate warnings if:
1. an `:::exercise` directive is not scoped by `:::full` or `:::terse`
2.  a `:::full` and `:::terse` nest 
3. a `:::gradeTheorem` or `:::autogradedHole` is not in an `:::exercise`
4. an optional `:::exercise` has `:::gradeTheorem` or `:::autogradedHole` 

Basics exercises have been marked as `(checkVisibility := false)`.