### PR TITLE
Imp: improve delabrator and reduce antiquotation noise

### DIFF
--- a/HL/Hoare.lean
+++ b/HL/Hoare.lean
@@ -567,66 +567,59 @@ This has the downside that assertions need to be wrapped in `()` parentheses whe
 ```lean
 namespace Assertion
 
-section
-open Lean Elab Term
+open Lean Elab Term Meta Imp.Elab
 
-scoped syntax:max (name := assn) "assn(" ident "; " term ")" : term
+scoped syntax:max "assn(" ident "; " term ")" : term
 scoped syntax:lead "{{" term "}}" : term
-
-@[term_elab assn]
-def assnElab : TermElab := fun stx _type? => do
-  match stx with
-  | `(assn($st; $t:term)) =>
-    let t ← elabTerm t none
-    let ty ← Meta.inferType t
-    -- if (← Meta.isDefEq ty (mkConst ``_root_.Ident)) then -- this incorrectly assigns metavariables
-    if (ty.constName == ``_root_.Ident) then
-      return mkApp6 (mkConst ``_root_.MyGetElem.getElem)
-        (mkApp2 (mkConst ``TotalMap) (mkConst ``String) (mkConst ``Nat))
-        (mkConst ``String)
-        (mkConst ``Nat)
-        (← Meta.synthInstance <| mkApp3 (mkConst ``_root_.MyGetElem)
-          (mkApp2 (mkConst ``TotalMap) (mkConst ``String) (mkConst ``Nat))
-          (mkConst ``String)
-          (mkConst ``Nat))
-        (← elabTerm st none) t
-    if (ty.constName == ``_root_.Aexp) then -- Detect an embedded `Aexp` and turn it into `Aexp.eval st t`
-      return (mkApp2 (mkConst ``Aexp.eval) (← elabTerm st none) t)
-    else if (ty.constName == ``_root_.Bexp) then  -- Detect an embedded `Bexp` and turn it into `Bexp.eval st t`
-      return (mkApp2 (mkConst ``Bexp.eval) (← elabTerm st none) t)
-    else if ty.isMVar then -- This is a hack to guard against `Meta.isDefEq` assigning the type to be an `Assertion`
-      return t
-    else if (← Meta.isDefEq ty (mkConst ``_root_.Assertion)) then
-      return mkApp t (← elabTerm st none)
-    else
-      return t
-  | _ => throwUnsupportedSyntax
 
 -- `: Assertion` guards that the resulting type is `State → Prop`.
 macro_rules
   | `({{ $t }}) => `((fun st : _root_.State => assn(st; $t) : Assertion))
 
 macro_rules
-  | `(assn($st; ($P))) => ``((assn($st; $P)))
-  | `(assn($st; $l = $r)) => ``(assn($st; $l) = assn($st; $r))
-  | `(assn($st; $l + $r)) => ``(assn($st; $l) + assn($st; $r))
-  | `(assn($st; $l - $r)) => ``(assn($st; $l) - assn($st; $r))
-  | `(assn($st; $l * $r)) => ``(assn($st; $l) * assn($st; $r))
-  | `(assn($st; $l ≤ $r)) => ``(assn($st; $l) ≤ assn($st; $r))
-  | `(assn($st; $l < $r)) => ``(assn($st; $l) < assn($st; $r))
-  | `(assn($st; $l ≥ $r)) => ``(assn($st; $l) ≥ assn($st; $r))
-  | `(assn($st; $l > $r)) => ``(assn($st; $l) > assn($st; $r))
-  | `(assn($st; $l ∧ $r)) => ``(assn($st; $l) ∧ assn($st; $r))
-  | `(assn($st; $l ∨ $r)) => ``(assn($st; $l) ∨ assn($st; $r))
-  | `(assn($st; $l → $r)) => ``(assn($st; $l) → assn($st; $r))
-  | `(assn($st; $l ↔ $r)) => ``(assn($st; $l) ↔ assn($st; $r))
-  | `(assn($st; ¬ $t)) => ``(¬ assn($st; $t))
-  | `(assn($st; $f $args*)) => do
-    let mut result := f
-    for arg in args do
-      result ← `($result assn($st; $arg))
-    return result
-end
+  | `(assn($st; $t)) => do
+    let result ← match t with
+      | `(($P)) => ``((assn($st; $P)))
+      | `($l = $r) => ``(assn($st; $l) = assn($st; $r))
+      | `($l + $r) => ``(assn($st; $l) + assn($st; $r))
+      | `($l - $r) => ``(assn($st; $l) - assn($st; $r))
+      | `($l * $r) => ``(assn($st; $l) * assn($st; $r))
+      | `($l ≤ $r) => ``(assn($st; $l) ≤ assn($st; $r))
+      | `($l < $r) => ``(assn($st; $l) < assn($st; $r))
+      | `($l ≥ $r) => ``(assn($st; $l) ≥ assn($st; $r))
+      | `($l > $r) => ``(assn($st; $l) > assn($st; $r))
+      | `($l ∧ $r) => ``(assn($st; $l) ∧ assn($st; $r))
+      | `($l ∨ $r) => ``(assn($st; $l) ∨ assn($st; $r))
+      | `($l → $r) => ``(assn($st; $l) → assn($st; $r))
+      | `($l ↔ $r) => ``(assn($st; $l) ↔ assn($st; $r))
+      | `(¬ $p) => ``(¬ assn($st; $p))
+      | `($f $args*) => do
+        let mut result := f
+        for arg in args do
+          result ← `($result assn($st; $arg))
+        pure result
+      | _ => Macro.throwUnsupported
+    return withSourceInfoOf t result
+
+elab_rules : term
+  | `(assn($st; $t:term)) => do
+    let t ← elabTerm t none
+    let ty ← whnf (← inferType t)
+    tryPostponeIfMVar ty
+    let st ← elabTerm st none
+    match_expr ty with
+    | String => mkAppM ``_root_.MyGetElem.getElem #[st, t]
+    | Aexp => mkAppM ``Aexp.eval #[st, t]
+    | Bexp => mkAppM ``Bexp.eval #[st, t]
+    | _ =>
+      match ty with
+      | .forallE _ domain body _ =>
+        if body.isProp && (← isDefEq domain (mkConst ``_root_.State)) then
+          pure <| mkApp t st
+        else
+          pure t
+      | _ => pure t
+
 ```
 
 :::dev "Niklas Halonen"
@@ -758,7 +751,14 @@ details.
 ::::details "Notation encoding: printing assertions back"
 ```lean
 namespace Assertion.Delab
-open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
+
+open Lean PrettyPrinter Delaborator SubExpr Imp.Elab Imp.Delab
+
+private def getAssn (stx : Term) : Term :=
+  withSourceInfoOf (canonical := false) stx <| Unhygienic.run do
+  match stx with
+  | `({{ $P }}) => return P
+  | _ => return stx
 
 /-- Rebuild the surface form of an assertion body, undoing the state
 threading the `assn` elaborator performs: `st[X]` prints as `X`,
@@ -773,39 +773,39 @@ partial def delabBody (stId : FVarId) : DelabM Term := do
     match_expr e with
     | MyGetElem.getElem _ _ _ _ st _ =>
       guard (st == .fvar stId)
-      withNaryArg 5 delab
+      withAppArg delab
     | Aexp.eval st _ =>
       guard (st == .fvar stId)
       withAppArg delab
     | HAdd.hAdd _ _ _ _ _ _ =>
-      `($(← withNaryArg 4 (delabBody stId)) + $(← withNaryArg 5 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) + $(← withAppArg (delabBody stId)))
     | HSub.hSub _ _ _ _ _ _ =>
-      `($(← withNaryArg 4 (delabBody stId)) - $(← withNaryArg 5 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) - $(← withAppArg (delabBody stId)))
     | HMul.hMul _ _ _ _ _ _ =>
-      `($(← withNaryArg 4 (delabBody stId)) * $(← withNaryArg 5 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) * $(← withAppArg (delabBody stId)))
     | Eq _ l r =>
       -- `Bexp.eval st b = true` is the threaded form of a bare boolean `b`
       if r.isConstOf ``Bool.true && l.isAppOfArity ``Bexp.eval 2
           && l.appFn!.appArg! == .fvar stId then
-        withNaryArg 1 <| withAppArg delab
+        withAppFn <| withAppArg <| withAppArg delab
       else
-        `($(← withNaryArg 1 (delabBody stId)) = $(← withNaryArg 2 (delabBody stId)))
+        `($(← withAppFn <| withAppArg (delabBody stId)) = $(← withAppArg (delabBody stId)))
     | Ne _ _ _ =>
-      `($(← withNaryArg 1 (delabBody stId)) ≠ $(← withNaryArg 2 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) ≠ $(← withAppArg (delabBody stId)))
     | LE.le _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) ≤ $(← withNaryArg 3 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) ≤ $(← withAppArg (delabBody stId)))
     | LT.lt _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) < $(← withNaryArg 3 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) < $(← withAppArg (delabBody stId)))
     | GE.ge _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) ≥ $(← withNaryArg 3 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) ≥ $(← withAppArg (delabBody stId)))
     | GT.gt _ _ _ _ =>
-      `($(← withNaryArg 2 (delabBody stId)) > $(← withNaryArg 3 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) > $(← withAppArg (delabBody stId)))
     | And _ _ =>
-      `($(← withNaryArg 0 (delabBody stId)) ∧ $(← withNaryArg 1 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) ∧ $(← withAppArg (delabBody stId)))
     | Or _ _ =>
-      `($(← withNaryArg 0 (delabBody stId)) ∨ $(← withNaryArg 1 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) ∨ $(← withAppArg (delabBody stId)))
     | Iff _ _ =>
-      `($(← withNaryArg 0 (delabBody stId)) ↔ $(← withNaryArg 1 (delabBody stId)))
+      `($(← withAppFn <| withAppArg (delabBody stId)) ↔ $(← withAppArg (delabBody stId)))
     | Not _ =>
       `(¬ $(← withAppArg (delabBody stId)))
     | _ =>
@@ -813,10 +813,14 @@ partial def delabBody (stId : FVarId) : DelabM Term := do
         `($(← withBindingDomain (delabBody stId)) →
           $(← withBindingBody `h (delabBody stId)))
       else if let .app f v := e then
-        -- an applied assertion `P st` (or an applied escape lambda)
-        guard (v == .fvar stId)
-        guard !(f.containsFVar stId)
-        withAppFn delab
+        if v == .fvar stId && !f.containsFVar stId then
+          -- an applied assertion `P st` (or an applied escape lambda)
+          if f.isLambda then
+            withAppFn <| withOptions (pp.notation.set · false) delab
+          else
+            withAppFn delab
+        else
+          `($(← withAppFn (delabBody stId)) $(← withAppArg (delabBody stId)))
       else
         failure
 
@@ -826,7 +830,7 @@ to the raw lambda, which is exactly this notation's escape form. -/
 partial def delabAssn : DelabM Term := do
   if (← getExpr).isLambda then
     (withBindingBody' `st (pure ·.fvarId!) fun stId => delabBody stId)
-      <|> Delaborator.delab
+      <|> withOptions (pp.notation.set · false) Delaborator.delab
   else
     delab
 
@@ -1188,7 +1192,7 @@ open scoped HasEval
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
   ∀ {st st' : State},
-    (st =[ ~c ]=> st') →
+    (st =[ c ]=> st') →
     P st →
     Q st'
 ```
@@ -1207,7 +1211,7 @@ class HasTriple (Com : Type) where
 namespace HasTriple
 
 /-- Hoare triple: `{{ P }} c {{ Q }}` with `imp_com` command syntax -/
-scoped syntax:lead "{{" term "}} " imp_com:lead " {{" term "}}" : term
+scoped syntax:lead "{{" term "}} " imp_com:min " {{" term "}}" : term
 scoped macro_rules
   | `({{ $P }} $c:imp_com {{ $Q }}) =>
       ``(HasTriple.Triple ({{ $P }}) (imp { $c }) ({{ $Q }}))
@@ -1230,8 +1234,8 @@ We make {name}`ValidHoareTriple` irreducible for "technical reasons", and use it
 open scoped HasTriple
 
 theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
-    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
-      (st =[ ~c ]=> st') →
+    {{ P }} c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
       P st →
       Q st' := by rfl
 
@@ -1276,7 +1280,7 @@ end HasTriple.Delab
 ```lean -show
 #check ({{ True }} skip {{ False }})
 #check ({{ True }} X := 0 {{ False }})
-#check ∀ c : Com, ({{ True }} ~c {{ False }})
+#check ∀ c : Com, ({{ True }} c {{ False }})
 
 /-- info: {{X ≤ 5}} X := X + 1 {{X ≤ 7}} : Prop -/
 #guard_msgs in
@@ -1302,7 +1306,7 @@ as its postcondition is valid.
 
 ```lean
 theorem hoare_post_true {P Q : Assertion} {c : Com} (h : ∀ st, Q st) :
-    {{ P }} ~c {{ Q }} := by
+    {{ P }} c {{ Q }} := by
   solution!
     rw [validHoareTriple_def]
     intro st st' hc hpre
@@ -1316,7 +1320,7 @@ its precondition is valid.
 
 ```lean
 theorem hoare_pre_false {P Q : Assertion} {c : Com} (h : ∀ st, ¬ (P st)) :
-    {{ P }} ~c {{ Q }} := by
+    {{ P }} c {{ Q }} := by
   solution!
     rw [validHoareTriple_def]
     intro st st' hc hpre
@@ -1388,8 +1392,8 @@ state where `P` holds to one where `R` holds:
 
 ```lean
 theorem hoare_seq {P Q R : Assertion} {c1 c2 : Com}
-    (h1 : {{ Q }} ~c2 {{ R }}) (h2 : {{ P }} ~c1 {{ Q }}) :
-    {{ P }} ~c1; ~c2 {{ R }} := by
+    (h1 : {{ Q }} c2 {{ R }}) (h2 : {{ P }} c1 {{ Q }}) :
+    {{ P }} c1; c2 {{ R }} := by
   rw [validHoareTriple_def]
   intro st st' h hpre
   inversion h with
@@ -1608,9 +1612,7 @@ a quick go at implementing it, but did not succeed yet.
 Introduce a notation typeclass for this (e.g. HasSubst)
 :::
 
-:::dev "Niklas Halonen (xhalo32)" PotentialImprovement
-A lot of the substitutions use `[x ↦ ~a]`. Could we have syntax support for `[x ↦ a]`. A naive approach that adds `" [" ident " ↦ " term "]" ` leads to ambiguity.
-:::
+
 
 ```lean
 namespace Assertion
@@ -1658,17 +1660,13 @@ open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
 bare inside-the-braces form: the generic application case of `delabBody`
 picks it up inside an assertion body, and the enclosing printer supplies
 the single pair of braces. -/
-@[delab app.Assertion.subst]
-def delabSub : Delab := whenPPOption getPPNotation do
-  guard <| (← getExpr).isAppOfArity ``Assertion.subst 3
-  let `($x:ident) ← withNaryArg 0 delab | failure
-  let a ← withNaryArg 1 delabAexpInner
-  if (← withNaryArg 2 getExpr).isLambda then
-    `(($(← withNaryArg 2 delabAssn)) [$x:ident ↦ $a:imp_aexp])
-  else
-    match ← withNaryArg 2 delab with
-    | `($P:ident) => `($P:ident [$x:ident ↦ $a:imp_aexp])
-    | P => `(($P) [$x:ident ↦ $a:imp_aexp])
+@[app_unexpander Assertion.subst]
+def unexpandSubst : Unexpander
+  | `($_ $x:ident $a $P) =>
+    match getAssn P with
+    | `($P:ident) => `($P:ident [$x:ident ↦ $(getAexp a):imp_aexp])
+    | P => `(($P) [$x:ident ↦ $(getAexp a):imp_aexp])
+  | _ => throw ()
 
 end Assertion.Delab
 ```
@@ -1801,7 +1799,7 @@ We can prove formally that this rule is indeed valid.
 
 ```lean
 theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
-    {{ Q [x ↦ ~a] }} x := ~a {{ Q }} := by
+    {{ Q [x ↦ a] }} x := a {{ Q }} := by
   rw [validHoareTriple_def]
   intro st st' hE hQ
   inversion hE with
@@ -1909,7 +1907,7 @@ Should we demonstrate this with an example before this exercise?
 
 ```lean
 theorem hoare_asgn_wrong : ∃ a : Aexp,
-    ¬ {{ True }} X := ~a {{ X = a }} := by
+    ¬ {{ True }} X := a {{ X = a }} := by
   solution!
     exists aexp { X + 1 }
     intro hc
@@ -1983,7 +1981,7 @@ the postcondition.
 ```lean
 theorem hoare_asgn_fwd {m : Nat} {a : Aexp} {P : Assertion} :
     {{ P ∧ X = m }}
-      X := ~a
+      X := a
     {{ fun st => P (X →ₜ m ; st)
          ∧ st[X] = a.eval (X →ₜ m ; st) }} := by
   solution!
@@ -2021,7 +2019,7 @@ https://www.cl.cam.ac.uk/archive/mjcg/HL/Notes/Notes.pdf
 ```lean
 theorem hoare_asgn_fwd_exists (a : Aexp) (P : Assertion) :
     {{ P }}
-      X := ~a
+      X := a
     {{ fun st => ∃ m, P (X →ₜ m ; st) ∧
          st[X] = a.eval (X →ₜ m ; st) }} := by
   solution!
@@ -2214,8 +2212,8 @@ Here are the formal versions:
 
 ```lean
 theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   apply hhoare heval
@@ -2223,8 +2221,8 @@ theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
   exact himp _ hpre
 
 theorem hoare_consequence_post {P Q Q' : Assertion} {c : Com}
-    (hhoare : {{ P }} ~c {{ Q' }}) (himp : Q' ->> Q) :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P }} c {{ Q' }}) (himp : Q' ->> Q) :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   rw [assertImplies_def] at himp
@@ -2320,8 +2318,8 @@ Another option is to just write `exact hoare_consequence_pre (hoare_consequence_
 
 ```lean
 theorem hoare_consequence {P P' Q Q' : Assertion} {c : Com}
-    (htriple : {{ P' }} ~c {{ Q' }}) (hpre : P ->> P') (hpost : Q' ->> Q) :
-    {{ P }} ~c {{ Q }} := by
+    (htriple : {{ P' }} c {{ Q' }}) (hpre : P ->> P') (hpost : Q' ->> Q) :
+    {{ P }} c {{ Q }} := by
   apply hoare_consequence_pre (P' := P')
   · exact hoare_consequence_post htriple hpost
   · exact hpre
@@ -2372,8 +2370,8 @@ Here's a good candidate for automation:
 
 ```display
 theorem hoare_consequence_pre (P P' Q : Assertion) (c : Com)
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   apply hhoare heval
@@ -2392,8 +2390,8 @@ This needs a better explanation of when it's okay to use definitions without usi
 
 ```lean
 theorem hoare_consequence_pre' (P P' Q : Assertion) (c : Com)
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   apply hhoare heval
@@ -2407,8 +2405,8 @@ goal (and each other), the remaining proof can be compressed into a single tacti
 
 ```lean
 theorem hoare_consequence_pre'' (P P' Q : Assertion) (c : Com)
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   apply_rules
@@ -2421,8 +2419,8 @@ The same trick works for {name}`hoare_consequence_post`.
 
 ```lean
 theorem hoare_consequence_post' (P Q Q' : Assertion) (c : Com)
-    (hhoare : {{ P }} ~c {{ Q' }}) (himp : Q' ->> Q) :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P }} c {{ Q' }}) (himp : Q' ->> Q) :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   apply_rules
@@ -2600,7 +2598,7 @@ assignment.  Note the use of {name}`hoare_seq` in conjunction with
 ```lean
 theorem hoare_asgn_example3 (a : Aexp) (n : Nat) :
     {{a = n}}
-      X := ~a;
+      X := a;
       skip
     {{X = n}} := by
   apply hoare_seq
@@ -2719,7 +2717,7 @@ def swap_program : Com := solution!(imp { Z := X; X := Y; Y := Z })
 
 theorem swap_exercise :
     {{X ≤ Y}}
-      ~swap_program
+      swap_program
     {{Y ≤ X}} := by
   solution!
     rw [swap_program]
@@ -2779,7 +2777,7 @@ Having chosen your `a` and `n`, proceed as follows:
 ```lean
 theorem invalid_triple : ¬ ∀ (a : Aexp) (n : Nat),
     {{ a = n }}
-      X := 3; Y := ~a
+      X := 3; Y := a
     {{ Y = n }} := by
   intro h
   simp only [validHoareTriple_def] at h
@@ -2883,14 +2881,14 @@ but should we build our own `congruence` tactic?
 Now we can formalize the Hoare proof rule for conditionals
 and prove it correct.
 
-The statement of the rule reads: given `htrue : {{ P ∧ b }} ~c1 {{Q}}`
-and `hfalse : {{ P ∧ ¬b }} ~c2 {{Q}}`, we can conclude
-`{{P}} if (~b) { ~c1 } else { ~c2 } {{Q}}`.
+The statement of the rule reads: given `htrue : {{ P ∧ b }} c1 {{Q}}`
+and `hfalse : {{ P ∧ ¬b }} c2 {{Q}}`, we can conclude
+`{{P}} if (b) { c1 } else { c2 } {{Q}}`.
 
 ```lean
 theorem hoare_if {P Q : Assertion} {b : Bexp} {c1 c2 : Com}
-    (htrue : {{ P ∧ b }} ~c1 {{ Q }}) (hfalse : {{ P ∧ ¬ b }} ~c2 {{ Q }}) :
-    {{ P }} if (~b) { ~c1 } else { ~c2 } {{ Q }} := by
+    (htrue : {{ P ∧ b }} c1 {{ Q }}) (hfalse : {{ P ∧ ¬ b }} c2 {{ Q }}) :
+    {{ P }} if (b) { c1 } else { c2 } {{ Q }} := by
   rw [validHoareTriple_def] at htrue hfalse ⊢
   intro st st' hE hpre
   inversion hE with
@@ -3013,23 +3011,32 @@ This means we need to redefine the `macro_rules` with the new `Com`.
 /-- One-sided conditional -/
 scoped syntax "if1 " "(" imp_bexp ")" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") : imp_com
 
-open Lean in
+namespace Com
+
+open Lean Imp.Elab
+
 scoped macro_rules
-  | `(imp { $x:ident }) =>
-    if x.getId == `skip then `(Com.skip)
-    else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
-  | `(imp { $c1; $c2 }) =>
-    `(Com.seq (imp {$c1}) (imp {$c2}))
-  | `(imp { $x:ident := $a }) =>
-    `(Com.asgn $x (aexp {$a}))
-  | `(imp { if ($b) {$c1} else {$c2} }) =>
-    `(Com.cond (bexp {$b}) (imp {$c1}) (imp {$c2}))
-  | `(imp { while ($b) {$c} }) =>
-    `(Com.whileDo (bexp {$b}) (imp {$c}))
-  | `(imp { if1 ($b) {$c} }) =>
-    `(Com.if1 (bexp {$b}) (imp {$c}))
-  | `(imp { ~$c }) =>
-    pure c
+  | `(imp { $s }) => do
+    let stx ← match s with
+      | `(imp_com| skip) => ``(Com.skip)
+      | `(imp_com| $x:ident) => ``(($x : Com))
+      | `(imp_com| $c₁ ; $c₂) =>
+        ``(Com.seq (imp {$c₁}) (imp {$c₂}))
+      | `(imp_com| $x:ident := $a) =>
+        ``(Com.asgn $x (aexp {$a}))
+      | `(imp_com| if ($b) {$c₁} else {$c₂}) =>
+        ``(Com.cond (bexp {$b}) (imp {$c₁}) (imp {$c₂}))
+      | `(imp_com| while ($b) {$c}) =>
+        ``(Com.whileDo (bexp {$b}) (imp {$c}))
+      | `(imp_com| if1 ($b) {$c}) =>
+        ``(Com.if1 (bexp {$b}) (imp {$c}))
+      | `(imp_com| ~$c) => `(($c : Com))
+      | _ => Macro.throwUnsupported
+    return withSourceInfoOf s stx
+
+end Com
+
+open scoped Com
 ```
 
 The delaborators are re-instantiated the same way: the Imp printer is
@@ -3039,23 +3046,19 @@ extended printer is that printer at `If1.Com` plus one case for `if1`.
 ::::details "Notation encoding: printing the extended commands back"
 ```lean
 namespace Delab
-open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
 
-/-- Rebuild `imp_com` syntax from an `If1.Com` term. -/
-partial def delabComInner : DelabM (TSyntax `imp_com) :=
-  delabComInnerFor ``Com do
-    let e ← getExpr
-    guard <| e.isAppOfArity ``Com.if1 2
-    let b ← withAppFn <| withAppArg delabBexpInner
-    let c ← withAppArg If1.Delab.delabComInner
-    `(imp_com| if1 ($b) {$c})
+open Lean PrettyPrinter Imp.Delab
 
-@[delab app.If1.Com.skip, delab app.If1.Com.asgn, delab app.If1.Com.seq,
-  delab app.If1.Com.cond, delab app.If1.Com.whileDo, delab app.If1.Com.if1]
-partial def delabCom : Delab := whenPPOption getPPNotation do
-  match ← delabComInner with
-  | `(imp_com| ~$e) => pure e
-  | e => `(term| imp { $e })
+@[app_unexpander Com.if1]
+private def Com.unexpandIf1 : Unexpander
+  | `($_ $b $c) => `(imp { if1 ($(getBexp b)) { $(getImp c) } })
+  | _ => throw ()
+
+attribute [app_unexpander Com.skip] unexpandComSkip
+attribute [app_unexpander Com.asgn] unexpandComAsgn
+attribute [app_unexpander Com.seq] unexpandComSeq
+attribute [app_unexpander Com.cond] unexpandComCond
+attribute [app_unexpander Com.whileDo] unexpandComWhileDo
 
 end Delab
 ```
@@ -3082,28 +3085,28 @@ inductive Com.EvalR : Com → State → State → Prop where
   | skip {st : State} :
       EvalR (imp {skip}) st st
   | asgn {st : State} (a : Aexp) {n : Nat} (x : Ident) (h : a.eval st = n) :
-      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
+      EvalR (imp {x := a}) st (x →ₜ n ; st)
   | seq {c1 c2 : Com} (st st' st'' : State)
       (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
-      EvalR (imp {~c1; ~c2}) st st''
+      EvalR (imp {c1; c2}) st st''
   | ifTrue {st st' : State} (b : Bexp) {c1 c2 : Com} (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (b) {c1} else {c2} }) st st'
   | ifFalse {st st' : State} (b : Bexp) {c1 c2 : Com} (hb : b.eval st = false)
       (hc : EvalR c2 st st') :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (b) {c1} else {c2} }) st st'
   | whileFalse {b : Bexp} (st : State) (c : Com) (hb : b.eval st = false) :
-      EvalR (imp {while (~b) {~c} }) st st
+      EvalR (imp {while (b) {c} }) st st
   | whileTrue {st st' st'' : State} {b : Bexp} {c : Com}
       (hb : b.eval st = true) (hc : EvalR c st st')
-      (hloop : EvalR (imp {while (~b) {~c} }) st' st'') :
-      EvalR (imp {while (~b) {~c} }) st st''
+      (hloop : EvalR (imp {while (b) {c} }) st' st'') :
+      EvalR (imp {while (b) {c} }) st st''
 -- SOLUTION
   | if1True {st st' : State} {b : Bexp} {c : Com} (hb : b.eval st = true)
       (hc : EvalR c st st') :
-      EvalR (imp {if1 (~b) {~c} }) st st'
+      EvalR (imp {if1 (b) {c} }) st st'
   | if1False {st : State} {b : Bexp} {c : Com} (hb : b.eval st = false) :
-      EvalR (imp {if1 (~b) {~c} }) st st
+      EvalR (imp {if1 (b) {c} }) st st
 -- END SOLUTION
 
 instance : HasEval Com State State where
@@ -3152,7 +3155,7 @@ so that they will use the updated {name}`Com` type.
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
   ∀ {st st' : State},
-    (st =[ ~c ]=> st') →
+    (st =[ c ]=> st') →
     P st →
     Q st'
 
@@ -3160,8 +3163,8 @@ instance : HasTriple Com where
   Triple := ValidHoareTriple
 
 theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
-    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
-      (st =[ ~c ]=> st') →
+    {{ P }} c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
       P st →
       Q st' := by rfl
 
@@ -3199,9 +3202,9 @@ parsed as an assertion, write it as `(e : Assertion)`.
 ```lean
 -- SOLUTION
 theorem hoare_if1 (b : Bexp) (c : Com) (P Q : Assertion)
-    (htrue : {{ P ∧ b }} ~c {{ Q }})
+    (htrue : {{ P ∧ b }} c {{ Q }})
     (hfalse : ({{ P ∧ ¬ b }}) ->> Q) :
-    {{ P }} if1 (~b) { ~c } {{ Q }} := by
+    {{ P }} if1 (b) { c } {{ Q }} := by
   rw [validHoareTriple_def] at htrue ⊢
   intro st st' heval hpre
   inversion heval with
@@ -3235,14 +3238,14 @@ type.
 
 ```lean
 theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   exact hhoare heval (himp st hpre)
 
 theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
-    {{Q [x ↦ ~a]}} x := ~a {{ Q }} := by
+    {{Q [x ↦ a]}} x := a {{ Q }} := by
   rw [validHoareTriple_def]
   intro st st' heval hQ
   rw [Assertion.subst_apply] at hQ
@@ -3380,8 +3383,8 @@ We need to explain the `generalize` tactic.
 
 ```lean
 theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
-    (hhoare : {{P ∧ b}} ~c {{ P }}) :
-    {{ P }} while (~b) { ~c } {{P ∧ ¬ b}} := by
+    (hhoare : {{P ∧ b}} c {{ P }}) :
+    {{ P }} while (b) { c } {{P ∧ ¬ b}} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   /- We proceed by induction on `heval`, because, in the "keep
@@ -3390,7 +3393,7 @@ theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
   arbitrary command, together with an equation remembering that the
   command is the original loop. The cases for commands other than
   `while` are dismissed because their equations are contradictory. -/
-  generalize heq : (imp { while (~b) { ~c } }) = cmd at heval
+  generalize heq : (imp { while (b) { c } }) = cmd at heval
   induction heval with
   | @whileFalse b0 s0 c0 hb =>
     injection heq with hbeq hceq
@@ -3419,7 +3422,7 @@ a previous draft included a discussion that explicitly placed {{ P }}
 before the while, perhaps along the lines of "a loop invariant P of
 [while b do c end] is also an invariant of [while b do c end]" (which
 is, FWIW, a (somewhat obtuse) way of stating a weaker variant of
-hoare_while, without the ~b in the postcondition). Combined with the
+hoare_while, without the b in the postcondition). Combined with the
 fact that it is supposed to justify a somewhat surprising and
 unexpected fact — [X = 0] is not what I would intuitively consider an
 invariant of this loop — this sentence ends up being quite confusing.
@@ -3737,7 +3740,7 @@ second case, the fact that this loop does not terminate),
 rather than using the while rule. -/
 /- LATER: Point out the trick using intros to do the splitting. -/
 theorem never_loop_hoare (P : Assertion) (c : Com) :
-    {{ P }} while (false) { ~c } {{ P }} := by
+    {{ P }} while (false) { c } {{ P }} := by
   apply hoare_consequence_post
   · apply hoare_while
     -- loop body preserves loop invariant
@@ -3980,7 +3983,7 @@ open Lean in
 scoped macro_rules
   | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
-    else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
+    else pure x
   | `(imp { $c1; $c2 }) =>
     `(Com.seq (imp {$c1}) (imp {$c2}))
   | `(imp { $x:ident := $a }) =>
@@ -4009,30 +4012,30 @@ inductive Com.EvalR : Com → State → State → Prop where
   | skip {st : State} :
       EvalR (imp {skip}) st st
   | asgn {st : State} (a : Aexp) {n : Nat} (x : Ident) (h : a.eval st = n) :
-      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
+      EvalR (imp {x := a}) st (x →ₜ n ; st)
   | seq {c1 c2 : Com} (st st' st'' : State)
       (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
-      EvalR (imp {~c1; ~c2}) st st''
+      EvalR (imp {c1; c2}) st st''
   | ifTrue {st st' : State} (b : Bexp) {c1 c2 : Com} (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (b) {c1} else {c2} }) st st'
   | ifFalse {st st' : State} (b : Bexp) {c1 c2 : Com} (hb : b.eval st = false)
       (hc : EvalR c2 st st') :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (b) {c1} else {c2} }) st st'
   | whileFalse {b : Bexp} (st : State) (c : Com) (hb : b.eval st = false) :
-      EvalR (imp {while (~b) {~c} }) st st
+      EvalR (imp {while (b) {c} }) st st
   | whileTrue {st st' st'' : State} {b : Bexp} {c : Com}
       (hb : b.eval st = true) (hc : EvalR c st st')
-      (hloop : EvalR (imp {while (~b) {~c} }) st' st'') :
-      EvalR (imp {while (~b) {~c} }) st st''
+      (hloop : EvalR (imp {while (b) {c} }) st' st'') :
+      EvalR (imp {while (b) {c} }) st st''
 -- SOLUTION
   | repeatEnd {st st' : State} {b : Bexp} {c : Com} (hc : EvalR c st st')
       (hb : b.eval st' = true) :
-      EvalR (imp {repeat {~c} until (~b) }) st st'
+      EvalR (imp {repeat {c} until (b) }) st st'
   | repeatLoop {st st' st'' : State} {b : Bexp} {c : Com}
       (hc : EvalR c st st') (hb : b.eval st' = false)
-      (hloop : EvalR (imp {repeat {~c} until (~b) }) st' st'') :
-      EvalR (imp {repeat {~c} until (~b) }) st st''
+      (hloop : EvalR (imp {repeat {c} until (b) }) st' st'') :
+      EvalR (imp {repeat {c} until (b) }) st st''
 -- END SOLUTION
 
 instance : HasEval Com State State where
@@ -4054,7 +4057,7 @@ new `Com.EvalR`.
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
   ∀ {st st' : State},
-    (st =[ ~c ]=> st') →
+    (st =[ c ]=> st') →
     P st →
     Q st'
 
@@ -4062,8 +4065,8 @@ instance : HasTriple Com where
   Triple := ValidHoareTriple
 
 theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
-    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
-      (st =[ ~c ]=> st') →
+    {{ P }} c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
       P st →
       Q st' := by rfl
 
@@ -4083,7 +4086,7 @@ def ex1_repeat : Com :=
   }
 
 theorem ex1_repeat_works :
-    ∅ =[ ~ex1_repeat ]=> (Y →ₜ 1 ; X →ₜ 1) := by
+    ∅ =[ ex1_repeat ]=> (Y →ₜ 1 ; X →ₜ 1) := by
   solution!
     apply Com.EvalR.repeatEnd
     · apply Com.EvalR.seq
@@ -4110,11 +4113,11 @@ programs, when we get to that, because it uses c twice, perhaps in
 different ways! -/
 
 theorem hoare_repeat {P Q : Assertion} {b : Bexp} {c : Com}
-    (h1 : {{ P }} ~c {{ Q }}) (h2 : {{ Q ∧ ¬ b }} ~c {{ Q }}) :
-    {{ P }} repeat { ~c } until (~b) {{ Q ∧ b }} := by
+    (h1 : {{ P }} c {{ Q }}) (h2 : {{ Q ∧ ¬ b }} c {{ Q }}) :
+    {{ P }} repeat { c } until (b) {{ Q ∧ b }} := by
   rw [validHoareTriple_def] at h1 h2 ⊢
   intro st st' heval hpre
-  generalize heq : (imp { repeat { ~c } until (~b) }) = cmd at heval
+  generalize heq : (imp { repeat { c } until (b) }) = cmd at heval
   induction heval generalizing P with
   | @repeatEnd s0 s0' b0 c0 hc hb ih =>
     injection heq with hceq hbeq
@@ -4177,7 +4180,7 @@ the proofs of some more Hoare rules from above (remember we're in
 a separate namespace, with a different definition of commands). -/
 
 theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
-    {{Q [x ↦ ~a]}} x := ~a {{ Q }} := by
+    {{Q [x ↦ a]}} x := a {{ Q }} := by
   rw [validHoareTriple_def]
   intro st st' hE hQ
   rw [Assertion.subst_apply] at hQ
@@ -4187,22 +4190,22 @@ theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
     exact hQ
 
 theorem hoare_consequence {P P' Q Q' : Assertion} {c : Com}
-    (hht : {{ P' }} ~c {{ Q' }}) (hPP' : P ->> P') (hQ'Q : Q' ->> Q) :
-    {{ P }} ~c {{ Q }} := by
+    (hht : {{ P' }} c {{ Q' }}) (hPP' : P ->> P') (hQ'Q : Q' ->> Q) :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hht ⊢
   intro st st' hc hP
   apply_rules
 
 theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' hc hP
   apply_rules
 
 theorem hoare_seq {P Q R : Assertion} {c1 c2 : Com}
-    (h1 : {{ Q }} ~c2 {{R}}) (h2 : {{ P }} ~c1 {{ Q }}) :
-    {{ P }} ~c1; ~c2 {{R}} := by
+    (h1 : {{ Q }} c2 {{R}}) (h2 : {{ P }} c1 {{ Q }}) :
+    {{ P }} c1; c2 {{R}} := by
   rw [validHoareTriple_def] at h1 h2 ⊢
   intro st st' h12 pre
   inversion h12 with
@@ -4222,7 +4225,7 @@ it's especially noticable here that an explicit state is given to
 the conditional statements. -/
 theorem ex2_repeat_hoare_repeat :
     {{ X > 0 }}
-      ~ex2_repeat
+      ex2_repeat
     {{ X = 0 ∧ Y > 0 }} := by
   rw [ex2_repeat]
   apply hoare_consequence
@@ -4242,12 +4245,12 @@ like this: -/
 /- NOTATION: Here, too, the printing isn't as we write the notation.
 (As soon as we start the proof context). Is this intended? -/
 theorem hoare_repeat' (P : Assertion) (b : Bexp) (c : Com)
-    (h : {{ P }} ~c {{ P }}) :
-    {{ P }} repeat { ~c } until (~b) {{ P ∧ b }} := by
+    (h : {{ P }} c {{ P }}) :
+    {{ P }} repeat { c } until (b) {{ P ∧ b }} := by
   rw [validHoareTriple_def]
   intro st st' he hP
-  have key : ∀ (cmd : Com) (s s' : State), (s =[ ~cmd ]=> s') →
-      cmd = (imp { repeat { ~c } until (~b) }) → P s →
+  have key : ∀ (cmd : Com) (s s' : State), (s =[ cmd ]=> s') →
+      cmd = (imp { repeat { c } until (b) }) → P s →
       P s' ∧ b.eval s' := by
     intro cmd s s' hev
     induction hev with
@@ -4277,12 +4280,12 @@ theorem hoare_repeat' (P : Assertion) (b : Bexp) (c : Com)
 
 theorem hoare_repeat_implies_hoare_repeat'
     (hoare_repeat : ∀ (P Q : Assertion) (b : Bexp) (c : Com),
-      ({{ P }} ~c {{ Q }}) →
-      ({{ Q ∧ ¬ b }} ~c {{ Q }}) →
-      {{ P }} repeat { ~c } until (~b) {{ Q ∧ b }}) :
+      ({{ P }} c {{ Q }}) →
+      ({{ Q ∧ ¬ b }} c {{ Q }}) →
+      {{ P }} repeat { c } until (b) {{ Q ∧ b }}) :
     ∀ (P : Assertion) (b : Bexp) (c : Com),
-      ({{ P }} ~c {{ P }}) →
-      {{ P }} repeat { ~c } until (~b) {{ P ∧ b }} := by
+      ({{ P }} c {{ P }}) →
+      {{ P }} repeat { c } until (b) {{ P ∧ b }} := by
   intro P b c h
   apply hoare_repeat <;> try assumption
   apply hoare_consequence_pre
@@ -4305,7 +4308,7 @@ failed proof attempt. -/
 #guard_msgs in
 example :
     {{ X > 0 ∧ Y > 0}}
-      ~ex2_repeat
+      ex2_repeat
     {{ X = 0 ∧ Y > 0}} := by
   apply hoare_consequence
   · apply hoare_repeat' (P := {{ Y > 0 }})
@@ -4330,7 +4333,7 @@ it is too strong. -/
 #guard_msgs in
 example :
     {{ X > 0 ∧ Y > 0}}
-      ~ex2_repeat
+      ex2_repeat
     {{ X = 0 ∧ Y > 0}} := by
   apply hoare_consequence
   · apply hoare_repeat' (P := {{ X > 0 ∧ Y > 0 }})
@@ -4465,7 +4468,7 @@ open Lean in
 scoped macro_rules
   | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
-    else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
+    else pure x
   | `(imp { $c1; $c2 }) =>
     `(Com.seq (imp {$c1}) (imp {$c2}))
   | `(imp { $x:ident := $a }) =>
@@ -4484,22 +4487,22 @@ inductive Com.EvalR : Com → State → State → Prop where
   | skip {st : State} :
       EvalR (imp {skip}) st st
   | asgn {st : State} {a : Aexp} {n : Nat} {x : Ident} (h : a.eval st = n) :
-      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
+      EvalR (imp {x := a}) st (x →ₜ n ; st)
   | seq {c1 c2 : Com} {st st' st'' : State}
       (h1 : EvalR c1 st st') (h2 : EvalR c2 st' st'') :
-      EvalR (imp {~c1; ~c2}) st st''
+      EvalR (imp {c1; c2}) st st''
   | ifTrue {st st' : State} {b : Bexp} {c1 c2 : Com} (hb : b.eval st = true)
       (hc : EvalR c1 st st') :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (b) {c1} else {c2} }) st st'
   | ifFalse {st st' : State} {b : Bexp} {c1 c2 : Com} (hb : b.eval st = false)
       (hc : EvalR c2 st st') :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st st'
+      EvalR (imp {if (b) {c1} else {c2} }) st st'
   | whileFalse {b : Bexp} {st : State} {c : Com} (hb : b.eval st = false) :
-      EvalR (imp {while (~b) {~c} }) st st
+      EvalR (imp {while (b) {c} }) st st
   | whileTrue {st st' st'' : State} {b : Bexp} {c : Com}
       (hb : b.eval st = true) (hc : EvalR c st st')
-      (hloop : EvalR (imp {while (~b) {~c} }) st' st'') :
-      EvalR (imp {while (~b) {~c} }) st st''
+      (hloop : EvalR (imp {while (b) {c} }) st' st'') :
+      EvalR (imp {while (b) {c} }) st st''
   | havoc {st : State} {x : Ident} {n : Nat} :
       EvalR (imp {havoc x}) st (x →ₜ n ; st)
 
@@ -4518,7 +4521,7 @@ The definition of Hoare triples is exactly as before.
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
   ∀ {st st' : State},
-    (st =[ ~c ]=> st') →
+    (st =[ c ]=> st') →
     P st →
     Q st'
 
@@ -4526,8 +4529,8 @@ instance : HasTriple Com where
   Triple := ValidHoareTriple
 
 theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
-    {{ P }} ~c {{ Q }} ↔ ∀ {st st' : State},
-      (st =[ ~c ]=> st') →
+    {{ P }} c {{ Q }} ↔ ∀ {st st' : State},
+      (st =[ c ]=> st') →
       P st →
       Q st' := by rfl
 
@@ -4538,8 +4541,8 @@ And the precondition consequence rule is exactly as before.
 
 ```lean
 theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st st' heval hpre
   apply_rules
@@ -4685,7 +4688,7 @@ open Lean in
 scoped macro_rules
   | `(imp { $x:ident }) =>
     if x.getId == `skip then `(Com.skip)
-    else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
+    else pure x
   | `(imp { $h:ident ($b) }) =>
     if h.getId == `assert then `(Com.assert (bexp {$b}))
     else if h.getId == `assume then `(Com.assume (bexp {$b}))
@@ -4727,34 +4730,34 @@ inductive Com.EvalR : Com → State → Result → Prop where
   | skip {st : State} :
       EvalR (imp {skip}) st (.normal st)
   | asgn {st : State} {a : Aexp} {n : Nat} {x : Ident} (h : a.eval st = n) :
-      EvalR (imp {x := ~a}) st (.normal (x →ₜ n ; st))
+      EvalR (imp {x := a}) st (.normal (x →ₜ n ; st))
   | seqNormal {c1 c2 : Com} {st st' : State} {r : Result}
       (h1 : EvalR c1 st (.normal st')) (h2 : EvalR c2 st' r) :
-      EvalR (imp {~c1; ~c2}) st r
+      EvalR (imp {c1; c2}) st r
   | seqError {c1 c2 : Com} {st : State} (h : EvalR c1 st .error) :
-      EvalR (imp {~c1; ~c2}) st .error
+      EvalR (imp {c1; c2}) st .error
   | ifTrue {st : State} {r : Result} {b : Bexp} {c1 c2 : Com}
       (hb : b.eval st = true) (hc : EvalR c1 st r) :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st r
+      EvalR (imp {if (b) {c1} else {c2} }) st r
   | ifFalse {st : State} {r : Result} {b : Bexp} {c1 c2 : Com}
       (hb : b.eval st = false) (hc : EvalR c2 st r) :
-      EvalR (imp {if (~b) {~c1} else {~c2} }) st r
+      EvalR (imp {if (b) {c1} else {c2} }) st r
   | whileFalse {b : Bexp} {st : State} {c : Com} (hb : b.eval st = false) :
-      EvalR (imp {while (~b) {~c} }) st (.normal st)
+      EvalR (imp {while (b) {c} }) st (.normal st)
   | whileTrueNormal {st st' : State} {r : Result} {b : Bexp} {c : Com}
       (hb : b.eval st = true) (hc : EvalR c st (.normal st'))
-      (hloop : EvalR (imp {while (~b) {~c} }) st' r) :
-      EvalR (imp {while (~b) {~c} }) st r
+      (hloop : EvalR (imp {while (b) {c} }) st' r) :
+      EvalR (imp {while (b) {c} }) st r
   | whileTrueError {st : State} {b : Bexp} {c : Com}
       (hb : b.eval st = true) (hc : EvalR c st .error) :
-      EvalR (imp {while (~b) {~c} }) st .error
+      EvalR (imp {while (b) {c} }) st .error
   /- Rules for Assert and Assume -/
   | assertTrue {st : State} {b : Bexp} (hb : b.eval st = true) :
-      EvalR (imp {assert (~b)}) st (.normal st)
+      EvalR (imp {assert (b)}) st (.normal st)
   | assertFalse {st : State} {b : Bexp} (hb : b.eval st = false) :
-      EvalR (imp {assert (~b)}) st .error
+      EvalR (imp {assert (b)}) st .error
   | assume {st : State} {b : Bexp} (hb : b.eval st = true) :
-      EvalR (imp {assume (~b)}) st (.normal st)
+      EvalR (imp {assume (b)}) st (.normal st)
 
 instance : HasEval Com State Result where
   Eval := Com.EvalR
@@ -4774,15 +4777,15 @@ satisfies `Q`.
 def ValidHoareTriple
     (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
   ∀ {st : State} {r : Result},
-    (st =[ ~c ]=> r) → P st →
+    (st =[ c ]=> r) → P st →
     ∃ st', r = Result.normal st' ∧ Q st'
 
 instance : HasTriple Com where
   Triple := ValidHoareTriple
 
 theorem validHoareTriple_def {P : Assertion} {c : Com} {Q : Assertion} :
-    {{ P }} ~c {{ Q }} ↔ ∀ {st : State} {r : Result},
-      (st =[ ~c ]=> r) → P st →
+    {{ P }} c {{ Q }} ↔ ∀ {st : State} {r : Result},
+      (st =[ c ]=> r) → P st →
       ∃ st', r = Result.normal st' ∧ Q st' := by rfl
 
 attribute [irreducible] ValidHoareTriple
@@ -4805,8 +4808,8 @@ statement but not by the `assert` statement.
 
 ```lean
 theorem assert_assume_differ : ∃ (P : Assertion) (b : Bexp) (Q : Assertion),
-    ({{ P }} assume (~b) {{ Q }})
-    ∧ ¬ ({{ P }} assert (~b) {{ Q }}) := by
+    ({{ P }} assume (b) {{ Q }})
+    ∧ ¬ ({{ P }} assert (b) {{ Q }}) := by
   solution!
     exists {{ True }}, bexp { false }, ({{ False }})
     constructor
@@ -4836,15 +4839,15 @@ Then prove that any triple for an `assert` also works when
 
 ```lean
 theorem assert_implies_assume (P : Assertion) (b : Bexp) (Q : Assertion)
-    (hhoare : {{ P }} assert (~b) {{ Q }}) :
-    {{ P }} assume (~b) {{ Q }} := by
+    (hhoare : {{ P }} assert (b) {{ Q }}) :
+    {{ P }} assume (b) {{ Q }} := by
   solution!
     rw [validHoareTriple_def] at hhoare ⊢
     intro st r heval hpre
     inversion heval with
     | assume hb =>
       exists st
-      have h : st =[ assert (~b) ]=> Result.normal st := by
+      have h : st =[ assert (b) ]=> Result.normal st := by
         apply Com.EvalR.assertTrue
         assumption
       obtain ⟨st', h1, h2⟩ := hhoare h hpre
@@ -4864,7 +4867,7 @@ semantics.  You don't need to do anything with these.
 
 ```lean
 theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
-    {{Q [x ↦ ~a]}} x := ~a {{ Q }} := by
+    {{Q [x ↦ a]}} x := a {{ Q }} := by
   rw [validHoareTriple_def]
   intro st r heval hQ
   rw [Assertion.subst_apply] at hQ
@@ -4875,8 +4878,8 @@ theorem hoare_asgn {Q : Assertion} {x : Ident} {a : Aexp} :
     exact ⟨rfl, hQ⟩
 
 theorem hoare_consequence_pre {P P' Q : Assertion} {c : Com}
-    (hhoare : {{ P' }} ~c {{ Q }}) (himp : P ->> P') :
-    {{ P }} ~c {{ Q }} := by
+    (hhoare : {{ P' }} c {{ Q }}) (himp : P ->> P') :
+    {{ P }} c {{ Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st r hc hpre
   apply_rules
@@ -4888,8 +4891,8 @@ These proofs are a bit messy. Can it be made shorter?
 
 ```lean
 theorem hoare_consequence_post {P Q Q' : Assertion} {c : Com}
-    (hhoare : {{ P }} ~c {{ Q' }}) (himp : Q' ->> Q) :
-    {{ P }} ~c {{   Q }} := by
+    (hhoare : {{ P }} c {{ Q' }}) (himp : Q' ->> Q) :
+    {{ P }} c {{   Q }} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st r hc hpre
   obtain ⟨st', hr, hQ'⟩ := hhoare hc hpre
@@ -4897,8 +4900,8 @@ theorem hoare_consequence_post {P Q Q' : Assertion} {c : Com}
   exact ⟨hr, himp _ hQ'⟩
 
 theorem hoare_seq {P Q R : Assertion} {c1 c2 : Com}
-    (h1 : {{ Q }} ~c2 {{R}}) (h2 : {{ P }} ~c1 {{ Q }}) :
-    {{ P }} ~c1; ~c2 {{R}} := by
+    (h1 : {{ Q }} c2 {{R}}) (h2 : {{ P }} c1 {{ Q }}) :
+    {{ P }} c1; c2 {{R}} := by
   rw [validHoareTriple_def] at h1 h2 ⊢
   intro st r h12 hpre
   inversion h12 with
@@ -4934,8 +4937,8 @@ theorem hoare_skip {P : Assertion} :
   exact ⟨st, rfl, hpre⟩
 
 theorem hoare_if {P Q : Assertion} {b : Bexp} {c1 c2 : Com}
-    (hTrue : {{ P ∧ b}} ~c1 {{ Q }}) (hFalse : {{ P ∧ ¬ b}} ~c2 {{ Q }}) :
-    {{ P }} if (~b) { ~c1 } else { ~c2 } {{ Q }} := by
+    (hTrue : {{ P ∧ b}} c1 {{ Q }}) (hFalse : {{ P ∧ ¬ b}} c2 {{ Q }}) :
+    {{ P }} if (b) { c1 } else { c2 } {{ Q }} := by
   rw [validHoareTriple_def] at hTrue hFalse ⊢
   intro st r hE hpre
   inversion hE with
@@ -4948,11 +4951,11 @@ theorem hoare_if {P Q : Assertion} {b : Bexp} {c1 c2 : Com}
     exact ⟨hpre, by simp [hb]⟩
 
 theorem hoare_while {P : Assertion} {b : Bexp} {c : Com}
-    (hhoare : {{P ∧ b}} ~c {{ P }}) :
-    {{ P }} while (~b) { ~c } {{ P ∧ ¬ b}} := by
+    (hhoare : {{P ∧ b}} c {{ P }}) :
+    {{ P }} while (b) { c } {{ P ∧ ¬ b}} := by
   rw [validHoareTriple_def] at hhoare ⊢
   intro st r heval hpre
-  generalize heq : (imp { while (~b) { ~c } }) = cmd at heval
+  generalize heq : (imp { while (b) { c } }) = cmd at heval
   induction heval generalizing P with
   | @whileFalse b0 s0 c0 hb =>
     injection heq with hbeq hceq
@@ -4987,7 +4990,7 @@ and `hoare_assume`.
 /- HIDE: Equivalently, we could make the postcondition Q ∧ b or the
 precondition Q → b ... -/
 theorem hoare_assert {Q : Assertion} {b : Bexp} :
-    {{Q ∧ b}} assert (~b) {{ Q }} := by
+    {{Q ∧ b}} assert (b) {{ Q }} := by
   rw [validHoareTriple_def]
   intro st r heval hpre
   obtain ⟨hst, hb⟩ := hpre
@@ -4999,7 +5002,7 @@ theorem hoare_assert {Q : Assertion} {b : Bexp} :
 /- Stating this in a backwards-direction friendly way. -/
 /- HIDE: Equivalently, we could make the postcondition Q ∧ b... -/
 theorem hoare_assume {Q : Assertion} {b : Bexp} :
-    {{ b → Q }} assume (~b) {{ Q }} := by
+    {{ b → Q }} assume (b) {{ Q }} := by
   rw [validHoareTriple_def]
   intro st r heval hpre
   exists st

--- a/HL/Hoare2.lean
+++ b/HL/Hoare2.lean
@@ -765,7 +765,7 @@ def reduceToZero : Com :=
 
 ```lean
 theorem reduce_to_zero_correct' :
-    {{ True }} ~reduceToZero {{ X = 0 }} := by
+    {{ True }} reduceToZero {{ X = 0 }} := by
   -- First put the postcondition into the form expected by
   -- the while rule.
   sorry
@@ -810,7 +810,7 @@ This makes it pretty easy to verify `reduce_to_zero`:
 
 ```lean
 theorem reduce_to_zero_correct''' :
-    {{ True }} ~reduceToZero {{ X = 0 }} := by
+    {{ True }} reduceToZero {{ X = 0 }} := by
   sorry
 ```
 
@@ -1030,14 +1030,14 @@ declare_syntax_cat dcom
 syntax:max "(" dcom ")" : dcom
 syntax:max "skip" " {{" term "}}" : dcom
 syntax:max ident " := " imp_aexp " {{" term "}}" : dcom
-syntax:20 dcom:21 ";" ppLine dcom:20 : dcom
+syntax:20 dcom:21 ";" ppDedent(ppLine dcom:20) : dcom
 syntax:max "if " "(" imp_bexp ")" ppHardSpace "then" ppLine
-  "{{" term "}}" ppLine dcom ppLine
-  "else" ppLine "{{" term "}}" ppLine dcom ppLine
-  "end" ppLine "{{" term "}}" : dcom
+  "{{" term "}}" ppLine dcom ppDedent(ppLine "else") ppLine
+  "{{" term "}}" ppLine dcom ppDedent(ppLine "end") ppLine
+  "{{" term "}}" : dcom
 syntax:max "while " "(" imp_bexp ")" ppHardSpace "do" ppLine
-  "{{" term "}}" ppLine dcom ppLine
-  "end" ppLine "{{" term "}}" : dcom
+  "{{" term "}}" ppLine dcom ppDedent(ppLine "end") ppLine
+  "{{" term "}}" : dcom
 syntax:5 "->>" " {{" term "}}" ppLine dcom:0 : dcom
 syntax:5 dcom:6 ppLine "->>" " {{" term "}}" : dcom
 
@@ -1045,43 +1045,200 @@ syntax:min "dcom" ppHardSpace "{" ppLine dcom
   ppDedent(ppLine "}") : term
 
 macro_rules
-  | `(dcom { ($body:dcom) }) =>
-      `(dcom { $body })
-  | `(dcom { skip {{ $q }} }) =>
-      `(DCom.skip ({{ $q }}))
-  | `(dcom { $x:ident := $a:imp_aexp {{ $q }} }) =>
-      `(DCom.asgn $x (aexp { $a }) ({{ $q }}))
-  | `(dcom { $d1:dcom; $d2:dcom }) =>
-      `(DCom.seq (dcom { $d1 }) (dcom { $d2 }))
-  | `(dcom {
-        if ($b:imp_bexp) then
-          {{ $p1 }}
-          $d1:dcom
+  | `(dcom { $s }) => do
+    let stx ← match s with
+      | `(dcom| ($body:dcom)) => `(dcom { $body })
+      | `(dcom| skip {{ $q }}) => `(DCom.skip ({{ $q }}))
+      | `(dcom| $x:ident := $a:imp_aexp {{ $q }}) =>
+        `(DCom.asgn $x (aexp { $a }) ({{ $q }}))
+      | `(dcom| $d1:dcom; $d2:dcom) =>
+        `(DCom.seq (dcom { $d1 }) (dcom { $d2 }))
+      | `(dcom|
+          if ($b:imp_bexp) then
+            {{ $p1 }}
+            $d1:dcom
+          else
+            {{ $p2 }}
+            $d2:dcom
+          end
+            {{ $q }}) =>
+        `(DCom.cond (bexp { $b })
+          ({{ $p1 }}) (dcom { $d1 })
+          ({{ $p2 }}) (dcom { $d2 })
+          ({{ $q }}))
+      | `(dcom|
+          while ($b:imp_bexp) do
+            {{ $p }}
+            $body:dcom
+          end
+            {{ $q }}) =>
+        `(DCom.whileDo (bexp { $b }) ({{ $p }})
+          (dcom { $body }) ({{ $q }}))
+      | `(dcom| ->> {{ $p }} $body:dcom) =>
+        `(DCom.pre ({{ $p }}) (dcom { $body }))
+      | `(dcom| $body:dcom ->> {{ $q }}) =>
+        `(DCom.post (dcom { $body }) ({{ $q }}))
+      | _ => Lean.Macro.throwUnsupported
+    return Imp.Elab.withSourceInfoOf s stx
+
+namespace DCom.Delab
+
+open Lean PrettyPrinter Delaborator SubExpr Parenthesizer Imp.Elab Imp.Delab
+
+@[category_parenthesizer «dcom»]
+def dcom.parenthesizer : CategoryParenthesizer := fun prec => do
+  maybeParenthesize `dcom false wrapParens prec <|
+    parenthesizeCategoryCore `dcom prec
+where
+  wrapParens (stx : Syntax) : Syntax := Unhygienic.run do
+    let stxInfo := SourceInfo.fromRef stx
+    let stx := stx.setInfo .none
+    let pstx ← `(dcom| ($(⟨stx⟩)))
+    return pstx.raw.setInfo stxInfo
+
+def getAssnBody (stx : Term) : Term :=
+  withSourceInfoOf (canonical := false) stx <| Unhygienic.run do
+    match stx with
+    | `({{ $P }}) => return P
+    | _ => return stx
+
+private def getDCom? (stx : Term) : Option (TSyntax `dcom) :=
+  match stx with
+  | `(dcom { $d:dcom }) => some <| withSourceInfoOf (canonical := false) stx d
+  | _ => none
+
+@[app_unexpander DCom.skip]
+def unexpandSkip : Unexpander
+  | `($_ $q) => `(dcom { skip {{ $(getAssnBody q) }} })
+  | _ => throw ()
+
+@[app_unexpander DCom.asgn]
+def unexpandAsgn : Unexpander
+  | `($_ $x:ident $a $q) =>
+      `(dcom { $x:ident := $(getAexp a) {{ $(getAssnBody q) }} })
+  | _ => throw ()
+
+@[app_unexpander DCom.seq]
+def unexpandSeq : Unexpander
+  | `($_ $first $second) => do
+      let some first := getDCom? first | throw ()
+      let some second := getDCom? second | throw ()
+      `(dcom { $first; $second })
+  | _ => throw ()
+
+@[app_unexpander DCom.cond]
+def unexpandCond : Unexpander
+  | `($_ $b $thenPre $thenBranch $elsePre $elseBranch $post) => do
+      let some thenBranch := getDCom? thenBranch | throw ()
+      let some elseBranch := getDCom? elseBranch | throw ()
+      `(dcom {
+        if ($(getBexp b)) then
+          {{ $(getAssnBody thenPre) }}
+          $thenBranch
         else
-          {{ $p2 }}
-          $d2:dcom
+          {{ $(getAssnBody elsePre) }}
+          $elseBranch
         end
-          {{ $q }}
-      }) =>
-      `(DCom.cond (bexp { $b })
-        ({{ $p1 }}) (dcom { $d1 })
-        ({{ $p2 }}) (dcom { $d2 })
-        ({{ $q }}))
-  | `(dcom {
-        while ($b:imp_bexp) do
-          {{ $p }}
-          $body:dcom
+          {{ $(getAssnBody post) }}
+      })
+  | _ => throw ()
+
+@[app_unexpander DCom.whileDo]
+def unexpandWhileDo : Unexpander
+  | `($_ $b $bodyPre $body $post) => do
+      let some body := getDCom? body | throw ()
+      `(dcom {
+        while ($(getBexp b)) do
+          {{ $(getAssnBody bodyPre) }}
+          $body
         end
-          {{ $q }}
-      }) =>
-      `(DCom.whileDo (bexp { $b }) ({{ $p }})
-        (dcom { $body }) ({{ $q }}))
-  | `(dcom { ->> {{ $p }} $body:dcom }) =>
-      `(DCom.pre ({{ $p }}) (dcom { $body }))
-  | `(dcom { $body:dcom ->> {{ $q }} }) =>
-      `(DCom.post (dcom { $body }) ({{ $q }}))
+          {{ $(getAssnBody post) }}
+      })
+  | _ => throw ()
+
+@[app_unexpander DCom.pre]
+def unexpandPre : Unexpander
+  | `($_ $pre $body) => do
+      let some body := getDCom? body | throw ()
+      `(dcom { ->> {{ $(getAssnBody pre) }} $body })
+  | _ => throw ()
+
+@[app_unexpander DCom.post]
+def unexpandPost : Unexpander
+  | `($_ $body $post) => do
+      let some body := getDCom? body | throw ()
+      `(dcom { $body ->> {{ $(getAssnBody post) }} })
+  | _ => throw ()
+
+end DCom.Delab
 ```
 ::::
+
+:::ignore
+```lean -show
+/-- info: dcom {
+  ->> {{True}}
+    if (X ≤ Y) then
+          {{X ≤ Y}}
+          skip {{True}}
+        else
+          {{X > Y}}
+          X := Y + 1 {{True}}
+        end
+          {{True}};
+      while (X ≠ 0) do
+        {{True}}
+        X := X - 1 {{True}}
+      end
+        {{X = 0}}
+      ->> {{X = 0}}
+} : DCom -/
+#guard_msgs in
+#check DCom.pre ({{ True }}) <|
+  DCom.post
+    (DCom.seq
+      (DCom.cond (bexp {X ≤ Y}) ({{ X ≤ Y }})
+        (DCom.skip ({{ True }})) ({{ X > Y }})
+        (DCom.asgn X (aexp {Y + 1}) ({{ True }})) ({{ True }}))
+      (DCom.whileDo (bexp {X ≠ 0}) ({{ True }})
+        (DCom.asgn X (aexp {X - 1}) ({{ True }})) ({{ X = 0 }})))
+    ({{ X = 0 }})
+
+/-- info: dcom {
+  ((->> {{True}}
+            skip {{True}})
+        ->> {{False}});
+  (->> {{False}}
+      skip {{False}})
+} : DCom -/
+#guard_msgs in
+#check DCom.seq
+  (DCom.post (DCom.pre ({{ True }}) (DCom.skip ({{ True }}))) ({{ False }}))
+  (DCom.pre ({{ False }}) (DCom.skip ({{ False }})))
+
+/-- info: dcom {
+  skip {{True}};
+  skip {{False}}
+} : DCom -/
+#guard_msgs in
+#check DCom.seq (DCom.skip ({{ True }})) (DCom.skip ({{ False }}))
+
+/-- info: dcom {
+  if (X ≤ Y) then
+    {{True}}
+    skip {{True}}
+  else
+    {{False}}
+    skip {{False}}
+  end
+    {{True}}
+} : DCom -/
+#guard_msgs in
+#check DCom.cond (bexp {X ≤ Y}) ({{ True }})
+  (DCom.skip ({{ True }})) ({{ False }})
+  (DCom.skip ({{ False }})) ({{ True }})
+```
+:::
 
 ::::terse
 (We then need to redefine all our Notations to get nice
@@ -1353,7 +1510,7 @@ is locally consistent with respect to precondition `P` if
 
    (1) `P /\ b ->> P1`
 
-   (2) `P /\ ~b ->> P2`
+   (2) `P /\ b ->> P2`
 
    (3) `d1` is locally consistent with respect to `P1`
 
@@ -1378,7 +1535,7 @@ is locally consistent with respect to precondition `P` if:
 
    (2) `d.postcondition /\ b ->> Q`
 
-   (3) `d.postcondition /\ ~b ->> R`
+   (3) `d.postcondition /\ b ->> R`
 
    (4) `d` is locally consistent with respect to `Q`
 
@@ -1445,7 +1602,7 @@ def DCom.VerificationConditions
       d1.VerificationConditions P ∧
       d2.VerificationConditions d1.postcondition
   | .asgn x a Q =>
-      P ->> {{ Q [x ↦ ~a] }}
+      P ->> {{ Q [x ↦ a] }}
   | .cond b P1 d1 P2 d2 Q =>
       ({{ P ∧ b }} ->> P1) ∧
       ({{ P ∧ ¬ b }} ->> P2) ∧
@@ -3728,47 +3885,118 @@ declare_syntax_cat sparse_dcom
 syntax:max "(" sparse_dcom ")" : sparse_dcom
 syntax:max "skip" : sparse_dcom
 syntax:max ident " := " imp_aexp : sparse_dcom
-syntax:20 sparse_dcom:21 ";" ppLine
-  sparse_dcom:20 : sparse_dcom
-syntax:max "if " "(" imp_bexp ")" ppHardSpace "then" ppLine
-  sparse_dcom ppLine "else" ppLine sparse_dcom ppLine
-  "end" : sparse_dcom
-syntax:max "while " "(" imp_bexp ")" ppHardSpace "do" ppLine
-  "{{" term "}}" ppLine sparse_dcom ppLine
-  "end" : sparse_dcom
+syntax:20 sparse_dcom:21 ";" ppDedent(ppLine
+  sparse_dcom:20) : sparse_dcom
+syntax:max "if " "(" imp_bexp ")" ppHardSpace "then"
+  ppLine sparse_dcom ppDedent(ppLine ppDedent("else"))
+  ppLine sparse_dcom
+  ppDedent(ppLine ppDedent("end")) : sparse_dcom
+syntax:max "while " "(" imp_bexp ")" ppHardSpace "do"
+  ppLine "{{" term "}}" ppLine sparse_dcom
+  ppDedent(ppLine ppDedent("end")) : sparse_dcom
 syntax:max "assert" " {{" term "}}" : sparse_dcom
 
 syntax:min "sdcom" ppHardSpace "{" ppLine
   sparse_dcom ppDedent(ppLine "}") : term
 
 macro_rules
-  | `(sdcom { ($body:sparse_dcom) }) =>
-      `(sdcom { $body })
-  | `(sdcom { skip }) =>
-      `(DCom.skip)
-  | `(sdcom { $x:ident := $a:imp_aexp }) =>
-      `(DCom.asgn $x (aexp { $a }))
-  | `(sdcom { $d1:sparse_dcom; $d2:sparse_dcom }) =>
-      `(DCom.seq (sdcom { $d1 }) (sdcom { $d2 }))
-  | `(sdcom {
-        if ($b:imp_bexp) then
-          $d1:sparse_dcom
+  | `(sdcom { $s }) => do
+    let stx ← match s with
+      | `(sparse_dcom| ($body:sparse_dcom)) => `(sdcom { $body })
+      | `(sparse_dcom| skip) => `(DCom.skip)
+      | `(sparse_dcom| $x:ident := $a:imp_aexp) =>
+        `(DCom.asgn $x (aexp { $a }))
+      | `(sparse_dcom| $d1:sparse_dcom; $d2:sparse_dcom) =>
+        `(DCom.seq (sdcom { $d1 }) (sdcom { $d2 }))
+      | `(sparse_dcom|
+          if ($b:imp_bexp) then
+            $d1:sparse_dcom
+          else
+            $d2:sparse_dcom
+          end) =>
+        `(DCom.cond (bexp { $b })
+          (sdcom { $d1 }) (sdcom { $d2 }))
+      | `(sparse_dcom|
+          while ($b:imp_bexp) do
+            {{ $inv }}
+            $body:sparse_dcom
+          end) =>
+        `(DCom.whileDo (bexp { $b }) ({{ $inv }})
+          (sdcom { $body }))
+      | `(sparse_dcom| assert {{ $p }}) => `(DCom.assert ({{ $p }}))
+      | _ => Lean.Macro.throwUnsupported
+    return Imp.Elab.withSourceInfoOf s stx
+
+namespace DCom.Delab
+
+open Lean PrettyPrinter Delaborator SubExpr Parenthesizer Imp.Elab Imp.Delab
+
+@[category_parenthesizer «sparse_dcom»]
+def sparse_dcom.parenthesizer : CategoryParenthesizer := fun prec => do
+  maybeParenthesize `sparse_dcom false wrapParens prec <|
+    parenthesizeCategoryCore `sparse_dcom prec
+where
+  wrapParens (stx : Syntax) : Syntax := Unhygienic.run do
+    let stxInfo := SourceInfo.fromRef stx
+    let stx := stx.setInfo .none
+    let pstx ← `(sparse_dcom| ($(⟨stx⟩)))
+    return pstx.raw.setInfo stxInfo
+
+private def getDCom? (stx : Term) : Option (TSyntax `sparse_dcom) :=
+  match stx with
+  | `(sdcom { $d:sparse_dcom }) => some <| withSourceInfoOf (canonical := false) stx d
+  | _ => none
+
+@[app_delab SparseAnnotations.DCom.skip]
+def delabSkip : Delab := whenPPOption getPPNotation do
+  `(sdcom { skip })
+
+@[app_unexpander SparseAnnotations.DCom.asgn]
+def unexpandAsgn : Unexpander
+  | `($_ $x:ident $a) => `(sdcom { $x:ident := $(getAexp a) })
+  | _ => throw ()
+
+@[app_unexpander SparseAnnotations.DCom.seq]
+def unexpandSeq : Unexpander
+  | `($_ $first $second) => do
+      let some first := getDCom? first | throw ()
+      let some second := getDCom? second | throw ()
+      `(sdcom { $first; $second })
+  | _ => throw ()
+
+@[app_unexpander SparseAnnotations.DCom.cond]
+def unexpandCond : Unexpander
+  | `($_ $b $thenBranch $elseBranch) => do
+      let some thenBranch := getDCom? thenBranch | throw ()
+      let some elseBranch := getDCom? elseBranch | throw ()
+      `(sdcom {
+        if ($(getBexp b)) then
+          $thenBranch
         else
-          $d2:sparse_dcom
+          $elseBranch
         end
-      }) =>
-      `(DCom.cond (bexp { $b })
-        (sdcom { $d1 }) (sdcom { $d2 }))
-  | `(sdcom {
-        while ($b:imp_bexp) do
-          {{ $inv }}
-          $body:sparse_dcom
+      })
+  | _ => throw ()
+
+@[app_unexpander SparseAnnotations.DCom.whileDo]
+def unexpandWhileDo : Unexpander
+  | `($_ $b $invariant $body) => do
+      let some body := getDCom? body | throw ()
+      `(sdcom {
+        while ($(getBexp b)) do
+          {{ $(_root_.DCom.Delab.getAssnBody invariant) }}
+          $body
         end
-      }) =>
-      `(DCom.whileDo (bexp { $b }) ({{ $inv }})
-        (sdcom { $body }))
-  | `(sdcom { assert {{ $p }} }) =>
-      `(DCom.assert ({{ $p }}))
+      })
+  | _ => throw ()
+
+@[app_unexpander SparseAnnotations.DCom.assert]
+def unexpandAssert : Unexpander
+  | `($_ $assertion) =>
+      `(sdcom { assert {{ $(_root_.DCom.Delab.getAssnBody assertion) }} })
+  | _ => throw ()
+
+end DCom.Delab
 
 /- Here's how our decorated programs look now: -/
 
@@ -3808,7 +4036,7 @@ def DCom.awp (post : Assertion) (d : DCom) : Assertion :=
   match d with
   | .skip => post
   | .seq d1 d2 => d1.awp (d2.awp post)
-  | .asgn x a => {{ post [x ↦ ~a] }}
+  | .asgn x a => {{ post [x ↦ a] }}
   | .cond b d1 d2 =>
       fun st =>
         (b.eval st = true ∧ d1.awp post st) ∨
@@ -4093,6 +4321,64 @@ theorem dfib_correct (n : Nat) :
 
 end SparseAnnotations
 ```
+
+:::ignore
+```lean -show
+namespace SparseAnnotations
+
+/-- info: sdcom {
+  if (X ≤ Y) then
+      skip
+    else
+      X := Y + 1
+    end;
+  while (X ≠ 0) do
+      {{True}}
+      X := X - 1
+    end;
+  assert {{X = 0}}
+} : DCom -/
+#guard_msgs in
+#check DCom.seq
+  (DCom.cond (bexp {X ≤ Y}) DCom.skip (DCom.asgn X (aexp {Y + 1})))
+  (DCom.seq
+    (DCom.whileDo (bexp {X ≠ 0}) ({{ True }}) (DCom.asgn X (aexp {X - 1})))
+    (DCom.assert ({{ X = 0 }})))
+
+/-- info: sdcom {
+  (skip;
+      X := Y + 1);
+  skip
+} : DCom -/
+#guard_msgs in
+#check DCom.seq (DCom.seq DCom.skip (DCom.asgn X (aexp {Y + 1}))) DCom.skip
+
+/-- info: sdcom {
+  if (X ≤ Y) then
+      skip
+    else
+      X := Y + 1
+    end;
+  skip
+} : DCom -/
+#guard_msgs in
+#check DCom.seq
+  (DCom.cond (bexp {X ≤ Y}) DCom.skip (DCom.asgn X (aexp {Y + 1})))
+  DCom.skip
+
+/-- info: sdcom {
+  while (X ≠ 0) do
+    {{True}}
+    X := X - 1
+  end
+} : DCom -/
+#guard_msgs in
+#check DCom.whileDo (bexp {X ≠ 0}) ({{ True }})
+  (DCom.asgn X (aexp {X - 1}))
+
+end SparseAnnotations
+```
+:::
 :::::
 
 ::::::
@@ -4188,7 +4474,7 @@ equivalent; that is, `P <<->> P'`.
 ```lean
 def IsWp (P : Assertion) (c : Com) (Q : Assertion) : Prop :=
   ValidHoareTriple P c Q ∧
-  ∀ P' : Assertion, {{ P' }} ~c {{ Q }} → P' ->> P
+  ∀ P' : Assertion, {{ P' }} c {{ Q }} → P' ->> P
 ```
 
 :::slidebreak
@@ -4302,7 +4588,7 @@ weakest precondition.
 ```lean
 theorem hoare_asgn_weakest
     (Q : Assertion) (x : Ident) (a : Aexp) :
-    IsWp ({{ Q [x ↦ ~a] }}) (imp {x := ~a}) Q := by
+    IsWp ({{ Q [x ↦ a] }}) (imp {x := a}) Q := by
   solution!
     refine ⟨hoare_asgn, ?_⟩
     intro P hP

--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -244,7 +244,7 @@ the pattern repeated, and skip them otherwise.
 declare_syntax_cat imp_aexp
 /-- Numeric literal -/
 syntax:max num : imp_aexp
-/-- Variable reference -/
+/-- `Ident` or Lean identifier -/
 syntax:max ident : imp_aexp
 /-- Addition -/
 syntax:65 imp_aexp:65 " + " imp_aexp:66 : imp_aexp
@@ -253,7 +253,7 @@ syntax:65 imp_aexp:65 " - " imp_aexp:66 : imp_aexp
 /-- Multiplication -/
 syntax:70 imp_aexp:70 " * " imp_aexp:71 : imp_aexp
 /-- Parentheses for grouping -/
-syntax "(" imp_aexp ")" : imp_aexp
+syntax:max "(" imp_aexp ")" : imp_aexp
 /-- Escape to Lean -/
 syntax:max "~" term:max : imp_aexp
 
@@ -263,30 +263,55 @@ syntax:min "aexp " "{" imp_aexp "}" : term
 ::::
 
 :::instructors
-A variable reference elaborates to `Aexp.id $x` with the identifier spliced
-as a *term*, not as a string literal. So `aexp { X }` is `Aexp.id X`, using
-the declared constant `X : Ident`, exactly matching hand-written terms like
-`.asgn X …` and the shape the state/`ceval` proofs expect. (Rocq's `<{ }>`
-does the same via its `constr` fallback, yielding `AId X`.) A consequence is
-that a variable name must be a declared `Ident` constant — as W/X/Y/Z are.
+A bare identifier is resolved by its type.
+An {name}`Ident` such as {name}`X` becomes {name}`Aexp.id`,
+while an {name}`Aexp` is inserted directly.
+A consequence is that object-language variables must
+be a declared {name}`Ident` constants — as {name}`W`/{name}`X`/{name}`Y`/{name}`Z` are,
+but Lean variables of type {name}`Aexp` can be referred without antiquotation.
 :::
 
 ```lean
-open Lean in
+namespace Imp.Elab
+
+open Lean Elab Term Meta
+
+def withSourceInfoOf {kind : Name} (ref : Syntax) (stx : TSyntax kind)
+    (canonical := true) : TSyntax kind :=
+  let info := SourceInfo.fromRef ref (canonical := canonical)
+  ⟨stx.raw.setInfo info⟩
+
 macro_rules
-  | `(aexp { $n:num }) => `(Aexp.num $(quote n.getNat))
-  | `(aexp { $x:ident }) => `(Aexp.id $x)
-  | `(aexp { ~$e }) => pure e
-  | `(aexp { $a + $b }) => `(Aexp.plus (aexp {$a}) (aexp {$b}))
-  | `(aexp { $a - $b }) => `(Aexp.minus (aexp {$a}) (aexp {$b}))
-  | `(aexp { $a * $b }) => `(Aexp.mult (aexp {$a}) (aexp {$b}))
-  | `(aexp { ($a) }) => `(aexp {$a})
+  | `(aexp { $exp:imp_aexp }) => do
+    let stx ← match exp with
+      | `(imp_aexp| $n:num) => ``(Aexp.num $n)
+      | `(imp_aexp| ~$e:term) => ``(($e : Aexp))
+      | `(imp_aexp| $a + $b) => ``(Aexp.plus (aexp {$a}) (aexp {$b}))
+      | `(imp_aexp| $a - $b) => ``(Aexp.minus (aexp {$a}) (aexp {$b}))
+      | `(imp_aexp| $a * $b) => ``(Aexp.mult (aexp {$a}) (aexp {$b}))
+      | `(imp_aexp| ($a)) => ``(aexp {$a})
+      | _ => Lean.Macro.throwUnsupported
+    return withSourceInfoOf exp stx
+
+elab_rules : term
+  | `(aexp { $x:ident }) => do
+    let some e ← resolveId? x (withInfo := true)
+      | throwErrorAt x "unknown identifier `{x.getId.eraseMacroScopes}`"
+    let type ← whnf (← inferType e)
+    tryPostponeIfMVar type
+    match_expr type with
+    | Aexp => pure e
+    | String => mkAppM ``Aexp.id #[e]
+    | _ => throwErrorAt x "expected an Imp identifier or arithmetic expression"
+
+end Imp.Elab
 ```
 
 :::instructors
 The literals `true`/`false` are accepted through the bare-identifier form
 (`syntax:max ident : imp_bexp`) and turned into {name}`Bexp.bool` by the macro
-below, which rejects any other identifier. We take this route rather than
+below. Any other bare identifier is inserted as a Lean {name}`Bexp`.
+We take this route rather than
 declaring `true`/`false` as symbols: as reserved keywords they would break
 ordinary Lean uses of `true`/`false`, and as non-reserved symbols they would
 clash with the bare-identifier form of `imp_aexp`.
@@ -296,7 +321,7 @@ clash with the bare-identifier form of `imp_aexp`.
 ```lean
 /-- Boolean expressions of Imp -/
 declare_syntax_cat imp_bexp
-/-- Boolean literal (`true` or `false`) -/
+/-- Boolean literal (`true` or `false`) and Lean identifier -/
 syntax:max ident : imp_bexp
 /-- Equality of arithmetic expressions -/
 syntax:50 imp_aexp:51 " = " imp_aexp:51 : imp_bexp
@@ -308,10 +333,10 @@ syntax:50 imp_aexp:51 " ≤ " imp_aexp:51 : imp_bexp
 syntax:50 imp_aexp:51 " > " imp_aexp:51 : imp_bexp
 /-- Boolean negation -/
 syntax:70 "¬ " imp_bexp:70 : imp_bexp
-/-- Boolean conjunction -/
+/-- Boolean conjunction (right associative) -/
 syntax:35 imp_bexp:36 " ∧ " imp_bexp:35 : imp_bexp
 /-- Parentheses for grouping -/
-syntax "(" imp_bexp ")" : imp_bexp
+syntax:max "(" imp_bexp ")" : imp_bexp
 /-- Escape to Lean -/
 syntax:max "~" term:max : imp_bexp
 
@@ -329,21 +354,28 @@ and then insist on a comparison operator.
 
 ::::details "Notation encoding: boolean expressions, macro rules"
 ```lean
-open Lean in
+namespace Imp.Elab
+
+open Lean
+
 macro_rules
-  | `(bexp { $x:ident }) =>
-    match x.getId with
-    | `true  => `(Bexp.bool true)
-    | `false => `(Bexp.bool false)
-    | _      => Macro.throwErrorAt x s!"expected 'true' or 'false', got '{x.getId}'"
-  | `(bexp { ~$e }) => pure e
-  | `(bexp { $a:imp_aexp = $b:imp_aexp }) => `(Bexp.eq (aexp {$a}) (aexp {$b}))
-  | `(bexp { $a:imp_aexp ≠ $b:imp_aexp }) => `(Bexp.neq (aexp {$a}) (aexp {$b}))
-  | `(bexp { $a:imp_aexp ≤ $b:imp_aexp }) => `(Bexp.le (aexp {$a}) (aexp {$b}))
-  | `(bexp { $a:imp_aexp > $b:imp_aexp }) => `(Bexp.gt (aexp {$a}) (aexp {$b}))
-  | `(bexp { ¬ $b:imp_bexp }) => `(Bexp.not (bexp {$b}))
-  | `(bexp { $b₁:imp_bexp ∧ $b₂:imp_bexp }) => `(Bexp.and (bexp {$b₁}) (bexp {$b₂}))
-  | `(bexp { ($b:imp_bexp) }) => `(bexp {$b})
+  | `(bexp { $exp:imp_bexp }) => do
+    let stx ← match exp with
+      | `(imp_bexp| true) => ``(Bexp.bool true)
+      | `(imp_bexp| false) => ``(Bexp.bool false)
+      | `(imp_bexp| $x:ident) => ``(($x : Bexp))
+      | `(imp_bexp| ~$e:term) => ``(($e : Bexp))
+      | `(imp_bexp| $a:imp_aexp = $b:imp_aexp) => ``(Bexp.eq (aexp {$a}) (aexp {$b}))
+      | `(imp_bexp| $a:imp_aexp ≠ $b:imp_aexp) => ``(Bexp.neq (aexp {$a}) (aexp {$b}))
+      | `(imp_bexp| $a:imp_aexp ≤ $b:imp_aexp) => ``(Bexp.le (aexp {$a}) (aexp {$b}))
+      | `(imp_bexp| $a:imp_aexp > $b:imp_aexp) => ``(Bexp.gt (aexp {$a}) (aexp {$b}))
+      | `(imp_bexp| ¬ $b:imp_bexp) => ``(Bexp.not (bexp {$b}))
+      | `(imp_bexp| $b₁:imp_bexp ∧ $b₂:imp_bexp) => ``(Bexp.and (bexp {$b₁}) (bexp {$b₂}))
+      | `(imp_bexp| ($b:imp_bexp)) => ``(bexp {$b})
+      | _ => Macro.throwUnsupported
+    return withSourceInfoOf exp stx
+
+end Imp.Elab
 ```
 ::::
 
@@ -386,99 +418,30 @@ a pile of constructors.
 ::::details "Notation encoding: printing expressions back"
 ```lean
 namespace Imp.Delab
-open Lean PrettyPrinter Delaborator SubExpr Parenthesizer
 
-/-- Re-inserts parentheses in `imp_aexp` output according to the grammar's precedences. -/
+open Lean PrettyPrinter Delaborator SubExpr Parenthesizer Imp.Elab
+
 @[category_parenthesizer imp_aexp]
-def imp_aexp.parenthesizer : CategoryParenthesizer | prec => do
+def imp_aexp.parenthesizer : CategoryParenthesizer := fun prec => do
   maybeParenthesize `imp_aexp true wrapParens prec <|
     parenthesizeCategoryCore `imp_aexp prec
 where
   wrapParens (stx : Syntax) : Syntax := Unhygienic.run do
-    let pstx ← `(($(⟨stx⟩)))
-    return pstx.raw.setInfo (SourceInfo.fromRef stx)
+    let stxInfo := SourceInfo.fromRef stx
+    let stx := stx.setInfo .none
+    let pstx ← `(imp_aexp| ($(⟨stx⟩)))
+    return pstx.raw.setInfo stxInfo
 
-/-- Re-inserts parentheses in `imp_bexp` output according to the grammar's precedences. -/
 @[category_parenthesizer imp_bexp]
-def imp_bexp.parenthesizer : CategoryParenthesizer | prec => do
-  maybeParenthesize `imp_bexp true wrapParens prec <|
-    parenthesizeCategoryCore `imp_bexp prec
+def imp_bexp.parenthesizer : CategoryParenthesizer := fun prec => do
+  Parenthesizer.maybeParenthesize `imp_bexp true wrapParens prec <|
+    Parenthesizer.parenthesizeCategoryCore `imp_bexp prec
 where
   wrapParens (stx : Syntax) : Syntax := Unhygienic.run do
-    let pstx ← `(($(⟨stx⟩)))
-    return pstx.raw.setInfo (SourceInfo.fromRef stx)
-
-/-- Tag freshly built syntax with the term info that Lean's pretty printer expects. -/
-def annAsTerm {any} (stx : TSyntax any) : DelabM (TSyntax any) :=
-  (⟨·⟩) <$> annotateTermInfo ⟨stx.raw⟩
-
-/-- Rebuild `imp_aexp` concrete syntax from an `Aexp` term. -/
-partial def delabAexpInner : DelabM (TSyntax `imp_aexp) := do
-  let e ← getExpr
-  let stx ←
-    match_expr e with
-    | Aexp.num _ =>
-      match (← withAppArg getExpr).nat? with
-      | some v => pure ⟨Syntax.mkNumLit (toString v) |>.raw⟩
-      | none   => `(imp_aexp| ~$(← withAppArg delab))
-    | Aexp.id _ =>
-      -- A variable reference like aexp { X } elaborates to Aexp.id X where X is the
-      -- declared Ident constant, so the delaborators print the constant's name as a
-      -- bare identifier (and also handle the .id "X" string-literal form).
-      match ← withAppArg getExpr with
-      | .const nm _      => `(imp_aexp| $(mkIdent nm):ident)
-      | .lit (.strVal s) => `(imp_aexp| $(mkIdent (.mkSimple s)):ident)
-      | _                => `(imp_aexp| ~$(← withAppArg delab))
-    | Aexp.plus _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabAexpInner
-      let s₂ ← withAppArg delabAexpInner
-      `(imp_aexp| $s₁ + $s₂)
-    | Aexp.minus _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabAexpInner
-      let s₂ ← withAppArg delabAexpInner
-      `(imp_aexp| $s₁ - $s₂)
-    | Aexp.mult _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabAexpInner
-      let s₂ ← withAppArg delabAexpInner
-      `(imp_aexp| $s₁ * $s₂)
-    | _ => `(imp_aexp| ~$(← delab))
-  annAsTerm stx
-
-/-- Rebuild `imp_bexp` concrete syntax from a `Bexp` term. -/
-partial def delabBexpInner : DelabM (TSyntax `imp_bexp) := do
-  let e ← getExpr
-  let stx ←
-    match_expr e with
-    | Bexp.bool _ =>
-      match ← withAppArg getExpr with
-      | .const ``Bool.true _  => `(imp_bexp| $(mkIdent `true):ident)
-      | .const ``Bool.false _ => `(imp_bexp| $(mkIdent `false):ident)
-      | _                     => `(imp_bexp| ~$(← withAppArg delab))
-    | Bexp.eq _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabAexpInner
-      let s₂ ← withAppArg delabAexpInner
-      `(imp_bexp| $s₁:imp_aexp = $s₂:imp_aexp)
-    | Bexp.neq _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabAexpInner
-      let s₂ ← withAppArg delabAexpInner
-      `(imp_bexp| $s₁:imp_aexp ≠ $s₂:imp_aexp)
-    | Bexp.le _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabAexpInner
-      let s₂ ← withAppArg delabAexpInner
-      `(imp_bexp| $s₁:imp_aexp ≤ $s₂:imp_aexp)
-    | Bexp.gt _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabAexpInner
-      let s₂ ← withAppArg delabAexpInner
-      `(imp_bexp| $s₁:imp_aexp > $s₂:imp_aexp)
-    | Bexp.not _ =>
-      let s ← withAppArg delabBexpInner
-      `(imp_bexp| ¬ $s)
-    | Bexp.and _ _ =>
-      let s₁ ← withAppFn <| withAppArg delabBexpInner
-      let s₂ ← withAppArg delabBexpInner
-      `(imp_bexp| $s₁ ∧ $s₂)
-    | _ => `(imp_bexp| ~$(← delab))
-  annAsTerm stx
+    let stxInfo := SourceInfo.fromRef stx
+    let stx := stx.setInfo .none
+    let pstx ← `(imp_bexp| ($(⟨stx⟩)))
+    return pstx.raw.setInfo stxInfo
 ```
 ::::
 
@@ -488,40 +451,133 @@ switch this delaborator off, revealing the raw constructors (see the
 
 ::::details "Notation encoding: registering the delaborators"
 ```lean
-@[delab app.Aexp.num, delab app.Aexp.id, delab app.Aexp.plus,
-  delab app.Aexp.minus, delab app.Aexp.mult]
-partial def delabAexp : Delab := whenPPOption getPPNotation do
-  -- This delaborator only understands `Aexp`'s constructors -- bail otherwise.
-  guard <| match_expr ← getExpr with
-    | Aexp.num _ => true
-    | Aexp.id _ => true
-    | Aexp.plus _ _ => true
-    | Aexp.minus _ _ => true
-    | Aexp.mult _ _ => true
-    | _ => false
-  match ← delabAexpInner with
-  | `(imp_aexp| ~$e) => pure e
-  | e => `(term| aexp { $e })
 
-@[delab app.Bexp.bool, delab app.Bexp.eq, delab app.Bexp.neq, delab app.Bexp.le,
-  delab app.Bexp.gt, delab app.Bexp.not, delab app.Bexp.and]
-partial def delabBexp : Delab := whenPPOption getPPNotation do
-  guard <| match_expr ← getExpr with
-    | Bexp.bool _ => true
-    | Bexp.eq _ _ => true
-    | Bexp.neq _ _ => true
-    | Bexp.le _ _ => true
-    | Bexp.gt _ _ => true
-    | Bexp.not _ => true
-    | Bexp.and _ _ => true
-    | _ => false
-  match ← delabBexpInner with
-  | `(imp_bexp| ~$e) => pure e
-  | e => `(term| bexp { $e })
+/--
+Recognizes a term as being an `aexp { ... }` expression.
+-/
+def getAexp (stx : Term) : TSyntax `imp_aexp :=
+  withSourceInfoOf (canonical := false) stx <| Unhygienic.run do
+    match stx with
+    | `(aexp { $e:imp_aexp }) => return e
+    | _ => `(imp_aexp| ~$stx)
+
+@[app_unexpander Aexp.num]
+private def Aexp.unexpandNum : Unexpander
+  | `($_ $n:num) => `(aexp { $n:num })
+  | _ => throw ()
+
+@[app_unexpander Aexp.id]
+private def Aexp.unexpandId : Unexpander
+  | `($_ $x:ident) => `(aexp { $x:ident })
+  | _ => throw ()
+
+@[app_unexpander Aexp.plus]
+private def Aexp.unexpandPlus : Unexpander
+  | `($_ $a $b) => `(aexp { $(getAexp a) + $(getAexp b) })
+  | _ => throw ()
+
+@[app_unexpander Aexp.minus]
+private def Aexp.unexpandMinus : Unexpander
+  | `($_ $a $b) => `(aexp { $(getAexp a) - $(getAexp b) })
+  | _ => throw ()
+
+@[app_unexpander Aexp.mult]
+private def Aexp.unexpandMult : Unexpander
+  | `($_ $a $b) => `(aexp { $(getAexp a) * $(getAexp b) })
+  | _ => throw ()
+
+/--
+Recognizes a term as being an `bexp { ... }` expression.
+-/
+def getBexp (stx : Term) : TSyntax `imp_bexp :=
+  withSourceInfoOf (canonical := false) stx <| Unhygienic.run do
+    match stx with
+    | `(bexp { $e:imp_bexp }) => return e
+    | _ => `(imp_bexp| ~$stx)
+
+/--
+Delaborator for `Bexp.bool`. This is needed since we want to be sure we are
+matching on the actual `true`/`false` expressions, rather than matching on the
+delaborated identifiers `true`/`false` (which might not be accurate).
+-/
+@[app_delab Bexp.bool]
+private def BExp.delabBool : Delab := whenPPOption getPPNotation do
+  let e ← getExpr
+  guard <| e.isAppOfArity ``Bexp.bool 1
+  match_expr e.appArg! with
+  | true => `(bexp { $(mkIdent `true):ident })
+  | false => `(bexp { $(mkIdent `false):ident })
+  | _ => failure
+
+
+@[app_unexpander Bexp.eq]
+private def Bexp.unexpandEq : Unexpander
+  | `($_ $a $b) => `(bexp { $(getAexp a):imp_aexp = $(getAexp b):imp_aexp })
+  | _ => throw ()
+
+@[app_unexpander Bexp.neq]
+private def Bexp.unexpandNeq : Unexpander
+  | `($_ $a $b) => `(bexp { $(getAexp a):imp_aexp ≠ $(getAexp b):imp_aexp })
+  | _ => throw ()
+
+@[app_unexpander Bexp.le]
+private def Bexp.unexpandLe : Unexpander
+  | `($_ $a $b) => `(bexp { $(getAexp a):imp_aexp ≤ $(getAexp b):imp_aexp })
+  | _ => throw ()
+
+@[app_unexpander Bexp.gt]
+private def Bexp.unexpandGt : Unexpander
+  | `($_ $a $b) => `(bexp { $(getAexp a):imp_aexp > $(getAexp b):imp_aexp })
+  | _ => throw ()
+
+@[app_unexpander Bexp.not]
+private def Bexp.unexpandNot : Unexpander
+  | `($_ $a) => `(bexp { ¬ $(getBexp a):imp_bexp })
+  | _ => throw ()
+
+@[app_unexpander Bexp.and]
+private def Bexp.unexpandAnd : Unexpander
+  | `($_ $a $b) => `(bexp { $(getBexp a):imp_bexp ∧ $(getBexp b):imp_bexp })
+  | _ => throw ()
 
 end Imp.Delab
 ```
 ::::
+
+:::ignore
+```lean -show -keep
+
+def a₁ : Aexp := aexp { X + 1 }
+def a₂ : Aexp := aexp { (a₁) * ~(.num 5) }
+
+/-- info: aexp {1 * (2 + 3)} : Aexp -/
+#guard_msgs in #check aexp { 1 * (2 + 3) }
+/-- info: aexp {(1 + 2) * 3} : Aexp -/
+#guard_msgs in #check aexp { (1 + 2) * 3 }
+/-- info: aexp {X + ~a₁} : Aexp -/
+#guard_msgs in #check aexp { X + a₁ }
+
+def b₁ := bexp { true ∧ ¬(X ≤ 4) }
+def b₂ := bexp { b₁ ∧ (¬ (X ≤ ~(.num <| 4 + 2))) }
+
+/-- info: bexp {1 = X} : Bexp -/
+#guard_msgs in #check bexp { 1 = X }
+/-- info: bexp {1 ≠ X} : Bexp -/
+#guard_msgs in #check bexp { 1 ≠ X }
+/-- info: bexp {1 ≤ X} : Bexp -/
+#guard_msgs in #check bexp { 1 ≤ X }
+/-- info: bexp {1 > X} : Bexp -/
+#guard_msgs in #check bexp { 1 > X }
+/-- info: bexp {¬ true} : Bexp -/
+#guard_msgs in #check bexp { ¬ true }
+/-- info: bexp {true ∧ false} : Bexp -/
+#guard_msgs in #check bexp { true ∧ false }
+
+/-- info: bexp {~b₁ ∧ ~b₂ ∧ ~a₁ + ~a₂ = ~a₂ + 1} : Bexp -/
+#guard_msgs in #check bexp { b₁ ∧ b₂ ∧ (a₁ + a₂) = (a₂ + 1) }
+
+```
+:::
 
 ::::full
 With these delaborators in place, Lean pretty-prints Imp expressions with the higher-level
@@ -652,15 +708,15 @@ We don't make `skip` a reserved keyword on purpose because otherwise `skip` coul
 /-- Imp commands -/
 declare_syntax_cat imp_com
 /-- The command that does nothing (`skip`) -/
-syntax ident : imp_com
-/-- Sequencing: one command after another -/
-syntax imp_com ";" ppDedent(ppLine imp_com) : imp_com
+syntax:max ident : imp_com
+/-- Sequencing: one command after another (right associative. min + 1 = 11) -/
+syntax:min imp_com:11 ";" ppDedent(ppLine imp_com:min) : imp_com
 /-- Assignment -/
-syntax ident " := " imp_aexp : imp_com
+syntax:max ident ppHardSpace ":=" ppHardSpace imp_aexp : imp_com
 /-- Conditional -/
-syntax "if " "(" imp_bexp ")" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}" ppHardSpace "else" ppHardSpace "{") ppLine imp_com ppDedent(ppLine "}") : imp_com
+syntax:max "if " "(" imp_bexp ")" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}" ppHardSpace "else" ppHardSpace "{") ppLine imp_com ppDedent(ppLine "}") : imp_com
 /-- Loop -/
-syntax "while " "(" imp_bexp ")" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") : imp_com
+syntax:max "while " "(" imp_bexp ")" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") : imp_com
 /-- Escape to Lean -/
 syntax:max "~" term:max : imp_com
 
@@ -669,21 +725,24 @@ syntax:min "imp" ppHardSpace "{" ppLine imp_com ppDedent(ppLine "}") : term
 
 namespace Com
 
-open Lean in
+open Lean Imp.Elab
+
 scoped macro_rules
-  | `(imp { $x:ident }) =>
-    if x.getId == `skip then `(Com.skip)
-    else Macro.throwErrorAt x s!"expected 'skip', got '{x.getId}'"
-  | `(imp { $c₁ ; $c₂ }) =>
-    `(Com.seq (imp {$c₁}) (imp {$c₂}))
-  | `(imp { $x:ident := $a }) =>
-    `(Com.asgn $x (aexp {$a}))
-  | `(imp { if ($b) {$c₁} else {$c₂} }) =>
-    `(Com.cond (bexp {$b}) (imp {$c₁}) (imp {$c₂}))
-  | `(imp { while ($b) {$c} }) =>
-    `(Com.whileDo (bexp {$b}) (imp {$c}))
-  | `(imp { ~$c }) =>
-    pure c
+  | `(imp { $s }) => do
+    let stx ← match s with
+      | `(imp_com| skip) => ``(Com.skip)
+      | `(imp_com| $x:ident) => ``(($x : Com))
+      | `(imp_com| $c₁ ; $c₂) =>
+        ``(Com.seq (imp {$c₁}) (imp {$c₂}))
+      | `(imp_com| $x:ident := $a) =>
+        ``(Com.asgn $x (aexp {$a}))
+      | `(imp_com| if ($b) {$c₁} else {$c₂}) =>
+        ``(Com.cond (bexp {$b}) (imp {$c₁}) (imp {$c₂}))
+      | `(imp_com| while ($b) {$c}) =>
+        ``(Com.whileDo (bexp {$b}) (imp {$c}))
+      | `(imp_com| ~$c) => `(($c : Com))
+      | _ => Macro.throwUnsupported
+    return withSourceInfoOf s stx
 
 end Com
 
@@ -703,58 +762,46 @@ unrecognized subcommand with the `~` escape.
 ::::details "Notation encoding: printing commands back"
 ```lean
 namespace Imp.Delab
-open Lean PrettyPrinter Delaborator SubExpr
+open Lean PrettyPrinter Delaborator SubExpr Imp.Elab
 
-partial def delabComInnerFor (ns : Name) (extra : DelabM (TSyntax `imp_com)) :
-    DelabM (TSyntax `imp_com) := do
-  let e ← getExpr
-  let stx ←
-    -- Using `(imp_com| skip)` would delaborate as `skip✝`. `mkIdent` fixes this.
-    if e.isConstOf (ns ++ `skip) then
-      `(imp_com| $(mkIdent `skip):ident)
-    else if e.isAppOfArity (ns ++ `asgn) 2 then
-      match ← withAppFn <| withAppArg getExpr with
-      | .lit (.strVal s) =>
-        let a ← withAppArg delabAexpInner
-        `(imp_com| $(mkIdent (.mkSimple s)):ident := $a)
-      | _ =>
-        let `($x:ident) ← withAppFn <| withAppArg delab | failure
-        let a ← withAppArg delabAexpInner
-        `(imp_com| $x:ident := $a)
-    else if e.isAppOfArity (ns ++ `seq) 2 then
-      let s₁ ← withAppFn <| withAppArg (delabComInnerFor ns extra)
-      let s₂ ← withAppArg (delabComInnerFor ns extra)
-      `(imp_com| $s₁; $s₂)
-    else if e.isAppOfArity (ns ++ `cond) 3 then
-      let b  ← withAppFn <| withAppFn <| withAppArg delabBexpInner
-      let c₁ ← withAppFn <| withAppArg (delabComInnerFor ns extra)
-      let c₂ ← withAppArg (delabComInnerFor ns extra)
-      `(imp_com| if ($b) {$c₁} else {$c₂})
-    else if e.isAppOfArity (ns ++ `whileDo) 2 then
-      let b ← withAppFn <| withAppArg delabBexpInner
-      let c ← withAppArg (delabComInnerFor ns extra)
-      `(imp_com| while ($b) {$c})
-    else
-      extra <|> `(imp_com| ~$(← delab))
-  annAsTerm stx
+/--
+Recognizes a term as being an `imp { ... }` expression.
+-/
+def getImp (stx : Term) : TSyntax `imp_com :=
+  withSourceInfoOf (canonical := false) stx <| Unhygienic.run do
+    match stx with
+    | `(imp { $e:imp_com }) => return e
+    | _ => `(imp_com| ~$stx)
 
-/-- Rebuild `imp_com` concrete syntax from a `Com` term. -/
-partial def delabComInner : DelabM (TSyntax `imp_com) :=
-  delabComInnerFor ``Com failure
+@[app_unexpander Com.skip]
+def unexpandComSkip : Unexpander
+  | _ => `(imp { $(mkIdent `skip):ident })
 
-@[delab app.Com.skip, delab app.Com.asgn, delab app.Com.seq,
-  delab app.Com.cond, delab app.Com.whileDo]
-partial def delabCom : Delab := whenPPOption getPPNotation do
-  guard <| match_expr ← getExpr with
-    | Com.skip => true
-    | Com.asgn _ _ => true
-    | Com.seq _ _ => true
-    | Com.cond _ _ _ => true
-    | Com.whileDo _ _ => true
-    | _ => false
-  match ← delabComInner with
-  | `(imp_com| ~$e) => pure e
-  | e => `(term| imp { $e })
+@[app_unexpander Com.asgn]
+def unexpandComAsgn : Unexpander
+  | `($_ $x:ident $a) => `(imp { $x:ident := $(getAexp a) })
+  | _ => throw ()
+
+@[app_unexpander Com.seq]
+def unexpandComSeq : Unexpander
+  | `($_ $a $b) =>
+    match a with
+    | `(imp { $_ ; $_ }) =>
+      -- seq syntax is right associative, so need to quote `a`
+      `(imp { ~$a ; $(getImp b):imp_com })
+    | _ =>
+      `(imp { $(getImp a):imp_com ; $(getImp b):imp_com })
+  | _ => throw ()
+
+@[app_unexpander Com.cond]
+def unexpandComCond : Unexpander
+  | `($_ $b $c₁ $c₂) => `(imp { if ($(getBexp b)) { $(getImp c₁) } else { $(getImp c₂) } })
+  | _ => throw ()
+
+@[app_unexpander Com.whileDo]
+def unexpandComWhileDo : Unexpander
+  | `($_ $b $c) => `(imp { while ($(getBexp b)) { $(getImp c) } })
+  | _ => throw ()
 
 end Imp.Delab
 ```
@@ -771,12 +818,121 @@ info: imp {
 #guard_msgs in
 #check imp { skip }
 
+/--
+info: imp {
+  skip;
+  if (true) {
+    X := 1
+  } else {
+    X := 2
+  }
+} : Com
+-/
+#guard_msgs in
+#check imp { skip; if (true) {X := 1} else {X:=2} }
+
+
 variable (x : Ident) (a : Aexp)
 /-- info: imp {
   x := ~a
 } : Com -/
 #guard_msgs in
 #check imp { x := ~a }
+
+/--
+info: imp {
+  x := ~a
+} : Com
+-/
+#guard_msgs in
+#check imp { ~(Com.asgn x a) }
+
+/-- info: Com.asgn (if true = true then x else x) a : Com -/
+#guard_msgs in
+#check imp { ~(Com.asgn (if true then x else x) a) }
+
+/--
+info: imp {
+  if (true) {
+    skip
+  } else {
+    ~(Com.asgn (if true = true then x else x) a)
+  }
+} : Com
+-/
+#guard_msgs in
+#check imp { if (true) { skip } else{ ~(Com.asgn (if true then x else x) a)}}
+
+variable (b : Bexp) (c c₁ c₂ : Com)
+
+/--
+info: imp {
+  x := ~a
+} : Com
+-/
+#guard_msgs in
+#check imp { x := a }
+
+/--
+info: imp {
+  if (~b) {
+    ~c₁
+  } else {
+    ~c₂
+  }
+} : Com
+-/
+#guard_msgs in
+#check imp { if (b) {c₁} else {c₂} }
+
+/-- info: c : Com -/
+#guard_msgs in
+#check imp { c }
+
+/--
+info: imp {
+  ~c₁;
+  ~c₂
+} : Com
+-/
+#guard_msgs in
+#check imp {c₁;c₂}
+
+example : (
+  match imp { skip; c } with
+    | imp { skip; c' } => c' -- no need to write `~c'`
+    | _ => imp { skip }) = c := rfl
+
+
+example : (
+  match imp { X := X + 1 } with
+    | imp { x := ~a } => (x, a) -- still need `~`, because `a` itself is a valid aexp.
+                                -- here we want to bind the entire RHS.
+    | _ => (X, aexp {0})) = (X, aexp {X + 1}) := rfl
+
+variable (b : Bool) (y : Ident)
+
+/--
+info: imp {
+  if (~(Bexp.bool b)) {
+    if (true) {
+      y := ~(Aexp.num (3 + 4))
+    } else {
+      ~(Com.asgn (if b = true then x else y) a)
+    }
+  } else {
+    skip
+  }
+} : Com
+-/
+#guard_msgs in
+#check
+  Com.cond (Bexp.bool b)
+    (.cond (Bexp.bool true)
+      (.asgn y (.num <| 3 + 4))
+      (.asgn (if b then x else y) a)
+    ) (.skip)
+
 end
 ```
 :::
@@ -941,10 +1097,10 @@ def Com.ceval_fun_no_while (st : State) (c : Com) : State :=
   match c with
   | imp {skip} => st
   | imp {x := ~a} => (x →ₜ a.eval st ; st)
-  | imp {~c₁; ~c₂} =>
+  | imp {c₁; c₂} =>
       let st' := ceval_fun_no_while st c₁
       ceval_fun_no_while st' c₂
-  | imp {if (~b) {~c₁} else {~c₂}} =>
+  | imp {if (b) {c₁} else {c₂}} =>
       if b.eval st then ceval_fun_no_while st c₁
       else ceval_fun_no_while st c₂
   | imp {while (~_) {~_}} => st     -- bogus
@@ -1073,20 +1229,20 @@ TODO Propose you use inline notation such as `Com.EvalR (imp {skip;}) st st`
 inductive Com.EvalR : Com → State → State → Prop where
   | skip {st : State} : EvalR (imp {skip}) st st
   | asgn {st : State} {a : Aexp} {n : Nat} {x : Ident} (h : a.eval st = n) :
-      EvalR (imp {x := ~a}) st (x →ₜ n ; st)
+      EvalR (imp {x := a}) st (x →ₜ n ; st)
   | seq {c₁ c₂ : Com} {st st' st'' : State} (h₁ : EvalR c₁ st st') (h₂ : EvalR c₂ st' st'') :
-      EvalR (imp {~c₁; ~c₂}) st st''
+      EvalR (imp {c₁; c₂}) st st''
   | ifTrue {st st' : State} {b : Bexp} {c₁ c₂ : Com} (hb : b.eval st = true)
       (hc : EvalR c₁ st st') :
-      EvalR (imp {if (~b) {~c₁} else {~c₂}}) st st'
+      EvalR (imp {if (b) {c₁} else {c₂}}) st st'
   | ifFalse {st st' : State} {b : Bexp} {c₁ c₂ : Com} (hb : b.eval st = false)
       (hc : EvalR c₂ st st') :
-      EvalR (imp {if (~b) {~c₁} else {~c₂}}) st st'
+      EvalR (imp {if (b) {c₁} else {c₂}}) st st'
   | whileFalse {b : Bexp} {st : State} {c : Com} (hb : b.eval st = false) :
-      EvalR (imp {while (~b) {~c}}) st st
+      EvalR (imp {while (b) {c}}) st st
   | whileTrue {st st' st'' : State} {b : Bexp} {c : Com} (hb : b.eval st = true)
-      (hc : EvalR c st st') (hloop : Com.EvalR (imp {while (~b) {~c}}) st' st'') :
-      EvalR (imp {while (~b) {~c}}) st st''
+      (hc : EvalR c st st') (hloop : Com.EvalR (imp {while (b) {c}}) st' st'') :
+      EvalR (imp {while (b) {c}}) st st''
 ```
 
 :::instructors
@@ -1104,7 +1260,7 @@ class HasEval (Com : Type) (In : outParam <| Type) (Out : outParam <| Type) wher
 
 namespace HasEval
 /-- Evaluation: `st =[ c ]=> st'` with `imp_com` command syntax -/
-scoped syntax:lead term " =[ " imp_com:lead " ]=> " term : term
+scoped syntax:lead term " =[ " imp_com:min " ]=> " term : term
 scoped macro_rules
   | `($st =[ $c:imp_com ]=> $st') => ``(HasEval.Eval (imp { $c }) $st $st')
 
@@ -1198,7 +1354,7 @@ Is the following proposition provable?
 
 ```display
 ∀ (c : Com) (st st' : State),
-  st =[ skip; ~c ]=> st' →
+  st =[ skip; c ]=> st' →
   st =[ c ]=> st'
 ```
 
@@ -1207,7 +1363,7 @@ Is the following proposition provable?
 :::quizSolution
 ```lean
 theorem quiz1_answer (c : Com) (st st' : State)
-    (h : st =[ skip; ~c ]=> st') : st =[ ~c ]=> st' := by
+    (h : st =[ skip; c ]=> st') : st =[ c ]=> st' := by
   inversion h with
   | seq smid h₁ h₂ =>
     inversion h₁
@@ -1221,7 +1377,7 @@ Is the following proposition provable?
 
 ```display
 ∀ (c₁ c₂ : Com) (st st' : State),
-  st =[ ~c₁ ~c₂ ]=> st' →
+  st =[ c₁ c₂ ]=> st' →
   st =[ c₁ ]=> st →
   st =[ c₂ ]=> st'
 ```
@@ -1238,7 +1394,7 @@ Is the following proposition provable?
 
 ```display
 ∀ (b : Bexp) (c : Com) (st st' : State),
-  st =[ if (~b) { ~c } else { ~c } ]=> st' →
+  st =[ if (b) { c } else { c } ]=> st' →
   st =[ c ]=> st'
 ```
 
@@ -1247,7 +1403,7 @@ Is the following proposition provable?
 :::quizSolution
 ```lean
 theorem quiz3_answer (b : Bexp) (c : Com) (st st' : State)
-    (h : st =[ if (~b) { ~c } else { ~c } ]=> st') : st =[ ~c ]=> st' := by
+    (h : st =[ if (b) { c } else { c } ]=> st') : st =[ c ]=> st' := by
   inversion h with
   | ifTrue hb hc => exact hc
   | ifFalse hb hc => exact hc
@@ -1262,7 +1418,7 @@ Is the following proposition provable?
 ∀ (b : Bexp),
   (∀ st, b.eval st = true) →
   ∀ (c : Com) (st : State),
-  ¬ ∃ st', st =[ while (~b) { ~c } ]=> st'
+  ¬ ∃ st', st =[ while (b) { c } ]=> st'
 ```
 
 (A) Yes    (B) No    (C) Not sure
@@ -1271,10 +1427,10 @@ Is the following proposition provable?
 ```lean
 -- This one is tricky!
 theorem quiz4_answer (b : Bexp) (hbtrue : ∀ st, b.eval st = true)
-    (c : Com) (st : State) : ¬ ∃ st', st =[ while (~b) { ~c } ]=> st' := by
+    (c : Com) (st : State) : ¬ ∃ st', st =[ while (b) { c } ]=> st' := by
   rintro ⟨st', hev⟩
   have key : ∀ (cmd : Com) (s s' : State),
-      (s =[ ~cmd ]=> s') → cmd = (imp { while (~b) { ~c } }) → False := by
+      (s =[ cmd ]=> s') → cmd = (imp { while (b) { c } }) → False := by
     intro cmd s s' hce
     induction hce with
     | @whileFalse b₀ s₀ c₀ hbf =>
@@ -1297,7 +1453,7 @@ Is the following proposition provable?
 
 ```display
 ∀ (b : Bexp) (c : Com) (st : State),
-  (¬ ∃ st', st =[ while (~b) { ~c } ]=> st') →
+  (¬ ∃ st', st =[ while (b) { c } ]=> st') →
   ∀ st'', b.eval st'' = true
 ```
 
@@ -1309,7 +1465,7 @@ stuck immediately:
 
 ```lean +error
 theorem quiz5_answer (b : Bexp) (c : Com) (st : State)
-    (H : ¬ ∃ st', st =[ while (~b) { ~c } ]=> st') :
+    (H : ¬ ∃ st', st =[ while (b) { c } ]=> st') :
     ∀ st'', b.eval st'' = true := by
   intro st''
   -- Can't make any progress -- the claim is false!
@@ -1344,7 +1500,7 @@ Informal proof needed! (And one can surely be found in some past
 
 ```lean
 theorem ceval_deterministic (c : Com) (st st1 st2 : State)
-    (e₁ : st =[ ~c ]=> st1) (e₂ : st =[ ~c ]=> st2) : st1 = st2 := by
+    (e₁ : st =[ c ]=> st1) (e₂ : st =[ c ]=> st2) : st1 = st2 := by
   induction e₁ generalizing st2 with
   | @skip st =>
       inversion e₂
@@ -1417,7 +1573,7 @@ def pup_to_n : Com := solution!(
 
 ```lean
 theorem pup_to_2_ceval :
-    (X →ₜ 2 ; ∅) =[ ~pup_to_n ]=>
+    (X →ₜ 2 ; ∅) =[ pup_to_n ]=>
       (X →ₜ 0 ; Y →ₜ 3 ; X →ₜ 1 ; Y →ₜ 2 ; Y →ₜ 0 ; X →ₜ 2 ; ∅) := by
   solution!
     unfold pup_to_n
@@ -1468,7 +1624,7 @@ working with the bare definitions. This section explores some examples.
 
 ```lean
 theorem plus2_spec (st : State) (n : Nat) (st' : State)
-    (hx : st[X] = n) (heval : st =[ ~plus2 ]=> st') :
+    (hx : st[X] = n) (heval : st =[ plus2 ]=> st') :
     st'[X] = n + 2 := by
   -- Inverting `heval` forces one step of the `ceval` computation: since
   -- `plus2` is an assignment, `st'` must be `st` extended at `X`.
@@ -1490,7 +1646,7 @@ State and prove a specification of `XtimesYinZ`.
 -- SOLUTION
 /- Here is a specification in the style of `plus2_spec`: -/
 theorem XtimesYinZ_spec₁ (st : State) (nx ny : Nat) (st' : State)
-    (hx : st[X] = nx) (hy : st[Y] = ny) (heval : st =[ ~XtimesYinZ ]=> st') :
+    (hx : st[X] = nx) (hy : st[Y] = ny) (heval : st =[ XtimesYinZ ]=> st') :
     st'[Z] = nx * ny := by
   unfold XtimesYinZ at heval
   inversion heval with
@@ -1501,13 +1657,13 @@ theorem XtimesYinZ_spec₁ (st : State) (nx ny : Nat) (st' : State)
 
 /- Though perhaps a cleaner specification would be: -/
 theorem XtimesYinZ_spec (st : State) :
-    st =[ ~XtimesYinZ ]=> (Z →ₜ st[X] * st[Y] ; st) := by
+    st =[ XtimesYinZ ]=> (Z →ₜ st[X] * st[Y] ; st) := by
   unfold XtimesYinZ
   apply Com.EvalR.asgn
   rfl
 
 /- A less informative specification would be ... -/
-theorem XtimesYinZ_spec₂ (st : State) : ∃ st', st =[ ~XtimesYinZ ]=> st' := by
+theorem XtimesYinZ_spec₂ (st : State) : ∃ st', st =[ XtimesYinZ ]=> st' := by
   exact ⟨(Z →ₜ st[X] * st[Y] ; st), by unfold XtimesYinZ; apply Com.EvalR.asgn; rfl⟩
 -- END SOLUTION
 ```
@@ -1531,11 +1687,11 @@ solved in one step (by {tactic}`simp`/{tactic}`contradiction` on the impossible 
 equation).
 
 ```lean
-theorem loop_never_stops (st st' : State) : ¬ (st =[ ~loop ]=> st') := by
+theorem loop_never_stops (st st' : State) : ¬ (st =[ loop ]=> st') := by
   solution!
     intro contra
     -- Generalize over the command so the induction remembers what `loop` is.
-    have key : ∀ (c : Com) (s s' : State), (s =[ ~c ]=> s') → c = loop → False := by
+    have key : ∀ (c : Com) (s s' : State), (s =[ c ]=> s') → c = loop → False := by
       intro c s s' hce
       induction hce with
       | @whileFalse b s₀ c₀ hb =>
@@ -1583,18 +1739,18 @@ def Com.no_whiles (c : Com) : Bool :=
   match c with
   | imp {skip} => true
   | imp {_x := ~_a} => true
-  | imp {~c₁; ~c₂} => no_whiles c₁ && no_whiles c₂
-  | imp {if (~_) {~ct} else {~cf}} => no_whiles ct && no_whiles cf
+  | imp {c₁; c₂} => no_whiles c₁ && no_whiles c₂
+  | imp {if (~_) {ct} else {cf}} => no_whiles ct && no_whiles cf
   | imp {while (~_) {~_}} => false
 
 inductive Com.NoWhilesR : Com → Prop where
   -- SOLUTION
   | skip : Com.NoWhilesR (imp { skip })
-  | asgn (x : Ident) (a : Aexp) : Com.NoWhilesR (imp { x := ~a })
+  | asgn (x : Ident) (a : Aexp) : Com.NoWhilesR (imp { x := a })
   | seq (c₁ c₂ : Com) (h₁ : Com.NoWhilesR c₁) (h₂ : Com.NoWhilesR c₂) :
-      Com.NoWhilesR (imp { ~c₁; ~c₂ })
+      Com.NoWhilesR (imp { c₁; c₂ })
   | cond (b : Bexp) (c₁ c₂ : Com) (h₁ : Com.NoWhilesR c₁) (h₂ : Com.NoWhilesR c₂) :
-      Com.NoWhilesR (imp { if (~b) { ~c₁ } else { ~c₂ } })
+      Com.NoWhilesR (imp { if (b) { c₁ } else { c₂ } })
   -- END SOLUTION
 
 theorem no_whiles_eqv (c : Com) : c.no_whiles = true ↔ Com.NoWhilesR c := by
@@ -1626,7 +1782,7 @@ prove a theorem `no_whiles_terminating` that says this.  Use either
 
 ```lean
 theorem no_whiles_terminating (c : Com) (st : State) (h : Com.NoWhilesR c) :
-    ∃ st', st =[ ~c ]=> st' := by
+    ∃ st', st =[ c ]=> st' := by
   solution!
     induction h generalizing st with
     | @skip => exact ⟨st, .skip⟩
@@ -1651,7 +1807,7 @@ And here is an alternative solution by induction on `c` (using
 ```lean
 -- SOLUTION
 theorem no_whiles_terminating' (c : Com) (st1 : State)
-    (hb : c.no_whiles = true) : ∃ st2, st1 =[ ~c ]=> st2 := by
+    (hb : c.no_whiles = true) : ∃ st2, st1 =[ c ]=> st2 := by
   induction c generalizing st1 with
   | @skip => exact ⟨st1, .skip⟩
   | @asgn x a => exact ⟨(x →ₜ a.eval st1 ; st1), .asgn rfl⟩
@@ -1959,7 +2115,7 @@ enrich the language of commands with an additional case. Because `break`
 is a reserved keyword in Lean, we will abbreviate it as `brk`.
 
 ```lean
-namespace BreakImp
+namespace Imp.Break
 
 inductive Com where
   | skip
@@ -1974,43 +2130,42 @@ inductive Com where
 ```lean
 namespace Com
 
-open Lean in
+open Lean
+
 scoped macro_rules
-  | `(imp { $x:ident }) =>
-    if x.getId == `skip then `(Com.skip)
-    else if x.getId == `brk then `(Com.brk)
-    else Macro.throwErrorAt x s!"expected 'skip' or 'break', got '{x.getId}'"
-  | `(imp { $c₁; $c₂ }) =>
-    `(Com.seq (imp {$c₁}) (imp {$c₂}))
-  | `(imp { $x:ident := $a }) =>
-    `(Com.asgn $x (aexp {$a}))
-  | `(imp { if ($b) {$c₁} else {$c₂} }) =>
-    `(Com.cond (bexp {$b}) (imp {$c₁}) (imp {$c₂}))
-  | `(imp { while ($b) {$c} }) =>
-    `(Com.whileDo (bexp {$b}) (imp {$c}))
-  | `(imp { ~$c }) =>
-    pure c
+  | `(imp { $s }) => do
+    let stx ← match s with
+      | `(imp_com| skip) => ``(Com.skip)
+      | `(imp_com| brk) => ``(Com.brk)
+      | `(imp_com| $x:ident) => ``(($x : Com))
+      | `(imp_com| $c₁ ; $c₂) =>
+        ``(Com.seq (imp {$c₁}) (imp {$c₂}))
+      | `(imp_com| $x:ident := $a) =>
+        ``(Com.asgn $x (aexp {$a}))
+      | `(imp_com| if ($b) {$c₁} else {$c₂}) =>
+        ``(Com.cond (bexp {$b}) (imp {$c₁}) (imp {$c₂}))
+      | `(imp_com| while ($b) {$c}) =>
+        ``(Com.whileDo (bexp {$b}) (imp {$c}))
+      | `(imp_com| ~$c) => `(($c : Com))
+      | _ => Macro.throwUnsupported
+    return Imp.Elab.withSourceInfoOf s stx
 
 end Com
 
 open scoped Com
 
 namespace Delab
-open Lean PrettyPrinter Delaborator SubExpr Imp.Delab
+open Lean PrettyPrinter Imp.Delab
 
-/-- Rebuild `imp_com` syntax from a `BreakImp.Com` term. -/
-partial def delabComInner : DelabM (TSyntax `imp_com) :=
-  delabComInnerFor ``Com do
-    let e ← getExpr
-    guard <| e.isConstOf ``Com.brk
-    annAsTerm (← `(imp_com| $(mkIdent `brk):ident))
+@[app_unexpander Com.brk]
+private def unexpandComBrk : Unexpander
+  | _ => `(imp { $(mkIdent `brk):ident })
 
-@[delab app.BreakImp.Com.skip, delab app.BreakImp.Com.brk, delab app.BreakImp.Com.asgn,
-  delab app.BreakImp.Com.seq, delab app.BreakImp.Com.cond, delab app.BreakImp.Com.whileDo]
-partial def delabCom : Delab := whenPPOption getPPNotation do
-  match ← delabComInner with
-  | `(imp_com| ~$e) => pure e
-  | e => `(term| imp { $e })
+attribute [app_unexpander Com.skip] unexpandComSkip
+attribute [app_unexpander Com.asgn] unexpandComAsgn
+attribute [app_unexpander Com.seq] unexpandComSeq
+attribute [app_unexpander Com.cond] unexpandComCond
+attribute [app_unexpander Com.whileDo] unexpandComWhileDo
 
 end Delab
 ```
@@ -2118,28 +2273,28 @@ inductive Com.EvalR : Com → State → State → Result → Prop where
   -- SOLUTION
   | brk {st : State}  : EvalR (imp {brk}) st st sBreak
   | asgn {st : State} {a : Aexp} {n : Nat} {x : Ident} (h : a.eval st = n) :
-      EvalR (imp {x := ~a}) st (x →ₜ n ; st) sContinue
+      EvalR (imp {x := a}) st (x →ₜ n ; st) sContinue
   | seqContinue {c₁ c₂ : Com} {st st' st'' : State} {s : Result}
       (h₁ : EvalR c₁ st st' sContinue)
       (h₂ : EvalR c₂ st' st'' s) :
-      EvalR (imp {~c₁; ~c₂}) st st'' s
+      EvalR (imp {c₁; c₂}) st st'' s
   | seqBreak {c₁ c₂ : Com} {st st' : State} (h : EvalR c₁ st st' sBreak) :
-      EvalR (imp {~c₁; ~c₂}) st st' sBreak
+      EvalR (imp {c₁; c₂}) st st' sBreak
   | ifTrue {st st' : State} {b : Bexp} {c₁ c₂ : Com} {s : Result} (hb : b.eval st = true)
       (hc : EvalR c₁ st st' s) :
-      EvalR (imp {if (~b) {~c₁} else {~c₂}}) st st' s
+      EvalR (imp {if (b) {c₁} else {c₂}}) st st' s
   | ifFalse {st st' : State} {b : Bexp} {c₁ c₂ : Com} {s : Result} (hb : b.eval st = false)
       (hc : EvalR c₂ st st' s) :
-      EvalR (imp {if (~b) {~c₁} else {~c₂}}) st st' s
+      EvalR (imp {if (b) {c₁} else {c₂}}) st st' s
   | whileFalse {b : Bexp} {st : State} {c : Com} (hb : b.eval st = false) :
-      EvalR (imp {while (~b) {~c}}) st st sContinue
+      EvalR (imp {while (b) {c}}) st st sContinue
   | whileContinue {st st' st'' : State} {b : Bexp} {c : Com} (hb : b.eval st = true)
       (hc : EvalR c st st' sContinue)
-      (hloop : EvalR (imp {while (~b) {~c}}) st' st'' sContinue) :
-      EvalR (imp {while (~b) {~c}}) st st'' sContinue
+      (hloop : EvalR (imp {while (b) {c}}) st' st'' sContinue) :
+      EvalR (imp {while (b) {c}}) st st'' sContinue
   | whileBreak {st st' : State} {b : Bexp} {c : Com} (hb : b.eval st = true)
       (hc : EvalR c st st' sBreak) :
-      EvalR (imp {while (~b) {~c}}) st st' sContinue
+      EvalR (imp {while (b) {c}}) st st' sContinue
   -- END SOLUTION
 
 scoped notation:40 st0:41 " =[ " c " ]=> " st1:41 " // " s:41 => Com.EvalR c st0 st1 s
@@ -2152,7 +2307,7 @@ We don't make the notation with `c:imp_com` since it would need the custom `macr
 Now prove the following properties of your definition:
 
 ```lean
-theorem break_ignore (c : Com) (st st' : State) (s : Result) (h : st =[ imp { brk ; ~c } ]=> st' // s) :
+theorem break_ignore (c : Com) (st st' : State) (s : Result) (h : st =[ imp { brk ; c } ]=> st' // s) :
   st = st' := by
   solution!
     inversion h with
@@ -2164,7 +2319,7 @@ theorem break_ignore (c : Com) (st st' : State) (s : Result) (h : st =[ imp { br
 
 ```lean
 theorem while_continue (b : Bexp) (c : Com) (st st' : State) (s : Result)
-  (h : st =[ imp { while (~b) {~c} } ]=> st' // s) :
+  (h : st =[ imp { while (b) {c} } ]=> st' // s) :
   s = sContinue := by
   solution!
     inversion h <;> rfl
@@ -2173,25 +2328,25 @@ theorem while_continue (b : Bexp) (c : Com) (st st' : State) (s : Result)
 ```lean
 theorem while_stops_on_break (b : Bexp) (c : Com) (st st' : State)
   (h₁ : b.eval st = true)
-  (h₂ : st =[ imp { ~c } ]=> st' // sBreak) :
-  st =[ imp { while (~b) {~c} } ]=> st' // sContinue := by
+  (h₂ : st =[ imp { c } ]=> st' // sBreak) :
+  st =[ imp { while (b) {c} } ]=> st' // sContinue := by
   solution!
     apply Com.EvalR.whileBreak <;> assumption
 ```
 
 ```lean
 theorem seq_continue (c₁ c₂ : Com) (st st' st'' : State)
-  (h₁ : st =[ imp { ~c₁ } ]=> st' // sContinue)
-  (h₂ : st' =[ imp { ~c₂ } ]=> st'' // sContinue) :
-  st =[ imp { ~c₁ ; ~c₂ } ]=> st'' // sContinue := by
+  (h₁ : st =[ imp { c₁ } ]=> st' // sContinue)
+  (h₂ : st' =[ imp { c₂ } ]=> st'' // sContinue) :
+  st =[ imp { c₁ ; c₂ } ]=> st'' // sContinue := by
   solution!
     apply Com.EvalR.seqContinue (st' := st') <;> assumption
 ```
 
 ```lean
 theorem seq_stops_on_break (c₁ c₂ : Com) (st st' : State)
-  (h : st =[ imp { ~c₁ } ]=> st' // sBreak) :
-  st =[ imp { ~c₁ ; ~c₂ } ]=> st' // sBreak := by
+  (h : st =[ imp { c₁ } ]=> st' // sBreak) :
+  st =[ imp { c₁ ; c₂ } ]=> st' // sBreak := by
   solution!
     apply Com.EvalR.seqBreak <;> assumption
 ```
@@ -2200,11 +2355,11 @@ theorem seq_stops_on_break (c₁ c₂ : Com) (st st' : State)
 ::::exercise (rating := 3) (name := "while_break_true") (optional := true)
 ```lean
 theorem while_break_true (b : Bexp) (c : Com) (st st' : State)
-  (h₁ : st =[ imp { while (~b) {~c} } ]=> st' // sContinue)
+  (h₁ : st =[ imp { while (b) {c} } ]=> st' // sContinue)
   (h₂ : b.eval st' = true) :
-  ∃ st'', st'' =[ imp { ~c } ]=> st' // sBreak := by
+  ∃ st'', st'' =[ imp { c } ]=> st' // sBreak := by
   solution!
-    generalize heq : (imp {while (~b) {~c}}) = c' at h₁
+    generalize heq : (imp {while (b) {c}}) = c' at h₁
     generalize hr : sContinue = s at h₁ ⊢
     induction h₁ with (inversion heq; try lia)
     | whileContinue _ _ _ _ ih₂ =>
@@ -2217,8 +2372,8 @@ theorem while_break_true (b : Bexp) (c : Com) (st st' : State)
 ::::exercise (rating := 4) (name := "ceval_deterministic") (optional := true)
 ```lean
 theorem ceval_deterministic (c : Com) (st st₁ st₂ : State) (s₁ s₂ : Result)
-  (h₁ : st =[ imp { ~c } ]=> st₁ // s₁)
-  (h₂ : st =[ imp { ~c } ]=> st₂ // s₂) :
+  (h₁ : st =[ imp { c } ]=> st₁ // s₁)
+  (h₂ : st =[ imp { c } ]=> st₂ // s₂) :
   st₁ = st₂ ∧ s₁ = s₂ := by
   solution!
     induction h₁ generalizing st₂ s₂ with (try (inversion h₂ <;> lia))
@@ -2273,7 +2428,7 @@ theorem ceval_deterministic (c : Com) (st st₁ st₂ : State) (s₁ s₂ : Resu
 ::::
 
 ```lean
-end BreakImp
+end Imp.Break
 ```
 
 ::::exercise (rating := 4) (name := "add_for_loop") (optional := true)


### PR DESCRIPTION
This PR combines the nonrecursive delabration fallback from #256 with the current behavior from #231. So

```lean
#check
  Com.cond (Bexp.bool b)
    (.cond (Bexp.bool true)
      (.asgn y (.num <| 3 + 4))
      (.asgn (if b then x else y) a)
    ) (.skip)
```

now prints

```lean
info: imp {
  if (~(Bexp.bool b)) {
    if (true) {
      y := ~(Aexp.num (3 + 4))
    } else {
      ~(Com.asgn (if b = true then x else y) a)
    }
  } else {
    skip
  }
} : Com
```

instead of a recursive delabration failure.

Lean variables now can appear in Imp syntax without `~`. For example, given `(b : Bool) (c : Com)`:

```lean
imp {X := a}
imp { if (b) {c} else {skip} }
```

works without writing `~a`/`~b`/`~c`. Identifiers from `Aexp` are resolved by type -- `x : Indet` becomes `Aepx.id x` and `x : Aexp` is inserted directly. Delaborator always prints out `~` for round-tripping; and arithmetic patterns such as `imp { x := ~a }` still keep `~` to be explicit about what they are binding.

Delaborators for `dcom` and `sparse_dcom` are also added, with some pretty printing rules changed.