### PR TITLE
Fix recall's hidden-namespace name resolution silently falling back to root

### DIFF
--- a/SFLCompat/Recall/Check.lean
+++ b/SFLCompat/Recall/Check.lean
@@ -341,11 +341,20 @@ def elabRecallCommand (cmd : Syntax) (strictUniverse : Bool) : CommandElabM Unit
   -- resulting-type position included) resolve to the hidden copy, and
   -- every other name resolves as it would at the recall site. The
   -- namespace comes from the name generator: `_uniq` names cannot be
-  -- written in source, so it is collision-free, and unlike a macro-scoped
-  -- name it is an ordinary component, so declarations under it keep the
-  -- prefix structure that `renameBack` and the constructor comparison
-  -- rely on.
-  let ns ← liftCoreM (mkFreshId : CoreM Name)
+  -- written in source, so it is collision-free. `mkFreshId` itself returns
+  -- a name whose last component is a `Name.num`, not a `Name.str`; appended
+  -- onto `currNamespace` as-is, that trailing numeral breaks
+  -- `Lean.ResolveName.resolveUsingNamespace`, which only walks up an
+  -- enclosing-namespace chain built of `Name.str` components. The symptom
+  -- is silent: an unqualified name inside the restatement that should
+  -- resolve through the enclosing namespace instead falls through to a
+  -- same-named root declaration, if one exists (e.g. `Nat` resolving to
+  -- `_root_.Nat` instead of the local shadowing type). Converting the
+  -- fresh id to a single `Name.str` component keeps it collision-free
+  -- (its rendered form still can't be written in source) while keeping the
+  -- namespace chain walkable, and `renameBack`/the constructor comparison
+  -- only rely on structural prefix matching, which is unaffected.
+  let ns := Name.mkStr1 (← liftCoreM (mkFreshId : CoreM Name)).toString
   -- Any mismatch gets a clickable fix: replace the restatement with the
   -- original's source text, indented like the restatement. The helpers
   -- for recovering and re-indenting source are shared with the


### PR DESCRIPTION
I found a bug reviewing Induction, and asked Claude to fix it. It produced this PR.

## Summary
- `sf_recall` elaborates a restatement inside a temp namespace built as `currNamespace ++ ns` where `ns` comes from `mkFreshId`. That name's last component is a `Name.num`, not a `Name.str`; Lean's `Lean.ResolveName.resolveUsingNamespace` only walks up an enclosing-namespace chain built of `Name.str` components, so the numeric tail silently broke that walk.
- Symptom: an unqualified identifier inside the restatement that should resolve through the enclosing namespace instead fell through to a same-named root-level declaration when one existed (e.g. a chapter's own shadowing `Nat` type resolving to `_root_.Nat` inside the recall check) — sometimes a loud type mismatch, but in general this could silently swap in the wrong declaration with no error.
- Fix: build the temp namespace's fresh component as a single `Name.str` (via `Name.mkStr1 (← mkFreshId).toString`) instead of appending the raw `mkFreshId` result. Still collision-free (unwritable in source), but keeps the namespace chain walkable by `resolveUsingNamespace`. `renameBack` and the constructor comparison only rely on structural prefix matching, so they're unaffected by the component kind.

## Test plan
- [x] `lake build SFLCompat.Recall.Check` — all embedded `#guard_msgs` regression tests in the file still pass.
- [x] Minimal repro (a chapter-style shadowing `Nat`/`add` under a reopened namespace, mirroring `LF/Induction.lean`'s `NatPlayground.Nat`) — failed before the fix with the exact `_root_.Nat` mismatch, passes after.
- [x] Full `lake build` (all 574 jobs, LF/HL/TS) — no regressions in any chapter's use of `recall`/`recallSource`/`recall statement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)