### PR TITLE
Grading: add some missing attributes for non-optional exercises in LF

### DIFF
--- a/HL/Imp.lean
+++ b/HL/Imp.lean
@@ -1639,7 +1639,7 @@ theorem plus2_spec (st : State) (n : Nat) (st' : State)
 This used to be recommended.  Should it be reinstated?
 :::
 
-:::::exercise (rating := 3) (name := "XtimesYinZ_spec") (optional := true)
+:::::exercise (rating := 3) (name := "XtimesYinZ_spec") (optional := true) (manual := true)
 State and prove a specification of `XtimesYinZ`.
 
 ```lean

--- a/LF/Automation.lean
+++ b/LF/Automation.lean
@@ -1159,6 +1159,12 @@ theorem reNotEmpty_correct {α : Type} (re : RegExp α) :
     simp only [iff_true]; exists []; constructor
 ```
 :::
+
+:::grade
+```
+GRADE_MANUAL 1: reNotEmpty
+```
+:::
 ::::
 
 ## The {tactic}`generalize` Tactic

--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -1193,7 +1193,7 @@ But in the following example, because {name}`Bool.not` takes a {name}`Bool` argu
 
 :::::full
 
-::::exercise (rating := 1) (name := "custom_namespace_checks")
+::::exercise (rating := 1) (name := "custom_namespace_checks") (manual := true)
 Predict the output of each of the statements below.
 Would their results change depending on which namespace
 the statements appear in? How?

--- a/LF/IndProp.lean
+++ b/LF/IndProp.lean
@@ -3113,7 +3113,7 @@ the induction principles for all of these.
 :::
 
 ::::::full
-:::::exercise (rating := 3) (name := "nostutter_defn")
+:::::exercise (rating := 3) (name := "nostutter_defn") (manual := true)
 Formulating inductive definitions of properties is an important
 skill you'll need in this course.  Try to solve this exercise
 without any help.
@@ -3787,7 +3787,7 @@ theorem palindrome_converse {α : Type} (l : List α) (h : l = l.reverse) : Pal 
 ```
 :::::
 
-:::::exercise (rating := 4) (name := "NoDup") (level := Advanced) (optional := true)
+:::::exercise (rating := 4) (name := "NoDup") (level := Advanced) (optional := true) (manual := true)
 Use the `∈` property to define a proposition `Disjoint l₁ l₂`,
 which should be provable exactly when `l₁` and `l₂` are
 lists (with elements of type `α`) that have no elements in

--- a/LF/Induction.lean
+++ b/LF/Induction.lean
@@ -869,7 +869,7 @@ GRADE_MANUAL 2: add_comm_informal
 :::
 :::::
 
-:::::exercise (rating := 2) (name := "beq_refl_informal") (optional := true)
+:::::exercise (rating := 2) (name := "beq_refl_informal") (optional := true) (manual := true)
 Write an informal proof of the following theorem, using the
 informal proof of {name}`add_assoc` as a model.  Don't just
 paraphrase the Lean tactics into English!

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -936,6 +936,12 @@ theorem unzip_test_snd' : (unzip [(1, false), (2, true)]).snd = [false, true] :=
   rw [unzip_cons, unzip_cons, unzip_nil]
 ```
 :::
+
+:::grade
+```
+GRADE_MANUAL 3: unzip
+```
+:::
 :::::
 ::::::
 

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1345,7 +1345,7 @@ theorem add_self_injective (n m : Nat)
 :::
 :::::
 
-::::exercise (rating := 2) (name := "add_self_injective_informal")
+::::exercise (rating := 2) (name := "add_self_injective_informal") (manual := true)
 Give a careful informal proof of {name}`add_self_injective`, stating the induction
 hypothesis explicitly and being as explicit as possible about
 quantifiers, everywhere.
@@ -1374,6 +1374,12 @@ _Proof_: We prove by induction on {lean}`n` that for _every_ natrual number {lea
 _Qed_.
 :::
 
+
+:::grade
+```
+GRADE_MANUAL 2: add_self_injective_informal
+```
+:::
 ::::
 
 
@@ -1935,6 +1941,12 @@ theorem unzip_zip' {α β : Type}
 -- END SOLUTION
 ```
 
+
+:::grade
+```
+GRADE_MANUAL 3: unzip_zip
+```
+:::
 :::::
 
 :::::exercise (rating := 3) (name := "test_pos_of_filter_cons") (level := Advanced)

--- a/LF/Typeclasses.lean
+++ b/LF/Typeclasses.lean
@@ -622,6 +622,9 @@ theorem Monoid.id_unique_left {α : Type} [Monoid α] (x : α)
     rw [← right_id x]
     exact hₗ id
 ```
+
+:::gradeTheorem 1 Monoid.id_unique_left
+:::
 ::::
 
 :::dev "@ionathanch" PotentialImprovement
@@ -649,6 +652,9 @@ theorem inv_inv {α : Type} {g : Group α} (x : α) : g.inv (g.inv x) = x := by
   solution!
     symm; apply inv_inv' (y := g.inv x) <;> rfl
 ```
+
+:::gradeTheorem 1 inv_inv' inv_inv
+:::
 ::::
 
 ```lean

--- a/LF/UsingLean.lean
+++ b/LF/UsingLean.lean
@@ -300,7 +300,7 @@ Whereas before, the left-hand side of each equality in the
 previous one, we can replace the left-hand side entirely with an `_`.
 Now our Lean proof looks quite a bit like the textbook one we saw earlier!
 
-::::exercise (rating := 1) (name := "succ_mul_succ")
+::::exercise (rating := 1) (name := "succ_mul_succ") (manual := true)
 Consider this proof, which uses {tactic}`rw`.
 ```lean
 theorem succ_mul_succ (n m : Nat) :
@@ -320,6 +320,12 @@ theorem succ_mul_succ' (n m : Nat) :
       _ = (n * m + n) + (m + 1)     := by rw [Nat.mul_one]
       _ = n * m + n + m + 1         := by rw [← Nat.add_assoc]
 ```
+
+:::grade
+```
+GRADE_MANUAL 1: succ_mul_succ'
+```
+:::
 ::::
 If you prefer {tactic}`rw` to {tactic}`calc`, that's fine! Each has particular
 uses, and both will be tools in your ever-growing toolbox of tactics.

--- a/TS/Smallstep.lean
+++ b/TS/Smallstep.lean
@@ -1227,7 +1227,7 @@ plus some basic properties of `⟶*` (that it is reflexive, transitive, and
 includes `⟶`).
 :::::
 
-:::::exercise (rating := 3) (name := "multistep_of_eval_inf") (optional := true)
+:::::exercise (rating := 3) (name := "multistep_of_eval_inf") (optional := true) (manual := true)
 Write a detailed informal version of the proof of `multistep_of_eval`.  (A
 paper exercise — there is no Lean proof to fill in here.)
 

--- a/TS/StlcProp.lean
+++ b/TS/StlcProp.lean
@@ -911,7 +911,7 @@ variables.  (I.e., every term is an open term; the closed terms
 are a subset of the open ones.  "Open" precisely means "possibly
 containing free variables.")
 
-:::::exercise (rating := 1) (name := "afi")
+:::::exercise (rating := 1) (name := "afi") (manual := true)
 (Officially optional, but strongly recommended!) In the space
 below, write out the rules of the `∈ᶠ` relation in
 informal inference-rule notation.  (Use whatever notational
@@ -1089,7 +1089,7 @@ earlier.
 :::
 
 ::::::full
-:::::exercise (rating := 1) (name := "progress_preservation_statement")
+:::::exercise (rating := 1) (name := "progress_preservation_statement") (manual := true)
 (Officially optional, but strongly recommended!) Without peeking
 at their statements above, write down the progress and
 preservation theorems for the simply typed lambda-calculus (as Lean

--- a/TS/Types.lean
+++ b/TS/Types.lean
@@ -981,7 +981,7 @@ _strong progress_ from the {ref "Smallstep"}[Smallstep] chapter?
 (C) Strong progress implies progress
 :::
 
-:::::exercise (rating := 3) (name := "finish_progress_informal") (optional := true)
+:::::exercise (rating := 3) (name := "finish_progress_informal") (optional := true) (manual := true)
 Complete the corresponding informal proof.
 
 :::dev "Benjamin Pierce (bcpierce00)"
@@ -1156,7 +1156,7 @@ theorem preservation (t t' : Tm) (T : Ty) (hT : <{ ⊢ t ⦂ T }>) (he : t ⟶ t
 :::
 :::::
 
-:::::exercise (rating := 3) (name := "finish_preservation_informal") (optional := true)
+:::::exercise (rating := 3) (name := "finish_preservation_informal") (optional := true) (manual := true)
 Complete the following informal proof.
 
 _Theorem_: If `⊢ t ⦂ T` and `t ⟶ t'`, then `⊢ t' ⦂ T`.


### PR DESCRIPTION
Changes:
- Add `(manual := true)` where a `GRADE_MANUAL` spec exists.
- Add `GRADE_MANUAL` for the non-optional LF exercises that can only be graded by hand: `unzip`, `unzip_zip`, `reNotEmpty`, `add_self_injective_informal`, `succ_mul_succ'`.
- Add `:::gradeTheorem` for `IdentityUnique` and `InverseInverse`.

Note: I marked `succ_mul_succ'` as manual rather than autograded because of Niklas's dev note as the comparator cannot tell whether the proof uses `calc`.

Future TODOs:
- five non-optional LF exercises are anonymous `example` or `instance` declarations, so there is no name for the comparator to grade: `prod_ext_example`, `HasThree`, `NatMonoidMul`, `ListMonoidAppend`, `IntGroupAdd`.
- HL and TS have more of these missing attributes.
