### PR TITLE
Gradescope autograder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ TS/*Verso.lean
 # Personal keybinding cheat sheet and its generator (see .vscode/KEYBINDINGS-SETUP.md).
 .vscode/KEYBINDINGS*.md
 .vscode/keybindings-ref.*
+
+# Gradescope autograder build output (gradescope/package.py).
+gradescope/*.zip
+gradescope/autograder/
+gradescope/context/

--- a/GRADESCOPE-AUTOGRADER.md
+++ b/GRADESCOPE-AUTOGRADER.md
@@ -1,0 +1,56 @@
+# Gradescope autograder
+
+This tool grades a student submission on Gradescope using [comparator-autograder](https://github.com/plclub/comparator-autograder); the `:::gradeTheorem` directive it reads is described in AUTOMATED-GRADING.md. Students may upload chapter `.lean` file(s) directly, or a folder or a zip containing the `.lean` file(s) as Gradescope will unpack them automatically.
+
+
+## Build
+
+Run `make` first (and watch for warnings), then one of:
+
+```bash
+python3 gradescope/package.py --chapter Basics              # grade chapter Basics
+python3 gradescope/package.py --chapter Basics,Induction    # grade several chapters
+python3 gradescope/package.py                               # grade all released chapters
+```
+
+This gives you `gradescope/autograder.zip`:
+
+    autograder.zip
+    |-- setup.sh          runs when Gradescope builds the image
+    |-- run_autograder    runs once per submission; Gradescope's entrypoint
+    |-- grade.py          runs once per submission to grade and report
+    |-- config.env        this assignment's settings
+    `-- context/          the Lean workspace, will be copied to /opt/grader/workspace
+        |-- lakefile.toml
+        |-- lean-toolchain
+        |-- Challenge/     graded chapters from `grading`, the rest solved
+        |-- Solution/      graded chapters as skeletons, the rest solved
+        |-- SFLCompat.lean
+        `-- SFLCompat/
+
+Upload `autograder.zip` to Gradescope "Configure Autograder" and select Ubuntu 22.04 (the most recent version) as the base image to build.
+
+The context is the released part of the textbook: the chapters in
+`scripts/release_chapters.json` plus the support modules (`SFLCompat`, `CustomTactics`) that chapters import.
+
+For both the **Challenge** and the **Solution** side, the chapters that are not part of the assignment (not passed as an argument to `package.py`) are copied from the `solutions` variant. For the **Challenge** side, the chapters we'd like to grade are taken from the `grading` variant of the released chapters that contain `autogradedProof` and `autogradedHole` attributes. For the **Solution** side, the chapters we'd like to grade are the student submission (or the empty `student` variant if the file is not found in the submission). Chapters that are not part of the assignment but are included in the submission are ignored but listed in
+the output, so students will know that they uploaded the wrong files.
+
+Exercises with a `GRADE_MANUAL` spec (without `(optional := true)`) should not carry the `autogradedProof` attribute. `package.py` reads them from the
+chapter sources into `config.env` and outputs a reminder to create the manually graded components on Gradescope.
+
+
+## Test locally
+
+Example usage:
+
+```bash
+python3 gradescope/package.py --dev _out/lf/solutions/lean/LF/Basics.lean   # one file
+python3 gradescope/package.py --dev path/to/dir  # a folder containing multiple chapters
+```
+
+## Notes
+
+Sandbox is not currently supported on Gradescope. The comparator runs `lake` and `lean4export` through `$COMPARATOR_LANDRUN`. Real [landrun](https://github.com/zouuup/landrun) would confine them with Linux
+Landlock: It needs kernel 5.13+, but Gradescope's runners are Amazon Linux 2 on 4.14. `setup.sh` therefore checks `uname -r` and skips building landrun when the kernel is too old, so grading runs through the `fake-landrun.sh` and logs `sandbox=NONE`.
+

--- a/gradescope/grade.py
+++ b/gradescope/grade.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+# Claude-generated (see CLAUDE.md, "Marking AI-generated material").
+"""Grade one uploaded chapter and write Gradescope's results.json.
+
+The submission becomes the Solution side of a comparator-autograder run; the
+Challenge side is the chapter's grading build, which carries the grading
+attributes. Points come from those attributes, not from anything here.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from fractions import Fraction
+from pathlib import Path
+
+WORKSPACE  = Path(os.environ.get("SFL_WORKSPACE",  "/opt/grader/workspace"))
+BIN        = Path(os.environ.get("SFL_BIN",        "/opt/grader/bin"))
+SUBMISSION = Path(os.environ.get("SFL_SUBMISSION", "/autograder/submission"))
+RESULTS    = Path(os.environ.get("SFL_RESULTS",    "/autograder/results/results.json"))
+VOLUME     = os.environ.get("SFL_VOLUME",  "LF")
+# The chapters this assignment grades: the only ones scored, and the only ones a
+# submission may replace. package.py resolves "*" before writing config.env, so
+# this is always a concrete list.
+CHAPTERS   = [c.strip() for c in os.environ.get("SFL_CHAPTER", "Basics").split(",")
+              if c.strip()]
+MANUAL = [e.strip() for e in os.environ.get("SFL_MANUAL", "").split(",") if e.strip()]
+IMPORT = re.compile(r"(?m)^import (LF|HL|TS)\b")
+# Under Gradescope's 600s, so an overrun is our message, not a platform kill.
+TIMEOUT    = int(os.environ.get("SFL_TIMEOUT", "480"))
+_T0 = time.monotonic()
+SANDBOXED = False        # set in main() from sandbox_kind()
+
+
+def log(msg):
+    """Progress on stdout, which Gradescope shows to instructors only. Flushed,
+    because when the platform kills a run this is all there is to go on."""
+    print(f"[sfl] +{time.monotonic() - _T0:6.1f}s  {msg}", flush=True)
+
+
+def time_left(cmd):
+    """Seconds left for `cmd`, keeping the whole run below `TIMEOUT`."""
+    remaining = TIMEOUT - (time.monotonic() - _T0)
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired(cmd, TIMEOUT)
+    return remaining
+
+
+def clean_build():
+    """Discard cached root-package outputs before a build or comparison.
+
+    Lean's cache uses filesystem timestamps. Replacing a submission in the
+    same timestamp tick can otherwise reuse the previous student's `.olean`.
+    Clearing the root package also prevents a submitted elaborator from
+    carrying modified Challenge artifacts into the comparison.
+    """
+    subprocess.run(["lake", "clean", "sfl-grader"], cwd=WORKSPACE, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                   timeout=time_left("clearing build artifacts"))
+
+
+def rewrite(text, side):
+    """`import LF.Basics` -> `import Challenge.LF.Basics`, so both libraries can
+    coexist in one workspace. setup.sh applies this when staging and main()
+    applies it to the submission."""
+    return IMPORT.sub(rf"import {side}.\1", text)
+
+
+def human(names):
+    """Chapter names as a student sees them: `Basics.lean`, `Induction.lean`."""
+    return ", ".join(f"`{n}.lean`" for n in names)
+
+
+def listing(names):
+    """`a`, `b` and `c` -- prose, so the last item gets an "and"."""
+    q = [f"`{n}`" for n in names]
+    return q[0] if len(q) == 1 else ", ".join(q[:-1]) + " and " + q[-1]
+
+
+def emit(output, tests=None):
+    """Write results.json and stop. Gradescope reads nothing else."""
+    payload = {"output": output, "output_format": "md", "test_output_format": "md"}
+    if tests is None:
+        payload["score"] = 0.0
+    else:
+        payload["tests"] = tests
+    RESULTS.parent.mkdir(parents=True, exist_ok=True)
+    RESULTS.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    sys.exit(0)
+
+
+def find_submissions():
+    """What the student uploaded, split into what this assignment grades and
+    what it does not.
+
+    We allow the submission to be `.lean` files, a folder, or a zip. Gradescope
+    unpacks archives on arrival, so all three arrive as files and a recursive
+    search covers them. Anything under a dot-directory or `__MACOSX` is skipped:
+    a student who zips their project folder brings `.lake` along, and its
+    packages contain plenty of `.lean` files that are not their work.
+
+    Extra chapters are ignored rather than rejected, but they are reported, so
+    a student who did the work in the wrong file finds out instead of silently
+    scoring zero. If the same chapter appears twice we emit an error message."""
+    wanted = set(CHAPTERS)
+    graded, ignored, dupes = {}, [], {}
+    for p in sorted(SUBMISSION.rglob("*.lean")):
+        rel = p.relative_to(SUBMISSION)
+        if not p.is_file() or any(part.startswith(".") or part == "__MACOSX"
+                                  for part in rel.parts):
+            continue
+        if p.stem not in wanted:
+            ignored.append(str(rel))
+        elif p.stem in graded:
+            dupes.setdefault(p.stem, [str(graded[p.stem].relative_to(SUBMISSION))]).append(str(rel))
+        else:
+            graded[p.stem] = p
+    if dupes:
+        emit("**Your submission has more than one copy of the same chapter.**\n\n"
+             + "\n".join(f"- `{k}.lean`: " + ", ".join(f"`{v}`" for v in vs)
+                         for k, vs in dupes.items())
+             + "\n\nRemove the duplicates and resubmit, so it is unambiguous which "
+               "one should be graded.")
+    if not graded:
+        emit(f"**Nothing this assignment grades was found in your submission.**\n\n"
+             f"It grades {human(sorted(wanted))}."
+             + (f"\n\nIgnored: {', '.join(f'`{n}`' for n in ignored[:8])}."
+                if ignored else ""))
+    return graded, ignored
+
+
+MAX_ERRORS = 5
+
+def clean_log(raw):
+    """Reduce `lake build` output to the diagnostics a student can act on. lake
+    interleaves progress bars, the full `lean` command line (`trace:`) and every
+    `#check` in the chapter (`info:`) with the real errors, and one bad
+    definition cascades into a dozen more."""
+    kept, keeping, errors = [], False, 0
+    for line in raw.splitlines():
+        m = re.match(r"^(error|warning|info|trace):", line)
+        if m:
+            keeping = m.group(1) in ("error", "warning")
+            errors += 1 if line.startswith("error:") else 0
+        elif re.match(r"^[✔✖⚠ℹ]", line):       # a lake progress line
+            keeping = False
+        if keeping and errors <= MAX_ERRORS:
+            kept.append(line)
+    text = "\n".join(kept).replace(f"Solution/{VOLUME}/", "")
+    if errors > MAX_ERRORS:
+        text += f"\n\n... and {errors - MAX_ERRORS} further error(s)."
+    if errors > 1:
+        text += ("\n\nLater errors are often knock-on effects of the first, so "
+                 "start at the top.")
+    return text or raw[-2000:]
+
+
+def chapter_points(ch):
+    """What a chapter is worth, read off the Challenge side. Needed to score a
+    chapter that failed to compile: its theorems cannot be reported, but they
+    still have to count against the total."""
+    f = WORKSPACE / "Challenge" / VOLUME / f"{ch}.lean"
+    return sum((Fraction(p) * len(n.split()) for p, n in
+                re.findall(r"(?m)^attribute \[autogradedProof ([0-9./]+)\] (.*)$",
+                           f.read_text(encoding="utf-8"))), Fraction(0))
+
+
+def explain(error, name=None):
+    """A comparator FailureReason, as something a student can act on."""
+    reason = next(iter(error))
+    body = error[reason] if isinstance(error[reason], dict) else {}
+    target = body.get("target")
+    if reason == "illegalAxiom":
+        axiom = body.get("axiomName", "")
+        if "sorryAx" in str(axiom):
+            return "Incomplete: this proof still contains `sorry`."
+        return f"Uses the axiom `{axiom}`, which is not allowed here."
+    if reason == "constDoesNotMatch":
+        if target == name:
+            return ("This theorem's statement is not the one you were given. Prove "
+                    "the statement as written and do not change it.")
+        return (f"`{target}` differs from the version you were given. Fill in the "
+                f"parts marked `sorry`, but leave what you were handed unchanged.")
+    if reason == "constNotFoundInSolution":
+        return (f"`{target}` is missing from your submission. Do not rename or "
+                f"delete the declarations you were given; just fill them in.")
+    if reason == "wrongKind":
+        return (f"`{target}` is declared as a different kind of declaration than "
+                f"expected (for example `def` where a `theorem` was asked for). "
+                f"Please do not modify the declarations you were given.")
+    if reason == "holeDoesNotMatch":
+        return (f"`{target}` must keep the name and type you were given; please "
+                f"write the definition only.")
+    return f"`{target}` does not match what was expected ({reason})."
+
+
+def autograde(challenge, solution):
+    """Run comparator-autograder over the workspace, returning its JSON report."""
+    # A file, not a pipe: reading the report before draining stderr can deadlock
+    # once the comparator fills the stderr buffer. Kept outside the workspace,
+    # which the sandbox does not make writable.
+    with tempfile.TemporaryDirectory(prefix="sfl-autograder-") as tmp:
+        report = Path(tmp) / "report.json"
+        env = {**os.environ,
+               "AUTOGRADER_CHALLENGE": challenge,
+               "AUTOGRADER_SOLUTION": solution,
+               "AUTOGRADER_SKIP_IMPORTS": "true",  # this chapter only
+               "AUTOGRADER_EXPORT_PATH": str(report),
+               "AUTOGRADER_EXPORT_FORMAT": "json",
+               "COMPARATOR_LEAN4EXPORT": str(BIN / "lean4export"),
+               # setup.sh puts either real landrun or the unsandboxed shim here.
+               "COMPARATOR_LANDRUN": os.environ.get("SFL_LANDRUN", str(BIN / "landrun"))}
+        log(f"comparing {challenge}")
+        p = subprocess.Popen(["lake", "env", str(BIN / "comparatorautograder")],
+                             cwd=WORKSPACE, env=env, stdout=subprocess.DEVNULL,
+                             stderr=subprocess.PIPE)
+        try:
+            _, err = p.communicate(timeout=time_left("comparison"))
+        except subprocess.TimeoutExpired:
+            p.kill()
+            p.communicate()
+            raise
+        log(f"comparison done rc={p.returncode}")
+        raw = report.read_text(encoding="utf-8") if report.is_file() else ""
+    if p.returncode != 0 or not raw.strip():
+        emit("**The grader could not evaluate your submission.** Your file compiled, "
+             "but the comparison step failed. This is usually a problem with the "
+             "grader rather than your work, so please tell the course staff.\n\n```\n"
+             + err.decode(errors="replace")[-2000:] + "\n```")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        emit("**The grader produced an invalid report.** Please tell the course staff.\n\n"
+             "```\n" + raw[-2000:] + "\n```")
+
+
+def sandbox_kind():
+    """Which landrun is in play. setup.sh installs the real one and the shim at
+    the same path, so the path alone says nothing: look at the file. The real
+    binary is an ELF; the vendored fake-landrun.sh is a shell script."""
+    p = Path(os.environ.get("SFL_LANDRUN", BIN / "landrun"))
+    try:
+        magic = p.read_bytes()[:4]
+    except OSError:
+        return f"MISSING ({p})"
+    if magic == b"\x7fELF":
+        return f"landrun binary ({p})"
+    return f"NONE -- unsandboxed shim ({p})"
+
+
+def cgroup_memory():
+    """The container's memory cap, cgroup v2 then v1. Worth logging: Lean is
+    memory-hungry, and a starved container looks like a hang, not an error."""
+    for f in ("/sys/fs/cgroup/memory.max",
+              "/sys/fs/cgroup/memory/memory.limit_in_bytes"):
+        try:
+            return Path(f).read_text().strip()
+        except OSError:
+            pass
+    return "?"
+
+
+def main():
+    global SANDBOXED
+    kind = sandbox_kind()
+    SANDBOXED = kind.startswith("landrun")
+    log("sandbox=" + kind)
+    log(f"cpus={os.cpu_count()} mem={cgroup_memory()}")
+    graded, ignored = find_submissions()
+    for stem, src in graded.items():
+        (WORKSPACE / "Solution" / VOLUME / f"{stem}.lean").write_text(
+            rewrite(src.read_text(encoding="utf-8", errors="replace"), "Solution"),
+            encoding="utf-8")
+
+    # Every chapter the assignment covers; any chapter that needs to be graded but not 
+    # submitted keeps the skeleton of `sorry`s (from the student variant), which scores zero.
+    runs = [(f"Challenge.{VOLUME}.{c}", f"Solution.{VOLUME}.{c}") for c in CHAPTERS]
+    what = human(CHAPTERS)
+
+    # Build and grade each chapter on its own, so one that does not compile
+    # costs only its own score instead of the whole submission.
+    tests, broken = [], []
+    for challenge, solution in runs:
+        log(f"building {solution}")
+        built = subprocess.run(["lake", "build", solution], cwd=WORKSPACE,
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                               timeout=time_left(f"building {solution}"))
+        log(f"built {solution} rc={built.returncode}")
+        name = solution.split(".")[-1]
+        if built.returncode != 0:
+            errlog = clean_log(built.stdout.decode(errors="replace"))
+            # A break in an earlier chapter stops the later ones too, so blame
+            # whichever file the errors are actually in -- otherwise a student
+            # hunts for a bug that is not in the file we named.
+            culprits = sorted({m for m in re.findall(r"(?m)^error: (\w+)\.lean:", errlog)})
+            own = name in culprits
+            if own:
+                broken.append(name)
+                why = ("This file does not compile, so none of its exercises could be graded.")
+            else:
+                why = ("This file could not be graded because "
+                       + (human(culprits) if culprits else "a chapter it imports")
+                       + " does not compile.")
+            tests.append({"name": f"{name} (not graded)", "score": 0.0,
+                          "max_score": float(chapter_points(name)),
+                          "status": "failed",
+                          "output": why + "\n\n```\n" + errlog + "\n```"})
+            continue
+        # Building the submission just ran the student's code, which may have
+        # written into .lake. Clearing it makes the comparator rebuild
+        # Challenge from source instead of trusting those files. That costs a
+        # full recompile, so only do it under landrun: unsandboxed, the code
+        # can write anywhere in the container (?!), so protecting .lake alone 
+        # would not help.
+        if SANDBOXED:
+            log("clearing cached build artifacts before comparison")
+            clean_build()
+        for t in autograde(challenge, solution)["theoremReports"]:
+            pts = Fraction(t["points"]["num"], t["points"]["den"])
+            ok = t["error"] is None
+            tests.append({"name": t["name"]["const"],
+                          "score": float(pts) if ok else 0.0, "max_score": float(pts),
+                          "status": "passed" if ok else "failed",
+                          "output": "Correct." if ok
+                                    else explain(t["error"], t["name"]["const"])})
+
+    got = sum(Fraction(str(t["score"])) for t in tests)
+    total = sum(Fraction(str(t["max_score"])) for t in tests)
+    failed = sum(1 for t in tests if t["status"] == "failed")
+    note = ""
+    if broken:
+        note += (f"\n\n**{human(broken)} did not compile**, so none of "
+                 f"{'its' if len(broken) == 1 else 'their'} exercises could be "
+                 f"graded. See the failing check below for the errors.")
+    if MANUAL:
+        note += (f"\n\n{listing(MANUAL)} {'is' if len(MANUAL) == 1 else 'are'} "
+                 f"graded manually after the due date.")
+    if ignored:
+        note += (f"\n\n*This assignment grades {what}. Ignored "
+                f"{len(ignored)} other file(s): {', '.join(f'`{n}`' for n in ignored[:6])}"
+                + ("…" if len(ignored) > 6 else "") + ".*")
+    emit(f"Graded {what} — **{float(got):g} / {float(total):g}** points"
+         + (f"; {failed} of {len(tests)} checks still need work." if failed
+            else ". All checks passed.") + note, tests=tests)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.TimeoutExpired as e:
+        log(f"TIMED OUT running {e.cmd}")
+        emit("**Grading timed out.** If your file compiles quickly in your editor "
+             "this is a problem with the autograder, not your work — please tell "
+             "the course staff.")

--- a/gradescope/package.py
+++ b/gradescope/package.py
@@ -87,21 +87,28 @@ def manual_exercises(vol, chapters):
 
     Keyed on the `GRADE_MANUAL` spec, which is the grading instruction and
     carries the points; `(manual := true)` only labels the heading. An exercise
-    with `GRADE_MANUAL` but not `(manual := true)` is a bug in the chapter. 
-    A `:::grade` body is written either fenced or in backticks, so match both."""
+    with `GRADE_MANUAL` but not `(manual := true)` is a bug in the chapter.
+    A `:::grade` body is written either fenced or in backticks, so match both.
+
+    A spec names the *declaration* graded, which is often not the exercise's
+    own name (`GRADE_MANUAL 2: Repeats` sits in exercise `pigeonhole_principle`).
+    Optionality therefore has to come from whichever exercise encloses the spec,
+    found by scanning in order -- matching the spec name against exercise names
+    would let an optional exercise through whenever the two differ."""
     found = []
     for c in chapters:
         src = REPO / vol / f"{c}.lean"
         if not src.is_file():
             continue
-        text = src.read_text(encoding="utf-8")
-        optional = set()
-        for args in re.findall(r"(?m)^:{3,}exercise(.*)$", text):
-            name = re.search(r'name := "([^"]+)"', args)
-            if name and "optional := true" in args:
-                optional.add(name.group(1))
-        for names in re.findall(r"(?m)^`?GRADE_MANUAL\s+[0-9./]+\s*:\s*([^`\n]+)", text):
-            found += [n for n in names.split() if n not in optional]
+        optional = False
+        for line in src.read_text(encoding="utf-8").splitlines():
+            ex = re.match(r"^:{3,}exercise(.*)$", line)
+            if ex:
+                optional = "optional := true" in ex.group(1)
+                continue
+            spec = re.match(r"^`?GRADE_MANUAL\s+[0-9./]+\s*:\s*([^`\n]+)", line)
+            if spec and not optional:
+                found += spec.group(1).split()
     return found
 
 

--- a/gradescope/package.py
+++ b/gradescope/package.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# Claude-generated (see CLAUDE.md, "Marking AI-generated material").
+"""Build the Gradescope autograder, and run it locally without Docker.
+
+    package.py                 -> autograder.zip, grading every released chapter
+    package.py --chapter X,Y   ...grading only those
+    package.py --dev           stage the same workspace locally
+    package.py --dev FILE      ...and grade FILE through it
+
+Run `make` first: both are assembled from the extracted chapters in _out/.
+"""
+import argparse, json, os, re, shutil, subprocess, sys, tempfile, zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import grade
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+LIB = "comparator-autograder-lib"
+
+
+def pin(name):
+    """(url, rev) from the book's lake-manifest.json, so the grader builds
+    against exactly the revision the book does."""
+    for p in json.loads((REPO / "lake-manifest.json").read_text())["packages"]:
+        if p["name"].strip("«»") == name:
+            return p["url"], p["rev"]
+    sys.exit(f"{name} not found in lake-manifest.json")
+
+
+def lakefile():
+    """The two libraries, plus what the chapters need: the attribute library the
+    grading build imports, and batteries, which SFLCompat pulls in."""
+    req = "".join(f'\n[[require]]\nname = "{n}"\ngit = "{u}"\nrev = "{r}"\n'
+                  for n, (u, r) in ((n, pin(n)) for n in ("batteries", LIB)))
+    return ('name = "sfl-grader"\nversion = "0.1.0"\n' + req +
+            '\n[[lean_lib]]\nname = "Challenge"\n\n[[lean_lib]]\nname = "Solution"\n'
+            '\n[[lean_lib]]\nname = "SFLCompat"\n')
+
+
+def released(vol):
+    """Chapters this volume currently releases to students, from
+    scripts/release_chapters.json -- the same allow-list package_release.py
+    uses, so the autograder cannot cover more of the book than the students
+    have been given. A volume absent from that file releases everything."""
+    try:
+        cfg = json.loads((REPO / "scripts" / "release_chapters.json")
+                         .read_text(encoding="utf-8"))
+    except OSError:
+        return None
+    return cfg.get(vol.lower())
+
+
+def expand(vol, chapters):
+    """Resolve "*" to the chapters students actually have, so staging, build
+    targets and config.env all work from one concrete list."""
+    if not chapters:
+        sys.exit("at least one chapter is required")
+    if len(chapters) != len(set(chapters)):
+        sys.exit("each chapter may be named only once")
+    rel_list = released(vol)
+    if chapters == ["*"]:
+        if rel_list is not None:
+            if not rel_list:
+                sys.exit(f"{vol} releases no chapters yet "
+                         f"(scripts/release_chapters.json), so there is nothing "
+                         f"to grade.")
+            print(f"  '*' -> released chapters: {', '.join(rel_list)}")
+            return list(rel_list)
+        allc = sorted(p.stem for p in (REPO / "_out" / vol.lower() / "solutions"
+                                       / "lean" / vol).glob("*.lean"))
+        print(f"  '*' -> every chapter ({len(allc)}); no release allow-list found")
+        return allc
+    if rel_list is not None:
+        extra = [c for c in chapters if c not in rel_list]
+        if extra:
+            sys.exit(f"{', '.join(extra)}: not released, so there is nothing to "
+                     f"assign.\nAdd it to scripts/release_chapters.json "
+                     f"(currently {', '.join(rel_list) or 'empty'}) once students "
+                     f"have it.")
+    return chapters
+
+
+def manual_exercises(vol, chapters):
+    """Exercises that need to be manually graded (without `optional`).
+
+    Keyed on the `GRADE_MANUAL` spec, which is the grading instruction and
+    carries the points; `(manual := true)` only labels the heading. An exercise
+    with `GRADE_MANUAL` but not `(manual := true)` is a bug in the chapter. 
+    A `:::grade` body is written either fenced or in backticks, so match both."""
+    found = []
+    for c in chapters:
+        src = REPO / vol / f"{c}.lean"
+        if not src.is_file():
+            continue
+        text = src.read_text(encoding="utf-8")
+        optional = set()
+        for args in re.findall(r"(?m)^:{3,}exercise(.*)$", text):
+            name = re.search(r'name := "([^"]+)"', args)
+            if name and "optional := true" in args:
+                optional.add(name.group(1))
+        for names in re.findall(r"(?m)^`?GRADE_MANUAL\s+[0-9./]+\s*:\s*([^`\n]+)", text):
+            found += [n for n in names.split() if n not in optional]
+    return found
+
+
+def stage(vol, chapters, dest):
+    """Copy the volume into both trees, imports namespaced.
+
+    Graded chapters come from the `grading` extract on the Challenge side (it
+    carries the autogradedProof/autogradedHole attributes -- nothing else does)
+    and the `student` skeleton on the Solution side, so an exercise left undone
+    scores zero.
+
+    Every chapter the assignment does *not* grade comes from `solutions`, on
+    both sides. Chapters import each other, and a skeleton dependency is full of
+    `sorry`: a student's Induction proofs would inherit sorryAx from an ungraded
+    Basics. The two sides must use the same variant, or the comparison hits a
+    definition that differs and reports constDoesNotMatch.
+
+    What ships is the released book -- see below. Earlier-volume dependencies
+    bundled with the extract are staged from `solutions` on both sides. What
+    gets *compiled* is narrower still: setup.sh names only the graded chapters
+    as build targets and lake works out the rest."""
+    base = REPO / "_out" / vol.lower()
+    solutions = base / "solutions" / "lean" / vol
+    if not solutions.is_dir():
+        sys.exit(f"missing {solutions} -- run 'make' first")
+    graded = set(chapters)
+    names = sorted(p.name for p in solutions.glob("*.lean"))
+
+    # The released book, not the whole repo: the chapters students have, plus
+    # the support modules (SFLCompat, CustomTactics) that chapters import but
+    # that no release list names. Safe because chapters never import a later
+    # one, so a release list already holds everything its chapters need.
+    rel = released(vol)
+    if rel is not None:
+        in_book = set(re.findall(r"(?m)^import %s\.(\w+)" % vol,
+                                 (base / "solutions" / "lean" / f"{vol}.lean")
+                                 .read_text(encoding="utf-8")))
+        names = [n for n in names if Path(n).stem in set(rel) or Path(n).stem not in in_book]
+
+    dependencies = [
+        src
+        for dep_vol in ("LF", "HL", "TS")
+        if dep_vol != vol
+        for src in sorted((solutions.parent / dep_vol).rglob("*.lean"))
+    ]
+
+    for side, variant in (("Challenge", "grading"), ("Solution", "student")):
+        for name in names:
+            src = base / (variant if Path(name).stem in graded else "solutions") \
+                  / "lean" / vol / name
+            if not src.is_file():
+                sys.exit(f"missing {src} -- run 'make' first")
+            out = dest / side / vol / name
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(grade.rewrite(src.read_text(encoding="utf-8"), side),
+                           encoding="utf-8")
+
+        # HL and TS extracts bundle the earlier-volume modules they import.
+        # They are trusted dependencies, so both sides use the solved versions.
+        for src in dependencies:
+            out = dest / side / src.relative_to(solutions.parent)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(grade.rewrite(src.read_text(encoding="utf-8"), side),
+                           encoding="utf-8")
+    # SFLCompat is a library beside the volume, not a chapter, and is identical
+    # in every variant: one shared copy, and `import SFLCompat` needs no
+    # namespacing.
+    for src in [solutions.parent / "SFLCompat.lean",
+                *sorted((solutions.parent / "SFLCompat").rglob("*.lean"))]:
+        out = dest / src.relative_to(solutions.parent)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(src.read_bytes())
+
+    print(f"  staged {len(names) + len(dependencies)} module(s) x2 + SFLCompat -- graded: "
+          f"{', '.join(sorted(graded))}; the rest from solutions")
+
+
+def assemble(vol, chapters, dest, sandbox=True):
+    """Everything the archive holds except its own version stamp."""
+    toolchain = (REPO / "lean-toolchain").read_text().strip()
+    url, rev = pin("comparator-autograder")
+    stage(vol, chapters, dest / "context")
+    (dest / "context" / "lakefile.toml").write_text(lakefile())
+    (dest / "context" / "lean-toolchain").write_text(toolchain)
+    (dest / "config.env").write_text(
+        f"VOLUME={vol}\nCHAPTER={','.join(chapters)}\nLEAN_TOOLCHAIN={toolchain}\n"
+        f"COMPARATOR_AUTOGRADER_URL={url}\nCOMPARATOR_AUTOGRADER_REV={rev}\n"
+        f"MANUAL={','.join(manual_exercises(vol, chapters))}\n"
+        + ("" if sandbox else "SFL_LANDRUN=/opt/grader/bin/fake-landrun.sh\n"))
+    for f in ("setup.sh", "run_autograder", "grade.py"):
+        shutil.copyfile(HERE / f, dest / f)
+
+
+def write_zip(src, out):
+    """Gradescope wants the files at the archive root, not a folder containing
+    them, and needs setup.sh and run_autograder executable."""
+    out.unlink(missing_ok=True)
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+        for f in sorted(p for p in src.rglob("*") if p.is_file()):
+            info = zipfile.ZipInfo(str(f.relative_to(src)))
+            info.create_system = 3        # Unix, else the mode bits are ignored
+            mode = 0o755 if f.name in ("setup.sh", "run_autograder") else 0o644
+            info.external_attr = (0o100000 | mode) << 16
+            info.compress_type = zipfile.ZIP_DEFLATED
+            z.writestr(info, f.read_bytes())
+
+
+def dev(vol, chapters, submission):
+    """The workspace setup.sh builds, staged directly instead of through a
+    Docker image -- seconds, rather than a full image build."""
+    ws = Path(os.environ.get("SFL_WORKSPACE",
+                             Path(tempfile.gettempdir()) / "sfl-grader-ws"))
+    # Restage unless the workspace is both complete (`pristine` is written last)
+    # and built for this same assignment (`.chapters`) -- otherwise a Basics
+    # workspace silently grades an Induction run against the wrong Challenge.
+    want = f"{vol}:{','.join(chapters)}"
+    stamp = ws / ".chapters"
+    staged_for = stamp.read_text(encoding="utf-8").strip() if stamp.exists() else None
+    if not (ws / "pristine").exists() or staged_for != want:
+        print(f"staging {ws} for {want}…")
+        shutil.rmtree(ws, ignore_errors=True)
+        (ws / "bin").mkdir(parents=True)
+        stage(vol, chapters, ws)
+        (ws / "lakefile.toml").write_text(lakefile())
+        (ws / "lean-toolchain").write_text((REPO / "lean-toolchain").read_text().strip())
+        for b in (".lake/packages/comparator-autograder/.lake/build/bin/comparatorautograder",
+                  ".lake/packages/lean4export/.lake/build/bin/lean4export",
+                  ".lake/packages/comparator/scripts/fake-landrun.sh"):
+            if not (REPO / b).is_file():
+                sys.exit(f"missing {b}\nrun: lake build lean4export comparatorautograder")
+            # Landlock is Linux-only, so the dev loop always uses the shim.
+            name = "landrun" if b.endswith("fake-landrun.sh") else Path(b).name
+            (ws / "bin" / name).symlink_to(REPO / b)
+        targets = [f"{side}.{vol}.{c}" for c in chapters
+                   for side in ("Challenge", "Solution")]
+        subprocess.run(["lake", "build", *targets], cwd=ws, check=True,
+                       stdout=subprocess.DEVNULL)
+        shutil.copytree(ws / "Solution", ws / "pristine", dirs_exist_ok=True)
+        stamp.write_text(want, encoding="utf-8")
+    if not submission:
+        return print(f"ready: {ws}\ngrade with: package.py --dev path/to/a.lean")
+    # Undo the previous submission, exactly as run_autograder does.
+    shutil.copytree(ws / "pristine", ws / "Solution", dirs_exist_ok=True)
+    sub, res = Path(tempfile.mkdtemp()), Path(tempfile.mkdtemp())
+    try:
+        if Path(submission).is_dir():      # a folder, as a student would zip it
+            shutil.copytree(submission, sub, dirs_exist_ok=True)
+        else:
+            shutil.copyfile(submission, sub / Path(submission).name)
+        subprocess.run([sys.executable, str(HERE / "grade.py")], check=True, stdout=subprocess.DEVNULL,
+                       env={**os.environ, "SFL_WORKSPACE": str(ws),
+                            "SFL_BIN": str(ws / "bin"), "SFL_SUBMISSION": str(sub),
+                            "SFL_RESULTS": str(res / "results.json"),
+                            "SFL_VOLUME": vol, "SFL_CHAPTER": ",".join(chapters),
+                            "SFL_MANUAL": ",".join(manual_exercises(vol, chapters))})
+        print(json.dumps(json.loads((res / "results.json").read_text()), indent=2))
+    finally:
+        shutil.rmtree(sub, ignore_errors=True)
+        shutil.rmtree(res, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--volume", default="LF")
+    ap.add_argument("--chapter", default="*",
+                    help='chapter(s) this assignment grades: "*" (the default) '
+                         'for every released chapter, or a concrete list such as '
+                         '"Basics" or "Basics,Postscript"')
+    ap.add_argument("--out", type=Path, default=HERE / "autograder.zip")
+    ap.add_argument("--no-sandbox", action="store_true",
+                    help="grade without landrun, to rule it in or out")
+    ap.add_argument("--dev", nargs="?", const="", metavar="PATH",
+                    help="stage a local workspace; with a .lean file or a volume "
+                         "folder, grade it")
+    a = ap.parse_args()
+    chapters = expand(a.volume, [c.strip() for c in a.chapter.split(",") if c.strip()])
+    if a.dev is not None:
+        return dev(a.volume, chapters, a.dev or None)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        assemble(a.volume, chapters, tmp, sandbox=not a.no_sandbox)
+        write_zip(tmp, a.out)
+        print(f"wrote {a.out} ({a.out.stat().st_size // 1024} KB)")
+        manual = manual_exercises(a.volume, chapters)
+        if manual:
+            print("  reminder: " + ", ".join(manual) + " needs to be manually graded. Please create questions on Gradescope.")
+
+
+if __name__ == "__main__":
+    main()

--- a/gradescope/run_autograder
+++ b/gradescope/run_autograder
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Claude-generated (see CLAUDE.md, "Marking AI-generated material").
+#
+# Gradescope entrypoint, once per submission. Gradescope reads only results.json,
+# so we would like to make sure that the file exists however grade.py exits,
+# because without it the student sees an opaque platform error.
+set -uo pipefail
+
+# setup.sh installed Lean under /opt/elan; this runs in a fresh shell.
+export ELAN_HOME=/opt/elan
+export PATH=/opt/elan/bin:${PATH}
+. /autograder/source/config.env
+export SFL_VOLUME="${VOLUME}" SFL_CHAPTER="${CHAPTER}" SFL_MANUAL="${MANUAL:-}"
+[ -n "${SFL_LANDRUN:-}" ] && export SFL_LANDRUN
+
+RESULTS=/autograder/results/results.json
+mkdir -p /autograder/results
+
+# Undo the previous submission, so one cannot influence the next.
+cp -R /opt/grader/pristine/. /opt/grader/workspace/Solution/
+
+python3 /opt/grader/grade.py || true
+
+if [ ! -s "$RESULTS" ]; then
+  printf '%s\n' '{"score": 0.0, "output_format": "md", "output": "**The autograder failed before it could grade your submission.** This is not something you did wrong - please notify the course staff."}' > "$RESULTS"
+fi
+exit 0

--- a/gradescope/setup.sh
+++ b/gradescope/setup.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Claude-generated (see CLAUDE.md, "Marking AI-generated material").
+#
+# Gradescope build-time setup. Runs once, as root, with the zip already
+# unpacked at /autograder/source.
+#
+# Everything expensive belongs here rather than in run_autograder: the Lean
+# toolchain, the grader binaries, and a compiled workspace. Grading a
+# submission then recompiles one file and needs no network.
+set -euo pipefail
+
+SRC=/autograder/source
+. "${SRC}/config.env"
+
+LANDRUN_VERSION=v0.1.17
+GO_VERSION=go1.27.0
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl git python3 build-essential
+rm -rf /var/lib/apt/lists/*
+
+export ELAN_HOME=/opt/elan
+export PATH=/opt/elan/bin:${PATH}
+curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+  | sh -s -- -y --default-toolchain "${LEAN_TOOLCHAIN}" --no-modify-path
+
+# A throwaway Lake project whose only job is to produce the two binaries.
+mkdir -p /opt/grader/bin /opt/grader/tools
+cd /opt/grader/tools
+cat > lakefile.toml <<TOML
+name = "sfl-grader-tools"
+version = "0.1.0"
+
+[[require]]
+name = "comparator-autograder"
+git = "${COMPARATOR_AUTOGRADER_URL}"
+rev = "${COMPARATOR_AUTOGRADER_REV}"
+TOML
+printf '%s' "${LEAN_TOOLCHAIN}" > lean-toolchain
+lake build lean4export comparatorautograder
+cp .lake/packages/comparator-autograder/.lake/build/bin/comparatorautograder /opt/grader/bin/
+cp .lake/packages/lean4export/.lake/build/bin/lean4export                    /opt/grader/bin/
+cp .lake/packages/comparator/scripts/fake-landrun.sh                         /opt/grader/bin/
+chmod +x /opt/grader/bin/*
+cd / && rm -rf /opt/grader/tools
+
+# The two trees ship already namespaced, so this is a copy.
+mkdir -p /opt/grader/workspace
+cp -R "${SRC}/context/Challenge" "${SRC}/context/Solution" \
+      "${SRC}/context/SFLCompat" "${SRC}/context/SFLCompat.lean" /opt/grader/workspace/
+cp "${SRC}/context/lakefile.toml" "${SRC}/context/lean-toolchain" /opt/grader/workspace/
+cp "${SRC}/grade.py" /opt/grader/grade.py
+
+cd /opt/grader/workspace
+# Only what this assignment needs: its graded chapters and, through their
+# imports, the solved dependencies staged alongside them.
+TARGETS=""
+for c in $(printf '%s' "${CHAPTER}" | tr ',' ' '); do
+  TARGETS="${TARGETS} Challenge.${VOLUME}.${c} Solution.${VOLUME}.${c}"
+done
+lake build ${TARGETS}
+
+# ── sandbox ──────────────────────────────────────────────────────────────────
+# The comparator runs lake and lean4export through $COMPARATOR_LANDRUN. The
+# vendored fake-landrun.sh confines nothing; real landrun confines them with
+# Linux Landlock (kernel 5.13+), which matters because student Lean code runs
+# arbitrary code at elaboration time.
+#
+# As of 2026-08, Gradescope's runners report Landlock ABI v0 -- no support at
+# all -- so the probe below rejects landrun and grading runs unsandboxed. No
+# landrun version changes that; it is the kernel. The build is kept anyway so
+# the sandbox turns itself on if that ever changes; --no-sandbox skips it.
+#
+# Built from source, not downloaded: the published release binaries link against
+# glibc 2.38 and Ubuntu 22.04 has 2.35. CGO_ENABLED=0 sidesteps libc entirely --
+# landrun's only cgo-touching dependency, libcap/psx, has a pure-Go fallback.
+cp /opt/grader/bin/fake-landrun.sh /opt/grader/bin/landrun     # fallback
+case "$(uname -m)" in
+  x86_64)        LR_ARCH=amd64 ;;
+  aarch64|arm64) LR_ARCH=arm64 ;;
+  *)             LR_ARCH= ;;
+esac
+
+# Landlock needs kernel 5.13+. Gradescope's runners are Amazon Linux 2 on 4.14,
+# where landrun can only ever report ABI v0, so building it there costs a Go
+# toolchain download for a binary that cannot work. Check first.
+KVER=$(uname -r | cut -d- -f1)
+KMAJ=${KVER%%.*}
+KMIN=$(printf '%s' "${KVER#*.}" | cut -d. -f1)
+if [ "${KMAJ}" -gt 5 ] 2>/dev/null || { [ "${KMAJ}" -eq 5 ] && [ "${KMIN}" -ge 13 ]; } 2>/dev/null
+then LANDLOCK_POSSIBLE=yes; else LANDLOCK_POSSIBLE=no; fi
+
+if [ -n "${SFL_LANDRUN:-}" ]; then
+  echo "=== sandbox: disabled by config (SFL_LANDRUN=${SFL_LANDRUN}) ==="
+elif [ "${LANDLOCK_POSSIBLE}" = no ]; then
+  echo "=== sandbox: kernel $(uname -r) predates Landlock (needs 5.13+);" \
+       "skipping the landrun build -- GRADING WILL RUN UNSANDBOXED ===" >&2
+elif [ -n "${LR_ARCH}" ] \
+   && curl -fsSL --retry 3 "https://go.dev/dl/${GO_VERSION}.linux-${LR_ARCH}.tar.gz" \
+        | tar -C /usr/local -xz \
+   && CGO_ENABLED=0 GOBIN=/opt/grader GOFLAGS=-trimpath \
+        /usr/local/go/bin/go install "github.com/zouuup/landrun/cmd/landrun@${LANDRUN_VERSION}"
+then
+  # Two separate probes, so the log says which one failed. Running is not
+  # enough: --best-effort degrades to no enforcement when the kernel lacks
+  # Landlock, and the build succeeds either way -- so the second probe checks
+  # that a write outside .lake is actually refused.
+  LOG=/tmp/landrun-probe.log
+  PROBE=/opt/grader/workspace/Challenge/.landrun-write-probe
+  rm -f "${PROBE}"
+  echo "kernel $(uname -r); lsm: $(cat /sys/kernel/security/lsm 2>/dev/null || echo unknown)"
+
+  landrun_run() {
+    /opt/grader/landrun --best-effort --ro / --rw /dev -ldd -add-exec \
+      --env PATH --env HOME --env LEAN_ABORT_ON_PANIC \
+      --ro /opt/grader/workspace --rwx /opt/grader/workspace/.lake \
+      --rox "$(lean --print-prefix)" -- "$@"
+  }
+
+  if ! landrun_run lake build ${TARGETS} > "${LOG}" 2>&1; then
+    echo "=== WARNING: landrun could not run the build -- GRADING WILL RUN UNSANDBOXED ===" >&2
+    head -20 "${LOG}" >&2
+  elif landrun_run touch "${PROBE}" >> "${LOG}" 2>&1; then
+    echo "=== WARNING: landrun ran, but a write to Challenge/ was NOT blocked ===" >&2
+    echo "=== Landlock is not enforcing here; GRADING WILL RUN UNSANDBOXED ===" >&2
+    # --best-effort swallows the reason. Ask again without it, purely so the
+    # build log records *why* the kernel would not give us a ruleset.
+    echo "--- why (landrun without --best-effort) ---" >&2
+    /opt/grader/landrun --ro / -- /bin/true 2>&1 | head -5 >&2 || true
+    head -20 "${LOG}" >&2
+  else
+    mv /opt/grader/landrun /opt/grader/bin/landrun
+    echo "=== sandbox: landrun ${LANDRUN_VERSION} (Landlock enforcing) ==="
+  fi
+  rm -f "${PROBE}"
+else
+  echo "=== WARNING: could not build landrun -- GRADING WILL RUN UNSANDBOXED ===" >&2
+fi
+rm -rf /usr/local/go /root/go /opt/grader/landrun   # toolchain and module cache
+
+# What a submission replaces, and what run_autograder restores before each run.
+cp -R Solution /opt/grader/pristine


### PR DESCRIPTION
This adds a tool for creating an autograder zip file that can grade one or more chapters for a Gradescope assignment. See [GRADESCOPE-AUTOGRADER.md](https://github.com/plclub/sf-in-lean/blob/cheng/gradescope/GRADESCOPE-AUTOGRADER.md) for usage.

A few notes:

- When I tested it with Basics, the solutions variant scored 32/32 across 50 checks, and the student variant with `sorry`s scores 0/32, as expected. However, `and_eq_or` is marked optional but also has `attribute [autogradedProof 3] NatPlayground.and_eq_or` so it will still be graded. Definitions and theorems in optional exercises should not have autograder directives. Watch for warnings when running `make` to make sure optional exercises are not being graded.

- Please also check the manually graded questions and create components for them on Gradescope. At the moment, `GRADE_MANUAL` and `(manual := true)` are not always used consistently.

- Grading currently runs unsandboxed on Gradescope because Gradescope has kernel 4.14 but Landlock needs 5.13+.

The scripts are written with Claude. And thanks for help from @xhalo32!