### PR TITLE
Build: Install devcontainer in built artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,18 +27,30 @@ $(1)-build: ensure-build-symlink
 
 $(1)-student: $(1)-build
 	lake exe sfl-$(1) student
+	$$(call copy-devcontainer,_out/$(1)/student/lean)
 
 $(1)-solutions: $(1)-build
 	lake exe sfl-$(1) solutions
+	$$(call copy-devcontainer,_out/$(1)/solutions/lean)
 
 $(1)-terse: $(1)-build
 	lake exe sfl-$(1) terse
+	$$(call copy-devcontainer,_out/$(1)/terse/lean)
 
 $(1)-grading: $(1)-build
 	lake exe sfl-$(1) grading
+	$$(call copy-devcontainer,_out/$(1)/grading/lean)
 
 $(1): $(1)-student $(1)-solutions $(1)-terse $(1)-grading
 
+endef
+
+# Copy the repo's top-level .devcontainer into a generated lean/ output so it
+# can be opened on its own (e.g. as a Codespace) with the Lean toolchain
+# preconfigured. Re-copied on every run so it can't go stale.
+define copy-devcontainer
+	rm -rf $(1)/.devcontainer
+	cp -r .devcontainer $(1)/.devcontainer
 endef
 
 # ── Volume definitions ────────────────────────────────────────────────────────

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -121,6 +121,17 @@ def build_student(vol):
     subprocess.run(["scripts/relocate-lake-build.sh"], cwd=REPO_ROOT, check=True)
     subprocess.run(["lake", "build", f"sfl-{vol}"], cwd=REPO_ROOT, check=True)
     subprocess.run(["lake", "exe", f"sfl-{vol}", "student"], cwd=REPO_ROOT, check=True)
+    copy_devcontainer(REPO_ROOT / f"_out/{vol}/student/lean")
+
+
+def copy_devcontainer(lean_dir):
+    """Copy the repo's top-level .devcontainer into a generated lean/ output
+    (mirrors the Makefile's copy-devcontainer, for the `make release` path
+    which calls `lake` directly rather than through the volume targets)."""
+    dest = lean_dir / ".devcontainer"
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(REPO_ROOT / ".devcontainer", dest)
 
 
 def strip_excluded_from_lean_output(vol, excluded):


### PR DESCRIPTION
So that students (and others) can make use of the .devcontainer in the SFL sources, this commit updates the Makefile to copy it into the directories of the output lean projects when building is complete. It also updates the package-release script to include the devcontainer in the release package.

Code written by Claude.