### PR TITLE
Add normalize tactic using `solve_by_elim`.

### DIFF
--- a/TS/AttributeDecls.lean
+++ b/TS/AttributeDecls.lean
@@ -1,0 +1,10 @@
+module
+
+import Lean
+
+-- Smallstep.lean
+register_label_attr SimpleArith
+
+-- Stlc.lean
+register_label_attr StlcEval
+register_label_attr StlcTyping

--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -1,6 +1,7 @@
 import SFLMeta
 
 import TS.Slang
+import TS.AttributeDecls
 
 open Verso.Genre Manual
 open SFLMeta
@@ -1861,3 +1862,126 @@ theorem compiler_is_correct (a : Aexp) :
 ```lean
 end Slang
 ```
+
+## Automation with {tactic}`solve_by_elim`
+
+::::full
+When experimenting with definitions of programming languages
+in Lean, we often want to see what a particular term steps
+to - i.e., we want to find proofs for goals of the form `t ⟶* t'`.
+Consider, for example, reducing an arithmetic expression using the small-step
+relation `AStep`.
+::::
+
+::::terse
+Proofs that one expression multisteps to another can be tedious...
+::::
+
+```lean
+example : (.p (.c 3) (.p (.c 3) (.c 4))) ⟶* (.c 10) := by
+  apply Multi.step (y := .p (.c 3) (.c 7))
+  . apply Step.plusRight
+    . apply IsValue.const
+    . apply Step.plus
+  . apply Multi.step (y := .c 10)
+    . apply Step.plus
+    . apply Multi.refl
+```
+
+::::full
+Proofs that one term normalizes to another must repeatedly apply
+`Multi.step` until the term reaches a normal form, with some very simple
+intermediate steps along the way. Thankfully, we can automate this process
+with a new tactic: {tactic}`solve_by_elim`. When supplied with a list of
+constructors, `solve_by_elim [c₁, c₂, c₃, ...]` will attempt to apply
+these constructors repeatedly to a goal. It will also automatically
+attempt to use simple tactics like {tactic}`rfl`, {tactic}`trivial`, {tactic}`congr` and hypotheses
+from the context in order to solve simple goals. So, for example,
+the proof above also be written:
+::::
+
+::::terse
+We can automate such tedious proofs with {tactic}`solve_by_elim`:
+::::
+
+```lean
+example : (.p (.c 3) (.p (.c 3) (.c 4))) ⟶* (.c 10) := by
+  repeat apply Multi.step <;>
+    try solve_by_elim [Step.plusRight, Step.plusLeft, Step.plus, IsValue.const]
+```
+
+This one script would suffice to prove most concrete reduction sequences
+for this simple language. To make it work for others, we would need to supply
+constructors for those other languages to {tactic}`solve_by_elim`. The languages we
+will study in this book can grow to a large number of constructors for their `Step`
+relations, so we'd like a way to supply all of them to {tactic}`solve_by_elim` more easily.
+Luckily, Lean supports this. We can register a constructor (or lemma) for use with
+{tactic}`solve_by_elim` with an `attribute` command:
+
+:::instructors
+It is deeply unfortunate that Lean does not allow you to create an attribute and then
+register a constructor with it in the same file. What I have done instead
+is create an `AttributeDecls` file that we can import (similarly to how we import a `CustomTactics`
+file in LF) that pre-declares all the attribute names we care about. This is apparently what
+Mathlib does.
+:::
+
+:::details "Attributes"
+The command below tags all of these constructors with the `SimpleArith` attribute,
+which we can then use to automatically pull all of these constructors in when we use
+{tactic}`solve_by_elim`. However, due to a limitation of Lean, this attribute needs to be
+pre-declared in a different file; we can't create it here and then immediately use it.
+
+For this book, we've predeclared all the attributes we'll use in a file called
+`AttributeDecls.lean`, following the typical pattern from libraries like Mathlib.
+:::
+
+```lean
+attribute [SimpleArith] Step.plusRight Step.plusLeft Step.plus IsValue.const
+```
+
+This `using` option then tells {tactic}`solve_by_elim` to try to use every constructor
+we've registered with the supplied attribute:
+
+```lean
+example : (.p (.c 3) (.p (.c 3) (.c 4))) ⟶* (.c 10) := by
+  repeat apply Multi.step <;>
+    try solve_by_elim using SimpleArith
+```
+
+We can package all this up into a dedicated tactic for solving reduction sequences,
+which we'll call `normalize`:
+
+```lean
+syntax "normalize" " using " ident,+ : tactic
+
+macro_rules
+  | `(tactic| normalize using $xs,*) =>
+    `(tactic| repeat apply Multi.step <;> try solve_by_elim using $xs,*)
+```
+
+And voilà:
+
+```lean
+example : (.p (.c 3) (.p (.c 3) (.c 4))) ⟶* (.c 10) := by
+  normalize using SimpleArith
+```
+
+:::::full
+::::exercise (rating := 1) (name := "normalize_ex")
+Use the `normalize` tactic to prove the following. You will need to supply the
+term `e'` yourself.
+
+```lean
+theorem normalize_ex : exists e', (.p (.c 3) (.p (.c 2) (.c 1))) ⟶* e' ∧ IsValue e' := by
+  solution!
+    exists (.c 6); constructor
+    . normalize using SimpleArith
+    . constructor
+```
+
+:::gradeTheorem 3 normalize_ex
+:::
+
+::::
+:::::

--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -1957,7 +1957,7 @@ syntax "normalize" " using " ident,+ : tactic
 
 macro_rules
   | `(tactic| normalize using $xs,*) =>
-    `(tactic| repeat apply Multi.step <;> try solve_by_elim using $xs,*)
+    `(tactic| repeat apply Multi.step <;> try solve_by_elim (maxDepth:=10) using $xs,*)
 ```
 
 And voilà:

--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -1957,7 +1957,12 @@ syntax "normalize" " using " ident,+ : tactic
 
 macro_rules
   | `(tactic| normalize using $xs,*) =>
-    `(tactic| repeat apply Multi.step <;> try solve_by_elim (maxDepth:=10) using $xs,*)
+    `(tactic|
+      first
+      | apply Multi.refl
+      | (apply Multi.step
+         . solve_by_elim (maxDepth := 15) (constructor := false) only using $xs,*
+         . normalize using $xs,*))
 ```
 
 And voilà:

--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -1880,12 +1880,12 @@ Proofs that one expression multisteps to another can be tedious...
 ```lean
 example : (.p (.c 3) (.p (.c 3) (.c 4))) ⟶* (.c 10) := by
   apply Multi.step (y := .p (.c 3) (.c 7))
-  . apply Step.plusRight
-    . apply IsValue.const
-    . apply Step.plus
-  . apply Multi.step (y := .c 10)
-    . apply Step.plus
-    . apply Multi.refl
+  · apply Step.plusRight
+    · apply IsValue.const
+    · apply Step.plus
+  · apply Multi.step (y := .c 10)
+    · apply Step.plus
+    · apply Multi.refl
 ```
 
 ::::full
@@ -1961,8 +1961,8 @@ macro_rules
       first
       | apply Multi.refl
       | (apply Multi.step
-         . solve_by_elim (maxDepth := 15) (constructor := false) only using $xs,*
-         . normalize using $xs,*))
+         · solve_by_elim (maxDepth := 15) (constructor := false) only using $xs,*
+         · normalize using $xs,*))
 ```
 
 And voilà:
@@ -1981,8 +1981,8 @@ term `e'` yourself.
 theorem normalize_ex : exists e', (.p (.c 3) (.p (.c 2) (.c 1))) ⟶* e' ∧ IsValue e' := by
   solution!
     exists (.c 6); constructor
-    . normalize using SimpleArith
-    . constructor
+    · normalize using SimpleArith
+    · constructor
 ```
 
 :::gradeTheorem 3 normalize_ex

--- a/TS/Stlc.lean
+++ b/TS/Stlc.lean
@@ -1247,6 +1247,9 @@ end
 
 scoped notation:40 t:41 " ⟶ " t':41 => Step t t'
 scoped notation:40 t:41 " ⟶* " t':41 => Multi Step t t'
+
+-- for later use with `normalize`
+attribute [StlcEval] Step.appAbs Step.app1 Step.app2 Step.ifTrue Step.ifFalse Step.ifStep
 ```
 
 ::::full
@@ -1442,6 +1445,23 @@ example : <{ ~idBB (~notB true) }> ⟶* <{ false }> := by
   · rfl
 ```
 
+As in the {ref "Smallstep"}[Smallstep] chapter, we can use the `normalize` tactic to simplify
+these proofs:
+
+```lean
+example : <{ ~idBB ~idB }> ⟶* idB := by
+  normalize using StlcEval
+
+example : <{ ~idBB (~idBB ~idB) }> ⟶* idB := by
+  normalize using StlcEval
+
+example : <{ ~idBB ~notB true }> ⟶* <{ false }> := by
+  normalize using StlcEval
+
+example : <{ ~idBB (~notB true) }> ⟶* <{ false }> := by
+  normalize using StlcEval
+```
+
 ::::quiz
 Do values and normal forms coincide in the language presented so far?
 
@@ -1456,20 +1476,11 @@ E.g., `true true` is a normal form but not a value.
 :::
 
 ::::::full
-:::dev
-The Rocq source repeats the four examples above using the `normalize` tactic
-defined in its `Smallstep` chapter, and the exercise below asks for
-`step_example5` both with and without it.  We have no such tactic: the
-{ref "Smallstep"}[Smallstep] chapter here does not define one, so the repeats
-are dropped and the exercise is stated once, proved by hand.  Writing a
-`normalize` tactic — repeatedly applying {name}`Multi.step` with the unique
-available reduction, then closing with reflexivity — is the natural follow-up,
-and it belongs in the Smallstep chapter, not here.
-:::
-
 :::::exercise (rating := 2) (name := "step_example5")
+Try to do this one both with and without normalize.
+
 ```lean
-example : <{ ~idBBBB ~idBB ~idB }> ⟶* idB := by
+theorem stepExample5 : <{ ~idBBBB ~idBB ~idB }> ⟶* idB := by
   solution!
     apply Multi.step (y := <{ ~idBB ~idB }>)
     · exact .app1 <{ ~idBBBB ~idBB }> idBB idB
@@ -1478,6 +1489,19 @@ example : <{ ~idBBBB ~idBB ~idB }> ⟶* idB := by
     · exact .appAbs "x" <{ Bool → Bool }> <{ x }> idB idB_value
     · rfl
 ```
+
+:::gradeTheorem "1.5" stepExample5
+:::
+
+```lean
+theorem stepExample5' : <{ ~idBBBB ~idBB ~idB }> ⟶* idB := by
+  solution!
+    normalize using StlcEval
+```
+
+:::gradeTheorem "0.5" stepExample5'
+:::
+
 :::::
 
 ::::::
@@ -1679,6 +1703,8 @@ inductive HasType : Context → Tm → Ty → Prop where
       (h₁ : <{ ~Γ ⊢ ~t₁ ⦂ Bool }>) (h₂ : <{ ~Γ ⊢ ~t₂ ⦂ ~T₁ }>)
       (h₃ : <{ ~Γ ⊢ ~t₃ ⦂ ~T₁ }>) :
       <{ ~Γ ⊢ if ~t₁ then ~t₂ else ~t₃ ⦂ ~T₁ }>
+
+attribute [StlcTyping] HasType.var HasType.abs HasType.app HasType.tru HasType.fls HasType.ite
 ```
 
 ::::details "Notation encoding: the judgment, for real"
@@ -1776,25 +1802,24 @@ variable (x : String)
 ## Examples
 
 ```lean
-example : <{ ∅ ⊢ λ x : Bool . x ⦂ Bool → Bool }> :=
-  .abs _ "x" _ _ _ (.var _ "x" _ rfl)
+example : <{ ∅ ⊢ λ x : Bool . x ⦂ Bool → Bool }> := by
+  apply HasType.abs
+  apply HasType.var; rfl
 ```
 
 The derivation is small enough to write out directly: an abstraction rule
 whose premise is the variable rule, and the variable rule's premise — that the
 extended context maps `x` to `Bool` — holds by computation, hence `rfl`.
 
-:::dev
-The Rocq source proves this one, and the next, by `eauto`, having registered
-the `has_type` constructors in the `core` hint database; it also observes that
-plain `auto` suffices here because the term contains no application nodes.  We
-have no hint database, so both derivations are given explicitly.
-:::
-
 :::slidebreak
 :::
 
-More examples:
+Much like reduction sequences, long derivations of typing rules can grow
+quite tedious to prove. Luckily, we can have Lean automate proofs of this sort,
+using another tactic: {tactic}`apply_rules`. This tactic works much like
+{tactic}`normalize`, but is more efficient and will make progress even if it cannot
+solve the goal outright. Like {tactic}`normalize`, {tactic}`apply_rules` also
+takes a `using` argument which tells Lean which set of constructors to draw from.
 
 ```display
 ∅ ⊢ λx:Bool. λy:Bool → Bool. y (y x)
@@ -1804,15 +1829,23 @@ More examples:
 ```lean
 example :
     <{ ∅ ⊢ λ x : Bool . λ y : Bool → Bool . y (y x) ⦂
-       Bool → (Bool → Bool) → Bool }> :=
-  .abs _ _ _ _ _ (.abs _ _ _ _ _
-    (.app _ _ Ty.bool _ _ (.var _ "y" _ rfl)
-      (.app _ _ Ty.bool _ _ (.var _ "y" _ rfl) (.var _ "x" _ rfl))))
+       Bool → (Bool → Bool) → Bool }> := by
+  apply_rules using StlcTyping
 ```
+
+It's worth noting that  {tactic}`apply_rules` relies on an important property
+of our typing rules - namely, that they are _syntax directed_. A syntax directed
+judgment is one where the syntax of a term completely determines which rule
+can be applied at any given time; only one rule can be applied to each term.
+This is important because {tactic}`apply_rules` just applies the first rule in
+its set of constructors or lemmas that it can - it doesn't backtrack if that rule
+isn't correct. So, making sure that only one rule can apply to any given term
+is important to ensure that {tactic}`apply_rules` always discovers a valid
+derivation, if one exists.
 
 ::::::full
 :::::exercise (rating := 2) (name := "typing_example_2_full") (optional := true)
-Prove the same result in tactic mode, applying one rule at a time and
+Prove the same result, applying one rule at a time and
 naming the argument type of each application explicitly.
 
 ```lean
@@ -1846,12 +1879,10 @@ Formally prove the following typing derivation holds:
 ```lean
 example :
     ∃ T, <{ ∅ ⊢ λ x : Bool → Bool . λ y : Bool → Bool . λ z : Bool . y (x z)
-            ⦂ ~T }> :=
-  solution!(
-    ⟨<{ (Bool → Bool) → (Bool → Bool) → (Bool → Bool) }>,
-     .abs _ _ _ _ _ (.abs _ _ _ _ _ (.abs _ _ _ _ _
-       (.app _ _ Ty.bool _ _ (.var _ "y" _ rfl)
-         (.app _ _ Ty.bool _ _ (.var _ "x" _ rfl) (.var _ "z" _ rfl)))))⟩)
+            ⦂ ~T }> := by
+  solution!
+    exists <{ (Bool → Bool) → (Bool → Bool) → (Bool → Bool) }>
+    apply_rules using StlcTyping
 ```
 :::::
 

--- a/TS/Stlc.lean
+++ b/TS/Stlc.lean
@@ -763,6 +763,8 @@ inductive Tm.IsValue : Tm → Prop where
   | abs (x : String) (T₂ : Ty) (t₁ : Tm) : Tm.IsValue <{ λ ~x : ~T₂ . ~t₁ }>
   | tru : Tm.IsValue <{ true }>
   | fls : Tm.IsValue <{ false }>
+
+attribute [StlcEval] Tm.IsValue.abs Tm.IsValue.tru Tm.IsValue.fls
 ```
 
 ::::full

--- a/TS/StlcProp.lean
+++ b/TS/StlcProp.lean
@@ -409,18 +409,18 @@ order...
 
 First, we show that typing is preserved under "extensions" to the
 context `Γ`.  (Recall map inclusion, `Γ ⊆ Γ'`, from the `Typeclasses` chapter.)
+Through judicious use of `apply_rules`, we can heavily automate this proof.
+The tactic after `with` is applied to every case of the {tactic}`induction`,
+and has two options. The first one attempts to solve the goal with repeated
+applications of `HasType` constuctors, while the latter deals with
+goals where variables are added to the context using `PartialMap.update_subset`.
 
 ```lean
--- IN PROGRESS
-theorem weakening (Γ Γ' : Context) (t : Tm) (T : Ty)
-    (hi : Γ ⊆ Γ') (hT : <{ ~Γ ⊢ ~t ⦂ ~T }>) : <{ ~Γ' ⊢ ~t ⦂ ~T }> := by
-  induction hT generalizing Γ' with
-  | var _ x _ h => exact .var _ x _ (hi h)
-  | abs _ x _ _ _ _ ih => exact .abs _ x _ _ _ (ih _ (PartialMap.update_subset _ _ _ _ hi))
-  | app _ _ _ _ _ _ _ ih₁ ih₂ => exact .app _ _ _ _ _ (ih₁ _ hi) (ih₂ _ hi)
-  | tru => exact .tru _
-  | fls => exact .fls _
-  | ite _ _ _ _ _ _ _ _ ih₁ ih₂ ih₃ => exact .ite _ _ _ _ _ (ih₁ _ hi) (ih₂ _ hi) (ih₃ _ hi)
+theorem weakening {Γ Γ' : Context} {t : Tm} {τ : Ty}
+    (hi : Γ ⊆ Γ') (ht : <{ ~Γ ⊢ ~t ⦂ ~τ }>) : <{ ~Γ' ⊢ ~t ⦂ ~τ }> := by
+  induction ht generalizing Γ' with (first
+    | apply_rules using StlcTyping; done
+    | constructor <;> apply_rules [PartialMap.update_subset])
 ```
 
 :::slidebreak
@@ -429,12 +429,12 @@ theorem weakening (Γ Γ' : Context) (t : Tm) (T : Ty)
 The following simple corollary is what we actually need below.
 
 ```lean
-theorem weakening_empty (Γ : Context) (t : Tm) (T : Ty) (hT : <{ ∅ ⊢ ~t ⦂ ~T }>) :
-    <{ ~Γ ⊢ ~t ⦂ ~T }> :=
-  weakening _ _ _ _
-    (fun h => by
-      rw [PartialMap.getElem_empty] at h
-      cases h) hT
+theorem weakening_empty {Γ : Context} {t : Tm} {τ : Ty} (ht : <{ ∅ ⊢ ~t ⦂ ~τ }>) :
+    <{ ~Γ ⊢ ~t ⦂ ~τ }> := by
+  apply weakening _ ht
+  intro _ _ h
+  rw [PartialMap.getElem_empty] at h
+  contradiction
 ```
 
 ## The Substitution Lemma
@@ -488,7 +488,7 @@ theorem substitution_preserves_typing (Γ : Context) (x : String) (U : Ty)
         rw [subst_var_eq]
         have hUT : U = T := Option.some.inj h
         subst hUT
-        exact weakening_empty _ _ _ hv
+        exact weakening_empty hv
       · rw [PartialMap.update_neq hxy] at h
         rw [subst_var_ne _ _ _ hxy]
         exact .var _ y _ h
@@ -598,7 +598,7 @@ theorem substitution_preserves_typing_from_typing_ind (Γ : Context) (x : String
         rw [subst_var_eq]
         have hUT : U = T₁ := Option.some.inj h
         subst hUT
-        exact weakening_empty _ _ _ hv
+        exact weakening_empty hv
       · rw [PartialMap.update_neq hxy] at h
         rw [subst_var_ne _ _ _ hxy]
         exact .var _ y _ h

--- a/TS/StlcProp.lean
+++ b/TS/StlcProp.lean
@@ -409,18 +409,38 @@ order...
 
 First, we show that typing is preserved under "extensions" to the
 context `Γ`.  (Recall map inclusion, `Γ ⊆ Γ'`, from the `Typeclasses` chapter.)
-Through judicious use of `apply_rules`, we can heavily automate this proof.
-The tactic after `with` is applied to every case of the {tactic}`induction`,
-and has two options. The first one attempts to solve the goal with repeated
-applications of `HasType` constuctors, while the latter deals with
-goals where variables are added to the context using `PartialMap.update_subset`.
 
 ```lean
 theorem weakening {Γ Γ' : Context} {t : Tm} {τ : Ty}
     (hi : Γ ⊆ Γ') (ht : <{ ~Γ ⊢ ~t ⦂ ~τ }>) : <{ ~Γ' ⊢ ~t ⦂ ~τ }> := by
-  induction ht generalizing Γ' with (first
-    | apply_rules using StlcTyping; done
-    | constructor <;> apply_rules [PartialMap.update_subset])
+  induction ht generalizing Γ' with
+  | var =>
+      constructor; apply hi; assumption
+  | abs _ _ _ _ _ _ ih =>
+      constructor; apply ih; apply PartialMap.update_subset; assumption
+  | app _ _ _ _ _ _ _ ih₁ ih₂ =>
+      constructor
+      . exact ih₁ hi
+      . exact ih₂ hi
+  | tru => constructor
+  | fls => constructor
+  | ite _ _ _ _ _ _ _ _ ih₁ ih₂ ih₃ =>
+      constructor
+      . exact ih₁ hi
+      . exact ih₂ hi
+      . exact ih₃ hi
+```
+
+Through judicious use of `apply_rules`, we can heavily automate this proof.
+The tactic after `with` is applied to every case of the {tactic}`induction`
+and handles all the cases using {tactic}`apply_rules`'s automation.
+We must give the tactic access to all the `HasType` constructors and the
+{name}`PartialMap.update_subset` lemma for this to work:
+
+```lean
+theorem weakening' {Γ Γ' : Context} {t : Tm} {τ : Ty}
+    (hi : Γ ⊆ Γ') (ht : <{ ~Γ ⊢ ~t ⦂ ~τ }>) : <{ ~Γ' ⊢ ~t ⦂ ~τ }> := by
+  induction ht generalizing Γ' with (apply_rules [PartialMap.update_subset] using StlcTyping)
 ```
 
 :::slidebreak

--- a/TS/Types.lean
+++ b/TS/Types.lean
@@ -410,7 +410,7 @@ def Tm.IsStuck (t : Tm) : Prop := Tm.IsNormalForm t ∧ ¬ Tm.IsValue t
 ```lean
 theorem some_term_is_stuck : ∃ t, Tm.IsStuck t := by
   solution!
-    refine ⟨<{ succ false }>, ?_, ?_⟩
+    exists <{ succ false }>; constructor
     · intro hc; obtain ⟨t', hstp⟩ := hc
       cases hstp with
       | succStep _ _ h => cases h


### PR DESCRIPTION
This introduces a new automation tactic for use with small step evaluation derivations. It also teaches use of `apply_rules` to solve goals that are repeated applications of constructors. 

This will come especially in handy for the proofs in https://github.com/plclub/sf-in-lean/pull/349