### PR TITLE
Poly: Presentation polish

### DIFF
--- a/.claude/skills/proofread/SKILL.md
+++ b/.claude/skills/proofread/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: proofread
+description: Drive a low-level grammar, punctuation, usage, and markup pass over one SFL chapter — write a round of anchored edits, apply them for the author to review in the editor, then record which ones they kept. Use when the author types /proofread [Chapter] or asks for a chapter to be proofread.
+---
+
+<!-- This file is maintained by Claude (AI-generated). -->
+
+# Proofreading a chapter
+
+A pass has three phases, split by the one thing you cannot do yourself: the
+author reviewing the edits in their editor. You run the commands; the author
+only ever talks to you.
+
+`PROOFREADING.md` at the repo root is the authority on *what* to propose —
+read it in full before phase 1, every time. This skill is only about driving.
+
+## Phase 1 — write the round
+
+```
+python3 scripts/proofread.py start [<Chapter>]
+```
+
+It prints the chapter source to proofread and the round file to write, and
+refuses when the working tree is dirty (a pass starts from a clean branch) or
+when another round is already in flight. Relay that refusal to the author and
+stop — do not commit their work for them, and do not reach for `--allow-dirty`
+unless they ask.
+
+Then:
+
+1. Read `PROOFREADING.md` in full — "Writing a round", the house rules, and
+   the known non-issues.
+2. Read the recorded rejections: `python3 scripts/proofread.py ledger`.
+   Nothing already declined, covered by a house rule, or listed as a known
+   non-issue may be proposed again.
+3. Read the chapter and write the round to the path `start` printed:
+   `{"file", "chapter", "round", "proposals": [{"id", "cat", "old", "new",
+   "why"}]}`, anchored exactly as `PROOFREADING.md` requires.
+
+Do not edit the chapter yourself — every edit reaches it through the round, so
+that the author's accept/decline is what the ledger records.
+
+## Phase 2 — apply, and hand over
+
+```
+python3 scripts/proofread.py apply
+```
+
+This makes the edits, writes a diff of just this round, and opens both in VS
+Code. Anchor errors mean nothing was applied: fix the round file and run it
+again.
+
+Then **end your turn**. Tell the author what is in the round (the category
+counts the command printed, and any pair of edits it flagged as sharing a git
+hunk), and ask them to revert what they don't want — one click per hunk in the
+Source Control gutter — and say when they're done. Do not poll, do not watch
+the file, do not run `record` on their behalf. They may answer in a minute or
+tomorrow; `proofread/state.json` remembers the round either way.
+
+## Phase 3 — record
+
+When the author says they're done:
+
+```
+python3 scripts/proofread.py record
+```
+
+It decides kept-vs-declined by reading the chapter back, appends the declines
+to `proofread/ledger.jsonl`, and prints the rejection histogram. Then:
+
+* If a category is flagged as worth a house rule, propose the wording and, if
+  the author agrees, add the row to the house-rules table in `PROOFREADING.md`.
+  A flagged category means the proposer — you — was working from a rule this
+  book does not hold; the rule is what stops it recurring in every chapter.
+* Report anything `record` called `unclear` (the author rewrote that spot
+  themselves, so nothing was recorded and it will come back in a later round).
+* Run `lake build <Vol>.<Ch>` and offer to commit the chapter, the ledger, and
+  any `PROOFREADING.md` change together.
+
+## Elsewhere in the pass
+
+* Real content problems — a stale reference, a wrong claim, an inconsistent
+  term — never go in the round. Report them to the author in prose; they need
+  a decision, not a comma.
+* `python3 scripts/proofread.py undo` reverses an applied round and leaves it
+  for another day, recording nothing. `status` says what is in flight.

--- a/.claude/skills/proofread/SKILL.md
+++ b/.claude/skills/proofread/SKILL.md
@@ -46,14 +46,15 @@ that the author's accept/decline is what the ledger records.
 python3 scripts/proofread.py apply
 ```
 
-This makes the edits, writes a diff of just this round, and opens both in VS
-Code. Anchor errors mean nothing was applied: fix the round file and run it
-again.
+This makes the edits and opens a side-by-side diff in VS Code — a snapshot of
+the chapter before the round on the left, the live chapter on the right.
+Anchor errors mean nothing was applied: fix the round file and run it again.
 
 Then **end your turn**. Tell the author what is in the round (the category
-counts the command printed, and any pair of edits it flagged as sharing a git
-hunk), and ask them to revert what they don't want — one click per hunk in the
-Source Control gutter — and say when they're done. Do not poll, do not watch
+counts the command printed, and any pair of edits it flagged as sharing one
+change block), and ask them to revert what they don't want — the arrow in the
+gutter between the panes, or editing the right-hand side directly — and to say
+when they're done. Do not poll, do not watch
 the file, do not run `record` on their behalf. They may answer in a minute or
 tomorrow; `proofread/state.json` remembers the round either way.
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ TS/*Verso.lean
 # Personal keybinding cheat sheet and its generator (see .vscode/KEYBINDINGS-SETUP.md).
 .vscode/KEYBINDINGS*.md
 .vscode/keybindings-ref.*
+
+# The pre-round snapshot a proofreading review diffs against (scripts/proofread.py).
+proofread/rounds/*.before.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,24 @@ in `ALPHA-TESTERS.md`), your `origin` is your fork and the shared repo is
 `upstream`, so read `upstream/main` for `origin/main` throughout — rebasing onto
 your fork's `main` would replant your work on a stale base.
 
+### Proofreading a chapter
+
+For the low-level pass — commas, agreement, articles, hyphenation, markup slips
+— say `/proofread <Chapter>` in a Claude session, on a branch with nothing
+uncommitted (it refuses otherwise). Claude proposes a round of small edits and
+applies them, then opens the chapter alongside a diff of just those edits and
+waits: revert the ones you don't want, one click per hunk in the Source Control
+gutter, and tell Claude you are done. Every edit that survives has been vetted
+by hand, as the AI policy below requires; every edit you decline is recorded in
+`proofread/ledger.jsonl` and is never proposed again, in that chapter or any
+other, and a category you decline repeatedly becomes a house rule that stops it
+being proposed at all.
+
+`PROOFREADING.md` has the rest: the house rules accumulated so far, the known
+non-issues, what belongs in a round and what doesn't, how to drive the pass
+from a terminal instead, and the one-time `git config core.hooksPath
+scripts/hooks` that stops a half-finished round from being committed.
+
 ## Tools for coordinating work
 
 ### Branch activity dashboard

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,9 +178,10 @@ your fork's `main` would replant your work on a stale base.
 For the low-level pass — commas, agreement, articles, hyphenation, markup slips
 — say `/proofread <Chapter>` in a Claude session, on a branch with nothing
 uncommitted (it refuses otherwise). Claude proposes a round of small edits and
-applies them, then opens the chapter alongside a diff of just those edits and
-waits: revert the ones you don't want, one click per hunk in the Source Control
-gutter, and tell Claude you are done. Every edit that survives has been vetted
+applies them, then opens a side-by-side diff — the chapter before the round on
+the left, the live chapter on the right — and waits: revert the ones you don't
+want, with the arrow in the gutter between the panes or by editing the
+right-hand side, and tell Claude you are done. Every edit that survives has been vetted
 by hand, as the AI policy below requires; every edit you decline is recorded in
 `proofread/ledger.jsonl` and is never proposed again, in that chapter or any
 other, and a category you decline repeatedly becomes a house rule that stops it

--- a/LF/Induction-content-questions-claude.md
+++ b/LF/Induction-content-questions-claude.md
@@ -1,0 +1,81 @@
+<!-- This file is AI-generated (Claude). -->
+
+# Content questions — `LF/Lists.lean`
+
+Raised during the round-1 proofreading pass over **`LF/Lists.lean`**
+(2026-09-03, commit `2b085d6`). Deliberately kept out of the round: each
+needs an authorial decision, not a comma.
+
+Note on the filename: this file was requested as
+`Induction-content-questions-claude.md`, but everything below concerns
+`LF/Lists.lean`. Rename it if the `Induction-` prefix was not intended.
+
+---
+
+## 1. Informal-proof list structure (highest priority — renders wrong)
+
+In both the `append_assoc` informal proof and the
+`length_append` / `length_reverse` pair, continuation lines are indented
+inconsistently. Some sit inside the bullet:
+
+```
+  which follows directly from the definitions of `length`,
+  `++`, and `+`.
+```
+
+and others sit at column 0, which drops them out of the list entirely:
+
+```
+We must show
+```
+
+```
+By the definition of `append`, this follows from
+```
+
+The result is a broken bullet list in the rendered book. Fixing it means
+settling on one indentation for every continuation paragraph and the
+`display` blocks between them — a structural edit, so it was left alone.
+
+## 2. `.succ l.length` in the compressed proof
+
+[`LF/Lists.lean:1521`](Lists.lean#L1521) (as of `2b085d6`) states
+
+> `(l ++ [n]).length = .succ l.length`
+
+but the lemma actually proved, `append_length_succ`, states
+`(l ++ [n]).length = l.length + 1`. The `.succ` spelling appears nowhere
+else in the chapter. Probably should be `l.length + 1`.
+
+## 3. Stale Rocq references in the `AndrewTolmach` dev note
+
+The note on the `count_append` exercise says:
+
+* "how hard it is to prove (in terms of **Rocq** mechanics)" — carried over
+  from the Rocq source; the chapter is Lean.
+* "the proof in the exercise above for **`count_removeOne`**" — there is no
+  `count_removeOne` in this chapter. Presumably
+  `remove_does_not_increase_count`.
+
+## 4. The "And some examples:" block is inert
+
+[`LF/Lists.lean:538`](Lists.lean#L538) is a plain ``` fence inside `:::full`:
+
+```
+example : head 0 [1, 2, 3] = 1 := by rw [head_cons]
+example : head 0 [] = 0 := by rw [head_nil]
+example : [1, 2, 3].tail = [2, 3] := by rw [tail_cons]
+```
+
+Because the fence carries no language tag, these three examples are never
+elaborated, so they can drift out of date silently. Was a ` ```lean ` block
+intended? (They do currently typecheck.)
+
+## 5. `typeclass` vs `type class`
+
+The "Type Classes and Overloading Notation" section mixes both spellings
+within four lines — "instances of that **typeclass** inherit the notation"
+against "**type class**" everywhere around it. There is already a
+`:::dev "Benjamin Pierce (bcpierce00)"` note at the top of that section
+asking "One word, or two?", so this is an open authorial question rather
+than a slip; whichever is chosen should then be applied consistently.

--- a/LF/Lists-content-questions-claude.md
+++ b/LF/Lists-content-questions-claude.md
@@ -6,10 +6,6 @@ Raised during the round-1 proofreading pass over **`LF/Lists.lean`**
 (2026-09-03, commit `2b085d6`). Deliberately kept out of the round: each
 needs an authorial decision, not a comma.
 
-Note on the filename: this file was requested as
-`Induction-content-questions-claude.md`, but everything below concerns
-`LF/Lists.lean`. Rename it if the `Induction-` prefix was not intended.
-
 ---
 
 ## 1. Informal-proof list structure (highest priority — renders wrong)

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -16,10 +16,7 @@ file := some "Lists"
 :::instructors
 This file takes about 60 minutes to get through.
 Putting it together with Induction.lean makes a reasonable
-second week's homework assignment.
-:::
-:::dev "Benjamin Pierce (bcpierce00)"
-And UsingLean??
+second week's homework assignment, along with UsingLean.
 :::
 
 ```importBlock
@@ -44,10 +41,8 @@ This content is redundant with what's in Basics, which introduces the idea of
 tuple types and structures as shorthand for them. I suspect we can drop most
 of the Basics content and rely on what's here instead. If we do that, we can
 introduce the term "Tuple" here.
+(We do not need structures in the airport exercise, either.)
 ::::
-:::dev "Benjamin Pierce (bcpierce00)"
-Don't we need structures there in the airport exercise at least?
-:::
 
 ::::full
 In an `inductive` type definition, each constructor can take
@@ -1037,17 +1032,9 @@ theorem test_included2 : included [1, 2, 2] [2, 1, 4, 1] = false := solution!(by
 
 ::::full
 As with numbers, simple facts about list-processing
-functions can sometimes be proved entirely by rewriting.
-For example, just rewriting the left-hand side of the following equality using the theorem
-{name}`nil_append` is enough for this theorem.
+functions can sometimes be proved entirely by cases and rewriting,
+as shown for the following theorem.
 ::::
-
-:::dev "Claude" BeforeNextRelease
-This paragraph promises "the following equality", but no such example follows —
-the next code block is `tail_length_pred`, which is proved by `cases`, not by
-rewriting with `nil_append`. An example seems to have gone missing; it should be
-restored (or the paragraph reworded).
-:::
 
 ::::terse
 As with numbers, some proofs about list functions need only

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -18,6 +18,10 @@ This file takes about 60 minutes to get through.
 Putting it together with Induction.lean makes a reasonable
 second week's homework assignment.
 :::
+:::dev "Benjamin Pierce (bcpierce00)"
+And UsingLean??
+:::
+
 
 ```importBlock
 import LF.Induction

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -22,7 +22,6 @@ second week's homework assignment.
 And UsingLean??
 :::
 
-
 ```importBlock
 import LF.Induction
 import LF.UsingLean
@@ -49,8 +48,8 @@ introduce the term "Tuple" here.
 
 ::::full
 In an `inductive` type definition, each constructor can take
-any number of arguments — none (as with {name}`true` and  {lean}`0`),
-one (as with  {name}`Nat.succ`), or more than one (as with  {name}`Playground.Nibble` and
+any number of arguments — none (as with {name}`true` and {lean}`0`),
+one (as with {name}`Nat.succ`), or more than one (as with {name}`Playground.Nibble` and
 the following):
 ::::
 
@@ -77,7 +76,7 @@ to two arguments of type {name}`Nat`."
 :::slidebreak
 :::
 
-:::dev "Mike Hicks (@mwhicks1)"
+:::dev "Mike Hicks (mwhicks1)"
 I would have expected us to have `namespace NatProd` here when defining
 the following functions, so we don't need qualifiers. We've already
 fully explained namespaces back in Basics. Some of the text below
@@ -98,7 +97,7 @@ def NatProd.snd (p : NatProd) : Nat :=
   | .pair _ y => y
 ```
 
-Defining these functions with the {name}`NatProd` type name qualifying their name
+Defining these functions with the {name}`NatProd` type name qualifying their names
 allows us to use them with `.` notation:
 
 ```lean
@@ -110,7 +109,7 @@ example : (NatProd.pair 3 5).fst = 3 := by rfl
 
 ::::full
 Since pairs will be used heavily in what follows, it will be
-convenient to write them with angle bracket notation `⟨n, m⟩`
+convenient to write them with angle-bracket notation `⟨n, m⟩`
 instead of `NatProd.pair n m`.  This notation is built into Lean and is
 called "anonymous constructor syntax".  It is available for any inductive
 type with a single constructor, as long as the expected type is declared or
@@ -427,10 +426,6 @@ def append (l₁ l₂ : NatList) : NatList :=
 
 ## Type Classes and Overloading Notation
 
-:::dev "Benjamin Pierce (bcpierce00)"
-One word, or two?
-:::
-
 ::::full
 In Lean, notation like `++`, `==`, and `+` is not
 hardwired to particular definitions, which is the way we have
@@ -443,7 +438,7 @@ For now, the key idea is just this:
 a type class is like a Java-style interface, and an _instance_ is an
 implementation of that interface for a particular type.
 We associate notation with a particular type class member, and then
-instances of that typeclass inherit the notation.
+instances of that type class inherit the notation.
 
 For example, `++` is defined via the `HAppend` type class.
 Any type that provides an {name}`HAppend` instance gets to use `++`.
@@ -616,7 +611,7 @@ theorem test_nonZeros : nonZeros [0, 1, 0] = [1] := by
 :::gradeTheorem "0.5" test_nonZeros
 :::
 
-The next definition uses `bif`, Lean's conditional for Boolean tests.
+The next definition uses `bif`, Lean's conditional for boolean tests.
 The expression `bif b then x else y` evaluates to `x` when `b` is
 {name}`true` and to `y` when `b` is {name}`false`.
 Its characterizing lemmas are `cond_true` and `cond_false`.
@@ -816,7 +811,7 @@ theorem test_count2 : count 5 [1, 1, 4] = 0 := solution!(by rfl)
 :::
 :::::
 
-Again, all these proofs could be completed with just `rfl`, because the proof is computationally straightforward — compute both sides of the equality and check if they are the same.
+Again, all these proofs could be completed with just `rfl`, because the proof is computationally straightforward — compute both sides of the equality and check whether they are the same.
 
 ```lean
 example : count 1 [1, 2, 3, 1, 4, 1] = 3 := solution!(by rfl)
@@ -1043,6 +1038,13 @@ For example, just rewriting the left-hand side of the following equality using t
 {name}`nil_append` is enough for this theorem.
 ::::
 
+:::dev "Claude" BeforeNextRelease
+This paragraph promises "the following equality", but no such example follows —
+the next code block is `tail_length_pred`, which is proved by `cases`, not by
+rewriting with `nil_append`. An example seems to have gone missing; it should be
+restored (or the paragraph reworded).
+:::
+
 ::::terse
 As with numbers, some proofs about list functions need only
 rewriting.
@@ -1174,7 +1176,7 @@ By the definition of `append`, this follows from
 n :: ((l₁' ++ l₂) ++ l₃) = n :: (l₁' ++ (l₂ ++ l₃)),
 ```
 
-which is immediate from the induction hypothesis.  _Qed_.
+which is immediate from the induction hypothesis.  _QED_.
 
 ### Generalizing Statements
 
@@ -1182,7 +1184,7 @@ which is immediate from the induction hypothesis.  _Qed_.
 In some situations, it is necessary to generalize a
 statement in order to prove it by induction.  Intuitively, the
 reason is that a more general statement also yields a more general
-(stronger) inductive hypothesis. While the following
+(stronger) induction hypothesis. While the following
 statement is true, we cannot prove it directly:
 ::::
 
@@ -1212,11 +1214,11 @@ ih : replicate n c' ++ replicate n c' = replicate n (c' + c')
 ```
 
 ::::full
-To get a more general inductive hypothesis, we can generalize:
+To get a more general induction hypothesis, we can generalize:
 ::::
 
 :::terse
-A generalization that gives a stronger inductive hypothesis:
+A generalization that gives a stronger induction hypothesis:
 :::
 
 ```lean
@@ -1301,7 +1303,7 @@ ih : l'.reverse.length = l'.length
 ::::full
 A first attempt to make progress would be to prove exactly
 the statement that we are missing at this point.  But this attempt
-will fail because the inductive hypothesis is not general enough.
+will fail because the induction hypothesis is not general enough.
 ::::
 
 ```lean -keep +error (name := st3)
@@ -1466,13 +1468,13 @@ We must show
 ```
 
 This follows directly from the definitions of `length` and `++`
-together with the induction hypothesis.  _Qed_.
+together with the induction hypothesis.  _QED_.
 
-_Theorem_: For all lists `l`,  `l.reverse.length = l.length`.
+_Theorem_: For all lists `l`, `l.reverse.length = l.length`.
 
 _Proof_: By induction on `l`.
 
-  - First, suppose `l = []`.  We must show
+- First, suppose `l = []`.  We must show
 
 ```display
 [].reverse.length = [].length,
@@ -1506,7 +1508,7 @@ l'.reverse.length + [n].length = l'.length + 1.
 ```
 
 This follows directly from the induction hypothesis and the
-definition of `length`.  _Qed_.
+definition of `length`.  _QED_.
 
 The style of these proofs is rather long-winded and pedantic.
 After reading a couple like this, we might find it easier to
@@ -1518,10 +1520,18 @@ the above proof might look like this:
 _Theorem_: For all lists `l`, `l.reverse.length = l.length`.
 
 _Proof_: First observe, by a straightforward induction on `l`,
- that `(l ++ [n]).length = .succ l.length` for any `l`.  The main
- property then follows by another induction on `l`, using the
- observation together with the induction hypothesis in the case
- where `l = n' :: l'`. _Qed_.
+that `(l ++ [n]).length = .succ l.length` for any `l`.  The main
+property then follows by another induction on `l`, using the
+observation together with the induction hypothesis in the case
+where `l = n' :: l'`. _QED_.
+
+:::dev "Claude" BeforeNextRelease
+Two problems in this compressed proof. First, `.succ l.length` is Rocq-flavored;
+the chapter's Lean writes this as `l.length + 1`, and the lemma actually proved
+above is `append_length_succ`. Second, "by the previous lemma" points at
+`length_append`, which is not proved until later in the chapter — the step that
+is available here is `append_length_succ`.
+:::
 
 Which style is preferable in a given situation depends on
 the sophistication of the expected audience and how similar the
@@ -1733,7 +1743,7 @@ Before doing the next exercise, make sure you've filled in the
 definition of `removeOne` above.
 ::::::
 
-::::dev "Daniel Sainati @dsainati" PotentialImprovement
+::::dev "Daniel Sainati (dsainati)" PotentialImprovement
 
 There is a nicer solution to this exercise that doesn't require the contrived
 theorem statement that has 0s instead of arbitrary numbers. The only issue
@@ -1862,7 +1872,7 @@ theorem involutive_injective (f : Nat → Nat)
 
 :::::exercise (rating := 2) (name := "reverse_injective") (level := Advanced)
 Prove that {name}`reverse` is injective. Do not prove this by induction —
-that would be hard. Instead, re-use the same proof technique that
+that would be hard. Instead, reuse the same proof technique that
 you used for {name}`involutive_injective`. (But: Don't try to use that
 exercise directly as a lemma: the types are not the same!)
 
@@ -2181,7 +2191,7 @@ theorem quiz1 (d : PartialMap) (x : MyId) (n : Nat) :
 Is the following claim true or false?
 
 ```lean
-theorem quiz2  (d : PartialMap) (x y : MyId) (o : Nat) :
+theorem quiz2 (d : PartialMap) (x y : MyId) (o : Nat) :
     MyId.beq x y = false →
     find x (update d y o) = find x d := by
   intro h

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -37,7 +37,7 @@ namespace Lists
 # Pairs of Numbers
 
 ::::dev "Mike Hicks (mwhicks1)"
-This content is a redundant with what's in Basics, which introduces the idea of
+This content is redundant with what's in Basics, which introduces the idea of
 tuple types and structures as shorthand for them. I suspect we can drop most
 of the Basics content and rely on what's here instead. If we do that, we can
 introduce the term "Tuple" here.
@@ -45,7 +45,7 @@ introduce the term "Tuple" here.
 
 ::::full
 In an `inductive` type definition, each constructor can take
-any number of arguments -- none (as with {name}`true` and  {lean}`0`),
+any number of arguments — none (as with {name}`true` and  {lean}`0`),
 one (as with  {name}`Nat.succ`), or more than one (as with  {name}`Playground.Nibble` and
 the following):
 ::::
@@ -76,9 +76,9 @@ to two arguments of type {name}`Nat`."
 :::dev "Mike Hicks (@mwhicks1)"
 I would have expected us to have `namespace NatProd` here when defining
 the following functions, so we don't need qualifiers. We've already
-full explained namespaces back in Basics. Some of the text below
+fully explained namespaces back in Basics. Some of the text below
 mentions using the `NatProd` prefix specifically, but I think you can
-drop it and it will stick work.
+drop it and it will still work.
 :::
 
 Functions for extracting the first and second components of a pair
@@ -104,7 +104,6 @@ example : (NatProd.pair 3 5).fst = 3 := by rfl
 :::slidebreak
 :::
 
-
 ::::full
 Since pairs will be used heavily in what follows, it will be
 convenient to write them with angle bracket notation `⟨n, m⟩`
@@ -122,7 +121,7 @@ A nicer notation for pairs:
 example : (⟨3, 5⟩ : NatProd).fst = 3 := by rfl
 ```
 
-The anonymous constructor can be used in both expressions and in pattern matches.
+The anonymous constructor can be used both in expressions and in pattern matches.
 
 ```lean
 def NatProd.fst' (p : NatProd) : Nat :=
@@ -437,7 +436,7 @@ for different types.
 
 We'll learn more about type classes in chapter {ref "Typeclasses"}[Typeclasses].
 For now, the key idea is just this:
-a type class is like an Java-style interface, and an _instance_ is an
+a type class is like a Java-style interface, and an _instance_ is an
 implementation of that interface for a particular type.
 We associate notation with a particular type class member, and then
 instances of that typeclass inherit the notation.
@@ -534,7 +533,6 @@ theorem tail_cons (h : Nat) (t : NatList) : (h :: t).tail = t := by rfl
 theorem tail_nil : [].tail = [] := by rfl
 ```
 
-
 :::full
 And some examples:
 ```
@@ -570,7 +568,7 @@ Each exercise comes with non-graded examples followed by graded tests.
 We show how to rewrite with the lemmas explicitly in the first example and the fact that one can just use {tactic}`rfl` in the second (this is only visible in the solution because it would not type-check otherwise).
 The point of the graded tests is nearly always to be an {tactic}`rfl` proof that relies on a correctly formulated definition.
 The characterizing lemmas are provided (as statements) but not graded.
-The student is expected to also use {tactic}`rfl` as it's the easiest, and most idiomatic solution.
+The student is expected to also use {tactic}`rfl` as it's the easiest and most idiomatic solution.
 :::
 
 ::::::full
@@ -591,7 +589,7 @@ def nonZeros (l : NatList) : NatList := solution!(
 :::autogradedHole nonZeros
 :::
 
-The following lemmas should hold about your definition
+The following lemmas should hold about your definition.
 
 ```lean
 theorem nonZeros_cons_zero (t : NatList) :
@@ -673,7 +671,7 @@ example : oddMembers [1, 2] = [1] := by
     rw [Bool.not_true, Bool.not_false]
 ```
 
-This gets pretty verbose quite fast, however we can use {tactic}`rfl` to deal with subgoals such as {lean}`Nat.odd 2 = false`:
+This gets verbose pretty fast; however, we can use {tactic}`rfl` to deal with subgoals such as {lean}`Nat.odd 2 = false`:
 
 ```lean
 example : oddMembers [1, 2] = [1] := by
@@ -685,7 +683,7 @@ example : oddMembers [1, 2] = [1] := by
 ```
 
 In fact, as the entire proof is just plain computation, it can be done with a single `rfl`.
-This is possible because all of the elements and lists are concrete -- there are no variables involved.
+This is possible because all of the elements and lists are concrete — there are no variables involved.
 
 ```lean
 example : oddMembers [1, 2] = [1] := solution!(by rfl)
@@ -778,7 +776,7 @@ def count (n : Nat) (l : NatList) : Nat := solution!(
 :::autogradedHole count
 :::
 
-Now, prove these lemmas which should hold about your definition.
+Now prove these lemmas, which should hold about your definition.
 
 ```lean
 theorem count_nil (n : Nat) : count n [] = 0 := solution!(by rfl)
@@ -814,7 +812,7 @@ theorem test_count2 : count 5 [1, 1, 4] = 0 := solution!(by rfl)
 :::
 :::::
 
-Again, all these proofs could be completed with just `rfl`, because the proof is computationally straight-forward -- compute both sides of the equality and check if they are the same.
+Again, all these proofs could be completed with just `rfl`, because the proof is computationally straightforward — compute both sides of the equality and check if they are the same.
 
 ```lean
 example : count 1 [1, 2, 3, 1, 4, 1] = 3 := solution!(by rfl)
@@ -920,7 +918,6 @@ theorem test_removeOne2 : count 5 (removeOne 5 [1, 5, 5, 4]) = 1 := solution!(by
 
 :::gradeTheorem "0.5" test_removeOne1 test_removeOne2
 :::
-
 
 ```lean
 def removeAll (n : Nat) (l : NatList) : NatList := solution!(
@@ -1343,7 +1340,6 @@ theorem append_length_succ (l : NatList) (n : Nat) :
 
 Now we can prove the main theorem.
 
-
 ```lean
 theorem length_reverse (l : NatList) :
     l.reverse.length = l.length := by
@@ -1421,7 +1417,6 @@ To prove the following theorem, which tactics will we need besides
 
 (E) can't be done with the tactics we've seen.
 
-
 :::quizSolution
 ```lean
 example (n m : Nat) : (replicate n m).length = m := by
@@ -1454,7 +1449,7 @@ _Proof_: By induction on `l₁`.
   which follows directly from the definitions of `length`,
   `++`, and `+`.
 
-- Next, suppose `l₁ = n::l₁'`, with
+- Next, suppose `l₁ = n :: l₁'`, with
 
 ```display
 (l₁' ++ l₂).length = l₁'.length + l₂.length
@@ -1463,7 +1458,7 @@ _Proof_: By induction on `l₁`.
 We must show
 
 ```display
-((n::l₁') ++ l₂).length = (n::l₁').length + l₂.length.
+((n :: l₁') ++ l₂).length = (n :: l₁').length + l₂.length.
 ```
 
 This follows directly from the definitions of `length` and `++`
@@ -1482,7 +1477,7 @@ _Proof_: By induction on `l`.
   which follows directly from the definitions of `length`
   and `reverse`.
 
-- Next, suppose `l = n::l'`, with
+- Next, suppose `l = n :: l'`, with
 
 ```display
 l'.reverse.length = l'.length
@@ -1509,7 +1504,7 @@ l'.reverse.length + [n].length = l'.length + 1.
 This follows directly from the induction hypothesis and the
 definition of `length`.  _Qed_.
 
-The style of these proofs is rather longwinded and pedantic.
+The style of these proofs is rather long-winded and pedantic.
 After reading a couple like this, we might find it easier to
 follow proofs that give fewer details (which we can easily work
 out in our own minds or on scratch paper if necessary) and just
@@ -1522,7 +1517,7 @@ _Proof_: First observe, by a straightforward induction on `l`,
  that `(l ++ [n]).length = .succ l.length` for any `l`.  The main
  property then follows by another induction on `l`, using the
  observation together with the induction hypothesis in the case
- where `l = n'::l'`. _Qed_
+ where `l = n' :: l'`. _Qed_.
 
 Which style is preferable in a given situation depends on
 the sophistication of the expected audience and how similar the
@@ -1801,7 +1796,7 @@ before getting to this point.) MRC 1/19: The proof uses `cases`
 on a term that is not merely an identifier. That usage has not
 been introduced yet. APT 21: Added a hint about that. MRC 2/22:
 Even if the exercise is optional, it ought to be solvable with
-with the material introduced thus far. It is not. I note that BCP
+the material introduced thus far. It is not. I note that BCP
 has rejected the proof in the exercise above for `count_removeOne`
 because it uses `cases` on a term rather than identifier.
 :::
@@ -1890,7 +1885,7 @@ too short...
 
 :::terse
 Suppose we'd like a function to retrieve the `n`th element
-    of a list.  What to do if the list is too short?
+of a list.  What to do if the list is too short?
 :::
 
 ```lean
@@ -1906,7 +1901,7 @@ def nthBad (l : NatList) (n : Nat) : Nat :=
 :::
 
 ::::full
-This solution is not so good: If `nthBad` returns 42, we
+This solution is not so good: if `nthBad` returns 42, we
 don't know whether that value actually appears in the input or
 whether we gave bad arguments.  A better alternative is to change
 the return type to include an error value as a possible outcome.

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -45,6 +45,9 @@ tuple types and structures as shorthand for them. I suspect we can drop most
 of the Basics content and rely on what's here instead. If we do that, we can
 introduce the term "Tuple" here.
 ::::
+:::dev "Benjamin Pierce (bcpierce00)"
+Don't we need structures there in the airport exercise at least?
+:::
 
 ::::full
 In an `inductive` type definition, each constructor can take

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -95,12 +95,13 @@ inductive MyList (α : Type) : Type where
 
 ::::full
 This is exactly like the definition of `Natlist` from the
-previous chapter, except that the {name}`Nat` argument to the `cons`
-constructor has been replaced by an arbitrary type {lean}`α`, a type parameter
+{ref "Lists"}[Lists] chapter, except that a type parameter
 {lean}`α` has been added to the header on the first line,
+the {name}`Nat` argument to the `cons`
+constructor has been replaced by this arbitrary type {lean}`α`,
 and the occurrences of `Natlist` in the types of the constructors
 have been replaced by {lean}`MyList α`. We can now write {lean}`MyList Nat`
-instead of a dedicated nat-list type.
+instead of a dedicated `NatList` type.
 
 What sort of thing is {name}`MyList` itself?  A good way to think about it
 is as a _type constructor_ — that is, a function from {lean}`Type`s to
@@ -120,7 +121,7 @@ list-of-numbers type.
 ::::terse
 What is {name}`MyList` itself?
 
-It is a _type constructor_ — a function from types to types.
+It is a _type constructor_ — a function from {lean}`Type`s to {lean}`Type`s.
 ::::
 
 :::dev "Yipeng Liu (berberman)"
@@ -163,7 +164,10 @@ MyList.nil {α : Type} : MyList α
 ```
 
 ::::full
-Similarly, {name}`MyList.cons` adds an element of type {name}`Nat` to a
+Notice the use of curly braces in `{α : Type}`, rather than normal
+parentheses (as in `(α : Type)`); this is Lean telling us that `α` is an implicit parameter.
+
+The {name}`MyList.cons` constructor also adds an element of type {name}`Nat` to a
 list of type {lean}`MyList Nat`. Here is an example of forming a list
 containing just the natural number {lean}`3`.
 ::::
@@ -181,7 +185,7 @@ What is the full type of {name}`MyList.nil`? We can read off the
 result type {lean}`MyList α` from the definition,
 but to state the full type we must also bind {lean}`α`.
 Since the type argument to the constructor is implicit,
-Lean writes its type as (the equivalent of) {lean}`{α : Type} → MyList α`.
+it is presented with curly braces.
 ::::
 
 ```lean (name := nil)
@@ -193,7 +197,9 @@ MyList.nil {α : Type} : MyList α
 ```
 
 ::::full
-Similarly, the type of {name}`MyList.cons` includes the implicit
+Recall that this type is equivalent to {lean}`{α : Type} → MyList α`.
+
+The type of {name}`MyList.cons` also includes an implicit
 type parameter:
 ::::
 
@@ -207,8 +213,8 @@ MyList.cons {α : Type} (x : α) (l : MyList α) : MyList α
 
 ::::full
 Having to supply a type argument for every single use of a
-list constructor would be rather burdensome. Fortunately, the type
-argument is implicit, so Lean will normally infer it from context.
+list constructor would be rather burdensome. Fortunately, when a type
+argument is implicit, Lean will try to automatically infer it from context.
 
 We can now go back and make polymorphic versions of all the
 list-processing functions that we wrote before. Here is `replicate`,
@@ -233,11 +239,11 @@ def replicate (α : Type) (x : α) (count : Nat) : MyList α :=
 Some simple facts about {name}`replicate`:
 
 ```lean
-theorem replicate_zero (α : Type) (v : α) :
-    replicate α v 0 = MyList.nil := rfl
+theorem replicate_zero (α : Type) (a : α) :
+    replicate α a 0 = MyList.nil := rfl
 
-theorem replicate_succ (α : Type) (v : α) (count : Nat) :
-    replicate α v (count + 1) = MyList.cons v (replicate α v count) := rfl
+theorem replicate_succ (α : Type) (a : α) (count : Nat) :
+    replicate α a (count + 1) = MyList.cons a (replicate α a count) := rfl
 ```
 
 ::::full
@@ -310,7 +316,9 @@ What is the type of `replicate 1 2`?
 
 ::::full
 From now on, we'll use Lean's built-in {name}`List` type and its
-associated notation. The built-in {name}`List` is defined just like
+associated notation.
+
+The built-in {name}`List` is defined just like
 our {name}`MyList` above, but with notation {lean}`[]` for {name}`List.nil`,
 `::` for {name}`List.cons`, and {lean}`[1, 2, 3]` for list literals.
 The `++` operator is list append. The type arguments to the list constructors are implicit.
@@ -333,56 +341,12 @@ in the natural way:
 example : List Nat := [1, 2, 3]
 ```
 
-### Type Annotation Inference
-
-Let's write the definition of {name}`replicate` again, but this time we won't specify
-the type of the parameter {lean}`α`. Will Lean still accept it?
-
-```lean
-def replicate' α (x : α) (count : Nat) : List α :=
-  match count with
-  | 0 => .nil
-  | count' + 1 => .cons x (replicate' α x count')
-```
-
-Indeed it will. Lean infers that `α` is a type.
-
-```lean (name := replicate')
-#check replicate'
-```
-
-```leanOutput replicate'
-replicate'.{u_1} (α : Type u_1) (x : α) (count : Nat) : List α
-```
+### Implicit Type Arguments and Argument Synthesis
 
 ::::full
-The generated
-`u_1` is part of Lean's bookkeeping for treating types more generally.
-We will not need to interpret names like this for now —
-you can ignore them when they appear in Lean's output unless we explicitly
-call attention to them.
-::::
-
-::::terse
-Lean has used _type inference_ to deduce a type for {lean}`α`.
-::::
-
-::::full
-Lean was able to use _type inference_ to deduce what the type of {lean}`α`
-must be, based on how it is used. Since {lean}`α` is an argument to {name}`List`,
-it must be a {lean}`Type`, since {name}`List` expects a {lean}`Type` as its argument.
-
-This facility means we don't always have to write explicit type annotations
-everywhere, although explicit type annotations can still be quite useful
-as documentation, so we will continue to use them much of the time.
-::::
-
-### Type Argument Synthesis
-
-::::full
-To use a polymorphic function, we need to pass it one or
-more types in addition to its other arguments. For example, the
-recursive call in the body of the {name}`replicate` function above must
+In our {lean}`replicate` function above we wrote the type parameter `(α : Type)` explicitly, with normal parentheses.
+Doing so means that we need to pass in type argument explicitly, in addition to its other arguments.
+We see this in its own recursive call, which must
 pass along the type {lean}`α`. But since the second argument to
 {name}`replicate` is an element of {lean}`α`, it seems entirely obvious that the
 first argument can only be {lean}`α` — why should we have to write it
@@ -397,7 +361,7 @@ function being applied, the types of the other arguments, and the
 type expected by the context in which the application appears —
 to determine what concrete type should replace the `_`.
 
-Using holes, the {name}`replicate'` function can be rewritten like this:
+Using holes, the {name}`replicate` function can be rewritten like this:
 ::::
 
 ::::terse
@@ -406,16 +370,16 @@ can usually infer them:
 ::::
 
 ```lean
-def replicate'' (α : Type) (x : α) (count : Nat) : List α :=
+def replicate' (α : Type) (x : α) (count : Nat) : List α :=
   match count with
   | 0 => []
-  | count' + 1 => x :: replicate'' _ x count'
+  | count' + 1 => x :: replicate' _ x count'
 ```
 
 ::::full
-Alternatively, we can declare an argument to be implicit
+Alternatively, and more typically for Lean, we can declare an argument to be implicit
 when defining the function itself, by surrounding it in curly
-braces instead of parentheses. For example:
+braces instead of parentheses.
 ::::
 
 ::::terse
@@ -424,16 +388,15 @@ surrounding them with curly braces instead of parens:
 ::::
 
 ```lean
-def replicate''' {α : Type} (x : α) (count : Nat) : List α :=
+def replicate'' {α : Type} (x : α) (count : Nat) : List α :=
   match count with
   | 0 => []
-  | count' + 1 => x :: replicate''' x count'
+  | count' + 1 => x :: replicate'' x count'
 ```
 
 ::::full
-By making the type argument implicit, we no longer need to provide it
-to the recursive call to {name}`replicate'''`. Indeed, it
-would be invalid to provide one, because Lean is not expecting it.
+By making the type argument implicit, we no longer need to provide `α`
+to the recursive call to {name}`replicate''`.
 For each implicit parameter, Lean automatically inserts a hidden
 hole `_` argument for us, which is then inferred as usual.
 ::::
@@ -444,7 +407,8 @@ hole `_` argument for us, which is then inferred as usual.
 One small problem with implicit arguments is that, once in a
 while, Lean does not have enough local information to determine
 a type argument; in such cases, we need to tell Lean the type
-explicitly. For example:
+explicitly. For example, the following definition fails because
+Lean can't figure out the type of the empty list:
 ::::
 
 ::::terse
@@ -452,11 +416,17 @@ In general, it's fine to just let Lean infer all type
 arguments. But occasionally this can lead to problems:
 ::::
 
-This fails because Lean can't figure out the type of the empty list:
-`def mynil := []` — error: type not known
-We can fix this with an explicit type annotation:
+```lean +error (name := nil_type_error)
+def mynil := []
+```
 
-We can use the `@` prefix to supply the type
+```leanOutput nil_type_error
+Failed to infer type of definition `mynil`
+```
+
+We can fix this with an explicit type annotation.
+
+We use the `@` prefix when we want to supply the type
 argument explicitly. The `@` makes all implicit arguments
 of a function explicit:
 
@@ -671,8 +641,8 @@ theorem rev_cons {α : Type} {x : α} {l : List α} :
 :::::exercise (rating := 2) (name := "poly_exercises") (checkVisibility := false)
 Here are a few simple exercises, just like ones in the {ref "Lists"}[Lists] chapter,
 for practice with polymorphism. Complete the proofs below.
-You will likely find useful the following
-characterizing lemmas for {name}`List.append` in Lean standard library:
+You will find the following
+characterizing lemmas for {name}`List.append` in Lean standard library to be useful:
 
 ```lean (name := lemmas_append)
 #check List.nil_append
@@ -836,9 +806,7 @@ def zip {α β : Type} (l₁ : List α) (l₂ : List β) : List (α × β) :=
   | x :: l₁', y :: l₂' => (x, y) :: zip l₁' l₂'
 
 theorem zip_nil_left {α β : Type} (l₁ : List α) : zip l₁ [] = ([] : List (α × β)) := by
-  cases l₁ with
-  | nil => rfl
-  | cons h t => rfl
+  cases l₁ <;> rfl
 
 theorem zip_nil_right {α β : Type} (l₂ : List β) : zip [] l₂ = ([] : List (α × β)) := by
   cases l₂ <;> rfl
@@ -1019,7 +987,7 @@ theorem test_head?2 : head? [[1], [2]] = some [1] := solution!(by rfl)
 ::::full
 Like most modern programming languages — especially other
 "functional" languages, including OCaml, Haskell, Racket, Scala,
-Clojure, etc. — Lean treats functions as first-class citizens,
+and Clojure, among others — Lean treats functions as first-class citizens,
 allowing them to be passed as arguments to other functions,
 returned as results, stored in data structures, etc.
 ::::
@@ -1110,7 +1078,8 @@ example : filter isLength1
     [[1, 2], [3], [4], [5, 6, 7], [], [8]]
   = [[3], [4], [8]] := by rfl
 
-theorem filter_nil {α : Type} {test : α → Bool} : filter test [] = [] := by rfl
+theorem filter_nil {α : Type} {test : α → Bool} :
+  filter test [] = [] := by rfl
 
 theorem filter_cons_of_pos {α : Type} {test : α → Bool} {x : α}
     {l : List α} (h : test x = true) :
@@ -1125,19 +1094,23 @@ theorem filter_cons_of_neg {α : Type} {test : α → Bool} {x : α}
 
 ::::full
 You might have noticed that {name}`filter_cons_of_pos` and {name}`filter_cons_of_neg`
-have implicit parameters, such as `head` and `tail`, that do not have type {lean}`Type` like `α` does.
+have implicit parameters, such as `x` and `l`, that do not have type {lean}`Type` like `α` does.
 As it turns out, Lean allows _any_ parameter to be implicit, not just those of type {lean}`Type`.
 This is a standard Lean convention for lemmas that are likely to be used by {tactic}`rw`
-when their values can be inferred by unification.
+when their values can be inferred from the context.
 
-For example, suppose you were using this theorem to rewrite `filter Nat.even (3 :: rest)`.
-Matching that expression against the theorem's left-hand side `filter test (head :: tail)`
-establishes that `test = Nat.even`, `head = 3`, `tail = rest`, and
-{lean}`α = Nat`. By making these arguments implicit, Lean automatically inserts
+For example, suppose you were using theorem {name}`filter_cons_of_pos` to rewrite `filter Nat.even (3 :: rest)`.
+Matching the latter expression against the theorem's left-hand side `filter test (x :: l)`
+establishes that `test = Nat.even`, `x = 3`, `l = rest`, and
+{lean}`α = Nat`.
+If arguments `α`, `test`, `x`, and `l` were _not_ implicit, you'd
+have to write `rewrite [filter_cons_of_pos Nat Nat.even 3 rest]` in your proof.
+Since the arguments are implicit, Lean automatically inserts
 a hole `_` for each of them when you apply the theorem, just as with implicit parameters
 of type {lean}`Type`, so they can be inferred from the context.
+Thus you can write `rewrite [filter_cons_of_pos]` instead.
 
-Note that `h : test head` is not implicit, it's explicit. That's because it cannot be
+Note that `h : test x` is not implicit, it's explicit. That's because it cannot be
 solved by unification, i.e., Lean can't prove that `Nat.even 3 = true` that way.
 It's a general proof obligation.
 
@@ -1145,9 +1118,9 @@ We'll follow the Lean standard convention from now on.
 ::::
 
 ::::terse
-Note that `head` and `tail` are implicit too, following a general convention: any
+Note that `x` and `l` are implicit too, following a general convention: any
 argument an equation's shape determines when applied is made implicit, so using {tactic}`rw`
-and {tactic}`simp` lemmas requires no extra `_` arguments.
+lemmas requires no extra `_` arguments.
 ::::
 
 :::slidebreak

--- a/PROOFREADING.md
+++ b/PROOFREADING.md
@@ -14,42 +14,59 @@ the whole category at the source.
 
 ## Doing a pass
 
-Ask Claude to proofread a chapter. It reads this file and the ledger, then
-writes a *round* — a JSON file of anchored edits — into `proofread/rounds/`.
-Everything after that is one command with no arguments:
+Say `/proofread <Chapter>` in a Claude session — that is the whole interface.
+Claude reads this file and the ledger, writes a *round* (a JSON file of
+anchored edits, under `proofread/rounds/`), applies it, and opens a diff of
+just those edits in VS Code alongside the chapter. Revert the edits you don't
+want — one click per hunk in the Source Control gutter — and tell Claude you're
+done; it records your rejections in `proofread/ledger.jsonl` and reports any
+category that has earned a house rule. Then `lake build <Vol>.<Ch>` and commit
+the chapter and the ledger together.
+
+Two turns of conversation, then. The review in between can take a minute or a
+day, in that session or a later one: `proofread/state.json` holds the round in
+flight, so "I'm done" is understood whenever it comes. The round file and the
+script are never things you have to open.
+
+**A pass starts from a clean branch.** The round's edits must be the only
+uncommitted thing in the chapter — otherwise a reverted hunk cannot be told
+from your own work, and neither reconciling nor `undo` is exact. So the pass
+refuses to start while `git status` is dirty (its own files under `proofread/`
+excepted); commit or stash first. `--allow-dirty` overrides it, at that cost.
+
+`proofread.py undo` reverses the whole round and leaves it for another day.
+`proofread.py status` says where you are.
+
+### Never commit a round mid-flight
+
+Committing while a round is applied but unrecorded bakes in your reverts and
+loses the rejections. A hook is provided; install it once per clone:
 
 ```
-python3 scripts/proofread.py
+git config core.hooksPath scripts/hooks
 ```
 
-It offers the chapters with a round waiting (and skips the question when there
-is only one), applies every proposed edit, opens a diff of just those edits in
-VS Code alongside the chapter, and waits. Revert the edits you don't want — one
-click per hunk in the Source Control gutter — press return, and it records your
-rejections in `proofread/ledger.jsonl` and reports any category that has earned
-a house rule. Then `lake build <Vol>.<Ch>` and commit the chapter and the
-ledger together.
+`scripts/hooks/pre-commit` then blocks such a commit (and `git commit
+--no-verify` gets past it). Without the hook nothing enforces this — the
+`/proofread` flow simply asks Claude to record before committing.
 
-You can also start from nothing: run that command with no round waiting and it
-asks which chapter (offering the one you edited most recently), starts Claude
-on it with the instructions below, and waits. Leave Claude — `/exit`, or
-Ctrl-D — once the round is written and the command picks it up and carries on
-into the review. `proofread.py propose [<chapter>]` does the same on demand,
-even when other rounds are waiting; `<chapter>` is a path or a bare chapter
-name, e.g. `Basics`.
+### Doing it by hand
 
-Ctrl-C at the prompt stops without recording anything; run the command again
-and it resumes mid-review. `proofread.py undo` reverses the whole round and
-leaves it for another day. `proofread.py status` says where you are. The round
-file is never something you open.
+`python3 scripts/proofread.py`, with no arguments and a round already written,
+runs the same pass in a terminal: it applies the round, opens the diff, waits
+at a prompt while you review, and records when you press return. Ctrl-C stops
+without recording; run it again and it resumes mid-review. The phases are
+separately available as `proofread.py apply` and `proofread.py record`, which
+is what Claude runs; `proofread.py start [<chapter>]` names the chapter source
+and the next round file. `proofread.py --help` lists the rest.
 
-The diff exists because the chapter usually has other uncommitted work in it —
-`git diff` would mix your own edits in with the round's. The `.diff` file has
-only the round.
+The `.diff` file is the round as proposed: it stays next to the round file
+afterwards, and it still reads as one list of the proposals once you have begun
+reverting hunks in the chapter.
 
 ### Edits that share a hunk
 
-The command warns when two edits land within a few lines of each other. Those
+`apply` warns when two edits land within a few lines of each other. Those
 sit in one git hunk and cannot be reverted independently — fix that spot by
 hand instead. Such an edit is then reported as `unclear` and nothing is
 recorded for it, so it will come back in a later round.
@@ -124,5 +141,10 @@ For whoever (or whatever) does the proposing:
   claim, an inconsistent term — report those separately in prose. They need a
   decision, not a comma.
 * Proofread the hand-maintained source, not a generated `<Ch>Verso.lean`.
-* Just write the round to `proofread/rounds/<Ch>-rNN.json` and tell the author
-  to run `python3 scripts/proofread.py`; it finds waiting rounds on its own.
+* Write the round to the path `proofread.py start` printed
+  (`proofread/rounds/<Ch>-rNN.json`) and do not edit the chapter yourself —
+  every edit reaches it through the round, so that what the author accepts and
+  declines is what the ledger records.
+
+The driving loop around these rules — which command to run when, and where to
+stop and wait for the author — is `.claude/skills/proofread/SKILL.md`.

--- a/PROOFREADING.md
+++ b/PROOFREADING.md
@@ -16,12 +16,13 @@ the whole category at the source.
 
 Say `/proofread <Chapter>` in a Claude session — that is the whole interface.
 Claude reads this file and the ledger, writes a *round* (a JSON file of
-anchored edits, under `proofread/rounds/`), applies it, and opens a diff of
-just those edits in VS Code alongside the chapter. Revert the edits you don't
-want — one click per hunk in the Source Control gutter — and tell Claude you're
-done; it records your rejections in `proofread/ledger.jsonl` and reports any
-category that has earned a house rule. Then `lake build <Vol>.<Ch>` and commit
-the chapter and the ledger together.
+anchored edits, under `proofread/rounds/`), applies it, and opens a side-by-side
+diff in VS Code: the chapter as it was before the round on the left, the live
+chapter on the right. Revert the edits you don't want — hover a change and
+click the arrow in the gutter between the panes, or just edit the right-hand
+side — and tell Claude you're done; it records your rejections in
+`proofread/ledger.jsonl` and reports any category that has earned a house rule.
+Then `lake build <Vol>.<Ch>` and commit the chapter and the ledger together.
 
 Two turns of conversation, then. The review in between can take a minute or a
 day, in that session or a later one: `proofread/state.json` holds the round in
@@ -60,15 +61,33 @@ separately available as `proofread.py apply` and `proofread.py record`, which
 is what Claude runs; `proofread.py start [<chapter>]` names the chapter source
 and the next round file. `proofread.py --help` lists the rest.
 
-The `.diff` file is the round as proposed: it stays next to the round file
-afterwards, and it still reads as one list of the proposals once you have begun
-reverting hunks in the chapter.
+The `.diff` file is a unified diff of the round as proposed. It stays next to
+the round file afterwards, and — unlike the live side-by-side view — it still
+reads as the complete list once you have begun reverting.
+
+### The review view
+
+`apply` runs `code --diff` on two real files: a snapshot of the chapter taken
+before the round, and the chapter itself. That is one step to the two versions
+side by side, and it depends on no source-control extension — the left pane is
+a plain file, not a git revision. It is also read-only (mode 444), so an edit
+made in the wrong pane cannot quietly look like a revert; the right pane *is*
+the chapter, and what you leave standing there is what you have accepted.
+
+The snapshot lives at `proofread/rounds/<Ch>-rNN.before.lean` for the life of
+the round and is deleted by `record` or `undo`. It is gitignored.
+
+Because a pass starts from a clean branch, the git UI shows exactly the same
+thing, if you prefer it: the Source Control view (or any extension's
+equivalent) lists just this round, and its per-change revert works as well as
+the diff editor's. `apply --open files` opens the chapter and the unified diff
+as plain tabs instead, and `--open none` opens nothing.
 
 ### Edits that share a hunk
 
-`apply` warns when two edits land within a few lines of each other. Those
-sit in one git hunk and cannot be reverted independently — fix that spot by
-hand instead. Such an edit is then reported as `unclear` and nothing is
+`apply` warns when two edits land within a few lines of each other. Those sit
+in one change block, so a single revert takes both — edit that spot by hand
+instead. Such an edit is then reported as `unclear` and nothing is
 recorded for it, so it will come back in a later round.
 
 ## The ledger

--- a/STYLE-WRITING.md
+++ b/STYLE-WRITING.md
@@ -202,6 +202,8 @@ records the house rules that override Chicago.
 | "VS Code"              | "VSCode"                     |
 | "IH"                   | "I.H."                       |
 | "type class"           | "typeclass"                  |
+| "boolean"              | "Boolean"                    |
+| "induction hypothesis" | "inductive hypothesis"       |
 
 ### Informal Proofs
 

--- a/STYLE-WRITING.md
+++ b/STYLE-WRITING.md
@@ -200,6 +200,8 @@ records the house rules that override Chicago.
 | _italics_ for emphasis | **boldface**                 |
 | "Lean"                 | "Lean 4" (except in Preface) |
 | "VS Code"              | "VSCode"                     |
+| "IH"                   | "I.H."                       |
+| "type class"           | "typeclass"                  |
 
 ### Informal Proofs
 

--- a/STYLE-WRITING.md
+++ b/STYLE-WRITING.md
@@ -195,15 +195,18 @@ the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/).
 `PROOFREADING.md` describes the repeatable per-chapter proofreading pass and
 records the house rules that override Chicago.
 
-| Use this               | Not that                     |
-| ---------------------- | ---------------------------- |
-| _italics_ for emphasis | **boldface**                 |
-| "Lean"                 | "Lean 4" (except in Preface) |
-| "VS Code"              | "VSCode"                     |
-| "IH"                   | "I.H."                       |
-| "type class"           | "typeclass"                  |
-| "boolean"              | "Boolean"                    |
-| "induction hypothesis" | "inductive hypothesis"       |
+Word choices, one per line, as `use` / `not`:
+
+- _italics_ for emphasis / **boldface**
+- "Lean" / "Lean 4" (except in the Preface)
+- "VS Code" / "VSCode"
+- "IH" / "I.H."
+- "type class" / "typeclass"
+- "boolean" / "Boolean"
+- "induction hypothesis" / "inductive hypothesis"
+
+To add one, append a line in the same shape: the preferred form, a slash, the
+form to avoid, and any qualifier in parentheses.
 
 ### Informal Proofs
 

--- a/proofread/rounds/Lists-r01.diff
+++ b/proofread/rounds/Lists-r01.diff
@@ -1,0 +1,216 @@
+--- LF/Lists.lean (before this round)
++++ LF/Lists.lean
+@@ -37,7 +37,7 @@
+ # Pairs of Numbers
+ 
+ ::::dev "Mike Hicks (mwhicks1)"
+-This content is a redundant with what's in Basics, which introduces the idea of
++This content is redundant with what's in Basics, which introduces the idea of
+ tuple types and structures as shorthand for them. I suspect we can drop most
+ of the Basics content and rely on what's here instead. If we do that, we can
+ introduce the term "Tuple" here.
+@@ -45,7 +45,7 @@
+ 
+ ::::full
+ In an `inductive` type definition, each constructor can take
+-any number of arguments -- none (as with {name}`true` and  {lean}`0`),
++any number of arguments — none (as with {name}`true` and  {lean}`0`),
+ one (as with  {name}`Nat.succ`), or more than one (as with  {name}`Playground.Nibble` and
+ the following):
+ ::::
+@@ -76,9 +76,9 @@
+ :::dev "Mike Hicks (@mwhicks1)"
+ I would have expected us to have `namespace NatProd` here when defining
+ the following functions, so we don't need qualifiers. We've already
+-full explained namespaces back in Basics. Some of the text below
++fully explained namespaces back in Basics. Some of the text below
+ mentions using the `NatProd` prefix specifically, but I think you can
+-drop it and it will stick work.
++drop it and it will still work.
+ :::
+ 
+ Functions for extracting the first and second components of a pair
+@@ -104,7 +104,6 @@
+ :::slidebreak
+ :::
+ 
+-
+ ::::full
+ Since pairs will be used heavily in what follows, it will be
+ convenient to write them with angle bracket notation `⟨n, m⟩`
+@@ -122,7 +121,7 @@
+ example : (⟨3, 5⟩ : NatProd).fst = 3 := by rfl
+ ```
+ 
+-The anonymous constructor can be used in both expressions and in pattern matches.
++The anonymous constructor can be used both in expressions and in pattern matches.
+ 
+ ```lean
+ def NatProd.fst' (p : NatProd) : Nat :=
+@@ -437,7 +436,7 @@
+ 
+ We'll learn more about type classes in chapter {ref "Typeclasses"}[Typeclasses].
+ For now, the key idea is just this:
+-a type class is like an Java-style interface, and an _instance_ is an
++a type class is like a Java-style interface, and an _instance_ is an
+ implementation of that interface for a particular type.
+ We associate notation with a particular type class member, and then
+ instances of that typeclass inherit the notation.
+@@ -534,7 +533,6 @@
+ theorem tail_nil : [].tail = [] := by rfl
+ ```
+ 
+-
+ :::full
+ And some examples:
+ ```
+@@ -570,7 +568,7 @@
+ We show how to rewrite with the lemmas explicitly in the first example and the fact that one can just use {tactic}`rfl` in the second (this is only visible in the solution because it would not type-check otherwise).
+ The point of the graded tests is nearly always to be an {tactic}`rfl` proof that relies on a correctly formulated definition.
+ The characterizing lemmas are provided (as statements) but not graded.
+-The student is expected to also use {tactic}`rfl` as it's the easiest, and most idiomatic solution.
++The student is expected to also use {tactic}`rfl` as it's the easiest and most idiomatic solution.
+ :::
+ 
+ ::::::full
+@@ -591,7 +589,7 @@
+ :::autogradedHole nonZeros
+ :::
+ 
+-The following lemmas should hold about your definition
++The following lemmas should hold about your definition.
+ 
+ ```lean
+ theorem nonZeros_cons_zero (t : NatList) :
+@@ -673,7 +671,7 @@
+     rw [Bool.not_true, Bool.not_false]
+ ```
+ 
+-This gets pretty verbose quite fast, however we can use {tactic}`rfl` to deal with subgoals such as {lean}`Nat.odd 2 = false`:
++This gets pretty verbose quite fast; however, we can use {tactic}`rfl` to deal with subgoals such as {lean}`Nat.odd 2 = false`:
+ 
+ ```lean
+ example : oddMembers [1, 2] = [1] := by
+@@ -685,7 +683,7 @@
+ ```
+ 
+ In fact, as the entire proof is just plain computation, it can be done with a single `rfl`.
+-This is possible because all of the elements and lists are concrete -- there are no variables involved.
++This is possible because all of the elements and lists are concrete — there are no variables involved.
+ 
+ ```lean
+ example : oddMembers [1, 2] = [1] := solution!(by rfl)
+@@ -778,7 +776,7 @@
+ :::autogradedHole count
+ :::
+ 
+-Now, prove these lemmas which should hold about your definition.
++Now, prove these lemmas that should hold about your definition.
+ 
+ ```lean
+ theorem count_nil (n : Nat) : count n [] = 0 := solution!(by rfl)
+@@ -814,7 +812,7 @@
+ :::
+ :::::
+ 
+-Again, all these proofs could be completed with just `rfl`, because the proof is computationally straight-forward -- compute both sides of the equality and check if they are the same.
++Again, all these proofs could be completed with just `rfl`, because the proof is computationally straightforward — compute both sides of the equality and check if they are the same.
+ 
+ ```lean
+ example : count 1 [1, 2, 3, 1, 4, 1] = 3 := solution!(by rfl)
+@@ -921,7 +919,6 @@
+ :::gradeTheorem "0.5" test_removeOne1 test_removeOne2
+ :::
+ 
+-
+ ```lean
+ def removeAll (n : Nat) (l : NatList) : NatList := solution!(
+   match l with
+@@ -1343,7 +1340,6 @@
+ 
+ Now we can prove the main theorem.
+ 
+-
+ ```lean
+ theorem length_reverse (l : NatList) :
+     l.reverse.length = l.length := by
+@@ -1421,7 +1417,6 @@
+ 
+ (E) can't be done with the tactics we've seen.
+ 
+-
+ :::quizSolution
+ ```lean
+ example (n m : Nat) : (replicate n m).length = m := by
+@@ -1454,7 +1449,7 @@
+   which follows directly from the definitions of `length`,
+   `++`, and `+`.
+ 
+-- Next, suppose `l₁ = n::l₁'`, with
++- Next, suppose `l₁ = n :: l₁'`, with
+ 
+ ```display
+ (l₁' ++ l₂).length = l₁'.length + l₂.length
+@@ -1463,7 +1458,7 @@
+ We must show
+ 
+ ```display
+-((n::l₁') ++ l₂).length = (n::l₁').length + l₂.length.
++((n :: l₁') ++ l₂).length = (n :: l₁').length + l₂.length.
+ ```
+ 
+ This follows directly from the definitions of `length` and `++`
+@@ -1482,7 +1477,7 @@
+   which follows directly from the definitions of `length`
+   and `reverse`.
+ 
+-- Next, suppose `l = n::l'`, with
++- Next, suppose `l = n :: l'`, with
+ 
+ ```display
+ l'.reverse.length = l'.length
+@@ -1509,7 +1504,7 @@
+ This follows directly from the induction hypothesis and the
+ definition of `length`.  _Qed_.
+ 
+-The style of these proofs is rather longwinded and pedantic.
++The style of these proofs is rather long-winded and pedantic.
+ After reading a couple like this, we might find it easier to
+ follow proofs that give fewer details (which we can easily work
+ out in our own minds or on scratch paper if necessary) and just
+@@ -1522,7 +1517,7 @@
+  that `(l ++ [n]).length = .succ l.length` for any `l`.  The main
+  property then follows by another induction on `l`, using the
+  observation together with the induction hypothesis in the case
+- where `l = n'::l'`. _Qed_
++ where `l = n' :: l'`. _Qed_.
+ 
+ Which style is preferable in a given situation depends on
+ the sophistication of the expected audience and how similar the
+@@ -1801,7 +1796,7 @@
+ on a term that is not merely an identifier. That usage has not
+ been introduced yet. APT 21: Added a hint about that. MRC 2/22:
+ Even if the exercise is optional, it ought to be solvable with
+-with the material introduced thus far. It is not. I note that BCP
++the material introduced thus far. It is not. I note that BCP
+ has rejected the proof in the exercise above for `count_removeOne`
+ because it uses `cases` on a term rather than identifier.
+ :::
+@@ -1890,7 +1885,7 @@
+ 
+ :::terse
+ Suppose we'd like a function to retrieve the `n`th element
+-    of a list.  What to do if the list is too short?
++of a list.  What to do if the list is too short?
+ :::
+ 
+ ```lean
+@@ -1906,7 +1901,7 @@
+ :::
+ 
+ ::::full
+-This solution is not so good: If `nthBad` returns 42, we
++This solution is not so good: if `nthBad` returns 42, we
+ don't know whether that value actually appears in the input or
+ whether we gave bad arguments.  A better alternative is to change
+ the return type to include an error value as a possible outcome.

--- a/proofread/rounds/Lists-r01.json
+++ b/proofread/rounds/Lists-r01.json
@@ -1,0 +1,176 @@
+{
+ "file": "LF/Lists.lean",
+ "chapter": "Lists",
+ "round": 1,
+ "proposals": [
+  {
+   "id": "p01",
+   "cat": "typo/article",
+   "old": "This content is a redundant with what's in Basics",
+   "new": "This content is redundant with what's in Basics",
+   "why": "Stray article before a predicate adjective."
+  },
+  {
+   "id": "p02",
+   "cat": "punctuation/em-dash",
+   "old": "any number of arguments -- none (as with",
+   "new": "any number of arguments — none (as with",
+   "why": "Chapter prose uses a real em dash; ASCII `--` is the shorthand reserved for note bodies."
+  },
+  {
+   "id": "p03",
+   "cat": "typo/word-slip",
+   "old": "the following functions, so we don't need qualifiers. We've already\nfull explained namespaces back in Basics. Some of the text below\nmentions using the `NatProd` prefix specifically, but I think you can\ndrop it and it will stick work.",
+   "new": "the following functions, so we don't need qualifiers. We've already\nfully explained namespaces back in Basics. Some of the text below\nmentions using the `NatProd` prefix specifically, but I think you can\ndrop it and it will still work.",
+   "why": "Two slips in one note: \"full\" for \"fully\" and \"stick\" for \"still\". They share a hunk, so they travel together."
+  },
+  {
+   "id": "p04",
+   "cat": "formatting/blank-lines",
+   "old": ":::\n\n\n::::full\nSince pairs will be used heavily",
+   "new": ":::\n\n::::full\nSince pairs will be used heavily",
+   "why": "Two blank lines in a row; the file uses at most one."
+  },
+  {
+   "id": "p05",
+   "cat": "parallelism/both-and",
+   "old": "used in both expressions and in pattern matches",
+   "new": "used both in expressions and in pattern matches",
+   "why": "`both ... and` must join parallel elements; as written `both` scopes over \"expressions and in pattern matches\"."
+  },
+  {
+   "id": "p06",
+   "cat": "typo/article",
+   "old": "a type class is like an Java-style interface",
+   "new": "a type class is like a Java-style interface",
+   "why": "\"Java\" begins with a consonant sound, so it takes \"a\"."
+  },
+  {
+   "id": "p07",
+   "cat": "formatting/blank-lines",
+   "old": "theorem tail_nil : [].tail = [] := by rfl\n```\n\n\n:::full",
+   "new": "theorem tail_nil : [].tail = [] := by rfl\n```\n\n:::full",
+   "why": "Two blank lines in a row; the file uses at most one."
+  },
+  {
+   "id": "p08",
+   "cat": "comma/coordinate-adjectives",
+   "old": "as it's the easiest, and most idiomatic solution",
+   "new": "as it's the easiest and most idiomatic solution",
+   "why": "No comma before \"and\" joining two adjectives modifying the same noun."
+  },
+  {
+   "id": "p09",
+   "cat": "punctuation/missing-period",
+   "old": "The following lemmas should hold about your definition\n\n```lean",
+   "new": "The following lemmas should hold about your definition.\n\n```lean",
+   "why": "Sentence ends without a period; the parallel line in the next exercise has one."
+  },
+  {
+   "id": "p10",
+   "cat": "punctuation/comma-splice",
+   "old": "This gets pretty verbose quite fast, however we can use",
+   "new": "This gets pretty verbose quite fast; however, we can use",
+   "why": "\"however\" is a conjunctive adverb, not a coordinating conjunction, so a comma alone splices the two clauses."
+  },
+  {
+   "id": "p11",
+   "cat": "punctuation/em-dash",
+   "old": "lists are concrete -- there are no variables involved",
+   "new": "lists are concrete — there are no variables involved",
+   "why": "Chapter prose uses a real em dash."
+  },
+  {
+   "id": "p12",
+   "cat": "punctuation/em-dash",
+   "old": "computationally straight-forward -- compute both sides",
+   "new": "computationally straightforward — compute both sides",
+   "why": "Em dash in chapter prose; and \"straightforward\" is one word."
+  },
+  {
+   "id": "p13",
+   "cat": "usage/that-which",
+   "old": "Now, prove these lemmas which should hold",
+   "new": "Now, prove these lemmas that should hold",
+   "why": "Restrictive relative clause: CMOS uses \"that\" and no comma."
+  },
+  {
+   "id": "p14",
+   "cat": "formatting/blank-lines",
+   "old": ":::gradeTheorem \"0.5\" test_removeOne1 test_removeOne2\n:::\n\n\n```lean",
+   "new": ":::gradeTheorem \"0.5\" test_removeOne1 test_removeOne2\n:::\n\n```lean",
+   "why": "Two blank lines in a row; the file uses at most one."
+  },
+  {
+   "id": "p15",
+   "cat": "formatting/blank-lines",
+   "old": "Now we can prove the main theorem.\n\n\n```lean",
+   "new": "Now we can prove the main theorem.\n\n```lean",
+   "why": "Two blank lines in a row; the file uses at most one."
+  },
+  {
+   "id": "p16",
+   "cat": "formatting/blank-lines",
+   "old": "(E) can't be done with the tactics we've seen.\n\n\n:::quizSolution",
+   "new": "(E) can't be done with the tactics we've seen.\n\n:::quizSolution",
+   "why": "Two blank lines in a row; the file uses at most one."
+  },
+  {
+   "id": "p17",
+   "cat": "markup/code-spacing",
+   "old": "  `++`, and `+`.\n\n- Next, suppose `l₁ = n::l₁'`, with",
+   "new": "  `++`, and `+`.\n\n- Next, suppose `l₁ = n :: l₁'`, with",
+   "why": "The parallel informal proof earlier in the chapter writes `n :: l₁'`, as does every Lean block."
+  },
+  {
+   "id": "p18",
+   "cat": "markup/code-spacing",
+   "old": "((n::l₁') ++ l₂).length = (n::l₁').length + l₂.length.",
+   "new": "((n :: l₁') ++ l₂).length = (n :: l₁').length + l₂.length.",
+   "why": "Spaces around `::` everywhere else in the chapter."
+  },
+  {
+   "id": "p19",
+   "cat": "markup/code-spacing",
+   "old": "- Next, suppose `l = n::l'`, with",
+   "new": "- Next, suppose `l = n :: l'`, with",
+   "why": "Spaces around `::` everywhere else in the chapter."
+  },
+  {
+   "id": "p20",
+   "cat": "hyphenation/compound",
+   "old": "rather longwinded and pedantic",
+   "new": "rather long-winded and pedantic",
+   "why": "Merriam-Webster and CMOS both hyphenate \"long-winded\"."
+  },
+  {
+   "id": "p21",
+   "cat": "punctuation/missing-period",
+   "old": " where `l = n'::l'`. _Qed_\n",
+   "new": " where `l = n' :: l'`. _Qed_.\n",
+   "why": "Every other informal proof in this section closes `_Qed_.`; also spaces the `::` to match the rest of the chapter."
+  },
+  {
+   "id": "p22",
+   "cat": "formatting/stray-indent",
+   "old": "Suppose we'd like a function to retrieve the `n`th element\n    of a list.  What to do if the list is too short?",
+   "new": "Suppose we'd like a function to retrieve the `n`th element\nof a list.  What to do if the list is too short?",
+   "why": "Continuation line of the paragraph is indented four spaces; no other terse block does this."
+  },
+  {
+   "id": "p23",
+   "cat": "capitalization/after-colon",
+   "old": "This solution is not so good: If `nthBad` returns 42",
+   "new": "This solution is not so good: if `nthBad` returns 42",
+   "why": "CMOS 6.61: lowercase after a colon when a single sentence follows."
+  },
+  {
+   "id": "p24",
+   "cat": "typo/doubled-word",
+   "old": "it ought to be solvable with\nwith the material introduced thus far",
+   "new": "it ought to be solvable with\nthe material introduced thus far",
+   "why": "\"with with\" across the line break."
+  }
+ ],
+ "completed": true
+}

--- a/proofread/rounds/Lists-r02.diff
+++ b/proofread/rounds/Lists-r02.diff
@@ -1,0 +1,143 @@
+--- LF/Lists.lean (before this round)
++++ LF/Lists.lean
+@@ -22,7 +22,6 @@
+ And UsingLean??
+ :::
+ 
+-
+ ```importBlock
+ import LF.Induction
+ import LF.UsingLean
+@@ -49,8 +48,8 @@
+ 
+ ::::full
+ In an `inductive` type definition, each constructor can take
+-any number of arguments — none (as with {name}`true` and  {lean}`0`),
+-one (as with  {name}`Nat.succ`), or more than one (as with  {name}`Playground.Nibble` and
++any number of arguments — none (as with {name}`true` and {lean}`0`),
++one (as with {name}`Nat.succ`), or more than one (as with {name}`Playground.Nibble` and
+ the following):
+ ::::
+ 
+@@ -77,7 +76,7 @@
+ :::slidebreak
+ :::
+ 
+-:::dev "Mike Hicks (@mwhicks1)"
++:::dev "Mike Hicks (mwhicks1)"
+ I would have expected us to have `namespace NatProd` here when defining
+ the following functions, so we don't need qualifiers. We've already
+ fully explained namespaces back in Basics. Some of the text below
+@@ -98,7 +97,7 @@
+   | .pair _ y => y
+ ```
+ 
+-Defining these functions with the {name}`NatProd` type name qualifying their name
++Defining these functions with the {name}`NatProd` type name qualifying their names
+ allows us to use them with `.` notation:
+ 
+ ```lean
+@@ -110,7 +109,7 @@
+ 
+ ::::full
+ Since pairs will be used heavily in what follows, it will be
+-convenient to write them with angle bracket notation `⟨n, m⟩`
++convenient to write them with angle-bracket notation `⟨n, m⟩`
+ instead of `NatProd.pair n m`.  This notation is built into Lean and is
+ called "anonymous constructor syntax".  It is available for any inductive
+ type with a single constructor, as long as the expected type is declared or
+@@ -443,7 +442,7 @@
+ a type class is like a Java-style interface, and an _instance_ is an
+ implementation of that interface for a particular type.
+ We associate notation with a particular type class member, and then
+-instances of that typeclass inherit the notation.
++instances of that type class inherit the notation.
+ 
+ For example, `++` is defined via the `HAppend` type class.
+ Any type that provides an {name}`HAppend` instance gets to use `++`.
+@@ -816,7 +815,7 @@
+ :::
+ :::::
+ 
+-Again, all these proofs could be completed with just `rfl`, because the proof is computationally straightforward — compute both sides of the equality and check if they are the same.
++Again, all these proofs could be completed with just `rfl`, because the proof is computationally straightforward — compute both sides of the equality and check whether they are the same.
+ 
+ ```lean
+ example : count 1 [1, 2, 3, 1, 4, 1] = 3 := solution!(by rfl)
+@@ -1174,7 +1173,7 @@
+ n :: ((l₁' ++ l₂) ++ l₃) = n :: (l₁' ++ (l₂ ++ l₃)),
+ ```
+ 
+-which is immediate from the induction hypothesis.  _Qed_.
++which is immediate from the induction hypothesis.  _QED_.
+ 
+ ### Generalizing Statements
+ 
+@@ -1466,13 +1465,13 @@
+ ```
+ 
+ This follows directly from the definitions of `length` and `++`
+-together with the induction hypothesis.  _Qed_.
++together with the induction hypothesis.  _QED_.
+ 
+-_Theorem_: For all lists `l`,  `l.reverse.length = l.length`.
++_Theorem_: For all lists `l`, `l.reverse.length = l.length`.
+ 
+ _Proof_: By induction on `l`.
+ 
+-  - First, suppose `l = []`.  We must show
++- First, suppose `l = []`.  We must show
+ 
+ ```display
+ [].reverse.length = [].length,
+@@ -1506,7 +1505,7 @@
+ ```
+ 
+ This follows directly from the induction hypothesis and the
+-definition of `length`.  _Qed_.
++definition of `length`.  _QED_.
+ 
+ The style of these proofs is rather long-winded and pedantic.
+ After reading a couple like this, we might find it easier to
+@@ -1518,10 +1517,10 @@
+ _Theorem_: For all lists `l`, `l.reverse.length = l.length`.
+ 
+ _Proof_: First observe, by a straightforward induction on `l`,
+- that `(l ++ [n]).length = .succ l.length` for any `l`.  The main
+- property then follows by another induction on `l`, using the
+- observation together with the induction hypothesis in the case
+- where `l = n' :: l'`. _Qed_.
++that `(l ++ [n]).length = .succ l.length` for any `l`.  The main
++property then follows by another induction on `l`, using the
++observation together with the induction hypothesis in the case
++where `l = n' :: l'`. _QED_.
+ 
+ Which style is preferable in a given situation depends on
+ the sophistication of the expected audience and how similar the
+@@ -1733,7 +1732,7 @@
+ definition of `removeOne` above.
+ ::::::
+ 
+-::::dev "Daniel Sainati @dsainati" PotentialImprovement
++::::dev "Daniel Sainati (dsainati)" PotentialImprovement
+ 
+ There is a nicer solution to this exercise that doesn't require the contrived
+ theorem statement that has 0s instead of arbitrary numbers. The only issue
+@@ -1862,7 +1861,7 @@
+ 
+ :::::exercise (rating := 2) (name := "reverse_injective") (level := Advanced)
+ Prove that {name}`reverse` is injective. Do not prove this by induction —
+-that would be hard. Instead, re-use the same proof technique that
++that would be hard. Instead, reuse the same proof technique that
+ you used for {name}`involutive_injective`. (But: Don't try to use that
+ exercise directly as a lemma: the types are not the same!)
+ 
+@@ -2181,7 +2180,7 @@
+ Is the following claim true or false?
+ 
+ ```lean
+-theorem quiz2  (d : PartialMap) (x y : MyId) (o : Nat) :
++theorem quiz2 (d : PartialMap) (x y : MyId) (o : Nat) :
+     MyId.beq x y = false →
+     find x (update d y o) = find x d := by
+   intro h

--- a/proofread/rounds/Lists-r02.json
+++ b/proofread/rounds/Lists-r02.json
@@ -1,0 +1,113 @@
+{
+ "file": "LF/Lists.lean",
+ "chapter": "Lists",
+ "round": 2,
+ "proposals": [
+  {
+   "id": "blank-run-importblock",
+   "cat": "formatting/blank-lines",
+   "old": "And UsingLean??\n:::\n\n\n```importBlock",
+   "new": "And UsingLean??\n:::\n\n```importBlock",
+   "why": "Two blank lines in a row; the source uses at most one anywhere."
+  },
+  {
+   "id": "double-space-constructor-args",
+   "cat": "formatting/double-space",
+   "old": "none (as with {name}`true` and  {lean}`0`),\none (as with  {name}`Nat.succ`), or more than one (as with  {name}`Playground.Nibble` and",
+   "new": "none (as with {name}`true` and {lean}`0`),\none (as with {name}`Nat.succ`), or more than one (as with {name}`Playground.Nibble` and",
+   "why": "Three stray double spaces mid-sentence (not after a period)."
+  },
+  {
+   "id": "mwhicks-author-at",
+   "cat": "markup/dev-author",
+   "old": ":::dev \"Mike Hicks (@mwhicks1)\"\nI would have expected",
+   "new": ":::dev \"Mike Hicks (mwhicks1)\"\nI would have expected",
+   "why": "Author strings are \"Full Name (github-handle)\"; the same author is written without the @ at the previous note."
+  },
+  {
+   "id": "their-names",
+   "cat": "agreement/number",
+   "old": "qualifying their name\nallows us",
+   "new": "qualifying their names\nallows us",
+   "why": "Plural subject (\"these functions\") takes a plural \"names\"."
+  },
+  {
+   "id": "angle-bracket-notation",
+   "cat": "hyphenation/compound-modifier",
+   "old": "with angle bracket notation",
+   "new": "with angle-bracket notation",
+   "why": "Compound modifier before a noun takes a hyphen."
+  },
+  {
+   "id": "type-class-two-words",
+   "cat": "usage/house-style",
+   "old": "instances of that typeclass inherit the notation.",
+   "new": "instances of that type class inherit the notation.",
+   "why": "House style is \"type class\" (STYLE-WRITING.md); the surrounding paragraph already writes it as two words."
+  },
+  {
+   "id": "check-whether",
+   "cat": "usage/whether-vs-if",
+   "old": "compute both sides of the equality and check if they are the same.",
+   "new": "compute both sides of the equality and check whether they are the same.",
+   "why": "\"Whether\" for an alternative; \"if\" reads as a condition."
+  },
+  {
+   "id": "qed-1",
+   "cat": "usage/qed-caps",
+   "old": "which is immediate from the induction hypothesis.  _Qed_.",
+   "new": "which is immediate from the induction hypothesis.  _QED_.",
+   "why": "STYLE-WRITING.md and the Induction chapter close informal proofs with _QED_."
+  },
+  {
+   "id": "qed-2",
+   "cat": "usage/qed-caps",
+   "old": "This follows directly from the definitions of `length` and `++`\ntogether with the induction hypothesis.  _Qed_.",
+   "new": "This follows directly from the definitions of `length` and `++`\ntogether with the induction hypothesis.  _QED_.",
+   "why": "STYLE-WRITING.md and the Induction chapter close informal proofs with _QED_."
+  },
+  {
+   "id": "theorem-spacing-and-bullet-indent",
+   "cat": "formatting/whitespace",
+   "old": "_Theorem_: For all lists `l`,  `l.reverse.length = l.length`.\n\n_Proof_: By induction on `l`.\n\n  - First, suppose `l = []`.",
+   "new": "_Theorem_: For all lists `l`, `l.reverse.length = l.length`.\n\n_Proof_: By induction on `l`.\n\n- First, suppose `l = []`.",
+   "why": "Stray double space after the comma, and this bullet is indented two spaces while its sibling \"- Next,\" is not."
+  },
+  {
+   "id": "qed-3",
+   "cat": "usage/qed-caps",
+   "old": "definition of `length`.  _Qed_.",
+   "new": "definition of `length`.  _QED_.",
+   "why": "STYLE-WRITING.md and the Induction chapter close informal proofs with _QED_."
+  },
+  {
+   "id": "compressed-proof-indent",
+   "cat": "formatting/indentation",
+   "old": "_Proof_: First observe, by a straightforward induction on `l`,\n that `(l ++ [n]).length = .succ l.length` for any `l`.  The main\n property then follows by another induction on `l`, using the\n observation together with the induction hypothesis in the case\n where `l = n' :: l'`. _Qed_.",
+   "new": "_Proof_: First observe, by a straightforward induction on `l`,\nthat `(l ++ [n]).length = .succ l.length` for any `l`.  The main\nproperty then follows by another induction on `l`, using the\nobservation together with the induction hypothesis in the case\nwhere `l = n' :: l'`. _QED_.",
+   "why": "Continuation lines carry a stray one-space indent; also the fourth _Qed_ (same block, so it rides along here)."
+  },
+  {
+   "id": "dsainati-author-parens",
+   "cat": "markup/dev-author",
+   "old": "::::dev \"Daniel Sainati @dsainati\" PotentialImprovement",
+   "new": "::::dev \"Daniel Sainati (dsainati)\" PotentialImprovement",
+   "why": "Author strings are \"Full Name (github-handle)\"; every other note in the chapter uses parentheses."
+  },
+  {
+   "id": "reuse-unhyphenated",
+   "cat": "hyphenation/re-prefix",
+   "old": "Instead, re-use the same proof technique",
+   "new": "Instead, reuse the same proof technique",
+   "why": "\"reuse\" is unhyphenated in Chicago and elsewhere in the book (Basics, Typeclasses)."
+  },
+  {
+   "id": "quiz2-double-space",
+   "cat": "formatting/code-spacing",
+   "old": "theorem quiz2  (d : PartialMap)",
+   "new": "theorem quiz2 (d : PartialMap)",
+   "why": "Stray double space between the theorem name and its first binder."
+  }
+ ],
+ "completed": true
+}

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# This file is maintained by Claude (AI-generated).
+#
+# Refuse a commit while a proofreading round is applied but not yet recorded:
+# committing then would bake in the author's reverts and lose the rejections
+# that should have gone to proofread/ledger.jsonl.  See PROOFREADING.md.
+#
+# Install (once, per clone):   git config core.hooksPath scripts/hooks
+# Bypass a single commit:      git commit --no-verify
+
+exec python3 "$(git rev-parse --show-toplevel)/scripts/proofread.py" check

--- a/scripts/proofread.py
+++ b/scripts/proofread.py
@@ -1,37 +1,37 @@
 #!/usr/bin/env python3
 # This file is maintained by Claude (AI-generated).
 """
-proofread.py  —  Drives a low-level proofreading pass over a chapter.
+proofread.py  —  Mechanism for a low-level proofreading pass over a chapter.
 
-Claude writes a *round* — a JSON file of anchored edits under proofread/rounds/
-— and leaves it there. Doing the pass is one command with no arguments:
+The pass is driven from a Claude session — `/proofread <Chapter>` — and Claude
+issues these three commands in turn:
 
-    python3 scripts/proofread.py
+  start [CHAPTER]      name the chapter source and the round file to write
+  apply [ROUND]        apply a written round and open its diff for review
+  record [ROUND]       record what the author kept, after the review
 
-Run it with nothing waiting and it starts Claude on a chapter for you, then
-picks up the round Claude writes; leave Claude and the pass carries on.
+Between `apply` and `record` the author reverts the edits they don't want, in
+the chapter itself — one click per hunk in the Source Control gutter. That
+review is a human gesture nothing can observe, which is why the phases are
+separate commands. proofread/state.json remembers which round is in flight, so
+`record` can come minutes or days later, from a different session.
 
-It asks which chapter to proofread (skipping the question when only one round
-is waiting), makes every proposed edit, opens a diff of just those edits in VS
-Code, and waits. You revert the ones you don't want, press return, and it
-records your rejections and reports any pattern worth a house rule.
+You can also do a pass by hand: run with no arguments in a terminal and it
+applies the waiting round, waits at a prompt while you review, and records when
+you press return. Ctrl-C stops without recording; run it again to resume.
 
-Stop at any point with Ctrl-C; run it again and it picks up where it left off.
-The round file is never something you have to open. See PROOFREADING.md.
+OTHER COMMANDS
+  undo                 reverse the applied round and forget it
+  status               what is in flight
+  check                exit non-zero while a round is applied but unrecorded
+  ledger [--cat C]     list recorded rejections
+  patterns [--min N]   rejection categories that have earned a house rule
 
 Rejections land in proofread/ledger.jsonl, keyed by a whitespace-normalized
 hash of the (old, new) pair. A later round that proposes the same edit again —
 in this chapter or any other — is silently dropped before you ever see it.
 
-OTHER COMMANDS
-  propose [CHAPTER]    have Claude write a round now, then run it
-  undo                 reverse the applied round and forget it
-  status               what is in flight
-  ledger [--cat C]     list recorded rejections
-  patterns [--min N]   rejection categories that have earned a house rule
-
-Run non-interactively (a pipe, CI) and it falls back to two invocations: the
-first applies and writes the diff, the second reconciles.
+The round file is never something the author has to open. See PROOFREADING.md.
 """
 
 import argparse
@@ -195,7 +195,12 @@ def choose_round():
               f"edit{'' if live == 1 else 's'} to {round_['file']}")
         return path
     if not interactive():
-        sys.exit("several rounds are waiting; run this from a terminal to choose")
+        print("Several rounds are waiting — name the one to apply:")
+        for path, round_, live in rounds:
+            print(f"  proofread.py apply {os.path.basename(path)}"
+                  f"   {C_DIM}({round_['file']}, {live} edit"
+                  f"{'' if live == 1 else 's'}){C_OFF}")
+        sys.exit(1)
     print(f"{C_BLD}Which chapter?{C_OFF}")
     for i, (_, round_, live) in enumerate(rounds, 1):
         print(f"  {i}. {round_['file']}  {C_DIM}({round_label(round_)}, "
@@ -213,7 +218,50 @@ def choose_round():
 
 
 # --------------------------------------------------------------------------
-# asking Claude for a round
+# a clean tree
+# --------------------------------------------------------------------------
+def dirty_paths():
+    """Uncommitted changes, ignoring the proofreading machinery's own files —
+    a round is written into proofread/rounds/ before anything can be applied."""
+    r = subprocess.run(["git", "status", "--porcelain"], cwd=ROOT,
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        return []
+    paths = set()
+    for line in r.stdout.splitlines():
+        path = line[3:]
+        if " -> " in path:                      # a rename: the new name matters
+            path = path.split(" -> ", 1)[1]
+        path = path.strip().strip('"')
+        if path and not path.startswith("proofread/"):
+            paths.add(path)
+    return sorted(paths)
+
+
+def require_clean_tree(allow_dirty=False):
+    """A pass starts from a clean tree: the round's edits are then the only
+    thing in the chapter, so reverting a hunk is unambiguous and `undo` is
+    exact. Nothing else in the pass can tell the author's work from ours."""
+    paths = dirty_paths()
+    if not paths:
+        return
+    if allow_dirty:
+        print(f"{C_YEL}working tree is dirty ({len(paths)} path"
+              f"{'' if len(paths) == 1 else 's'}) — proceeding anyway{C_OFF}")
+        return
+    print(f"{C_RED}The working tree has uncommitted changes.{C_OFF} A "
+          f"proofreading pass starts from a\nclean branch, so that the round's "
+          f"edits are the only thing in the chapter:")
+    for path in paths[:10]:
+        print(f"  {path}")
+    if len(paths) > 10:
+        print(f"  {C_DIM}… and {len(paths) - 10} more{C_OFF}")
+    sys.exit(f"\nCommit or stash them and start again "
+             f"{C_DIM}(--allow-dirty overrides){C_OFF}")
+
+
+# --------------------------------------------------------------------------
+# chapters and round files
 # --------------------------------------------------------------------------
 def volumes():
     """Directories holding chapter sources — one per Targets<Vol>.lean."""
@@ -244,28 +292,6 @@ def find_chapter(name):
     return hits[0] if len(hits) == 1 else None
 
 
-def ask_chapter():
-    sources = chapter_sources()
-    if not sources:
-        return None
-    default = sources[0]
-    print(f"{C_BLD}Which chapter should Claude proofread?{C_OFF} "
-          f"{C_DIM}(return for {default}, Ctrl-C to stop){C_OFF}")
-    while True:
-        try:
-            answer = input("chapter: ").strip()
-        except (KeyboardInterrupt, EOFError):
-            print()
-            return None
-        if not answer:
-            return default
-        found = find_chapter(answer)
-        if found:
-            return found
-        print("no such chapter — give a path or a chapter name, e.g. "
-              f"{os.path.basename(default)[:-len('.lean')]}")
-
-
 def next_round_path(source):
     chapter = os.path.basename(source)[:-len(".lean")]
     used = [int(m.group(1))
@@ -273,53 +299,6 @@ def next_round_path(source):
                       for path in glob.glob(os.path.join(ROUNDS, f"{chapter}-r*.json")))
             if m]
     return os.path.join(ROUNDS, f"{chapter}-r{max(used, default=0) + 1:02d}.json")
-
-
-def proofread_prompt(source, dest):
-    return (
-        f"Proofread {source}.\n\n"
-        f"Read PROOFREADING.md in full first — its 'Writing a round' section, "
-        f"the house rules, and the known non-issues — and read the recorded "
-        f"rejections with `python3 scripts/proofread.py ledger`. Nothing already "
-        f"declined or covered by a house rule may be proposed again.\n\n"
-        f"Then write the round to {rel(dest)}: "
-        f'{{"file", "chapter", "round", "proposals": [{{"id", "cat", "old", '
-        f'"new", "why"}}]}}, anchored exactly as that section requires.\n\n'
-        f"Do not edit {source} yourself and do not run scripts/proofread.py "
-        f"other than its ledger and patterns commands — the author applies the "
-        f"round. Write the round file, say briefly what is in it, and stop.")
-
-
-def solicit_round(chapter=None):
-    """Nothing is waiting: start Claude on a chapter, then pick up what it writes."""
-    claude = shutil.which("claude")
-    if claude is None or not interactive():
-        print("No rounds are waiting. Ask Claude to proofread a chapter — it "
-              "writes one into proofread/rounds/ and this command picks it up.")
-        return None
-    source = chapter or ask_chapter()
-    if source is None:
-        return None
-    dest = next_round_path(source)
-    before = {path for path, _, _ in available_rounds()}
-    print(f"\nStarting Claude on {C_BLD}{source}{C_OFF} — it writes "
-          f"{rel(dest)}.\n{C_DIM}Leave Claude (/exit, or Ctrl-D) when the round "
-          f"is written and this command carries on with it.{C_OFF}\n")
-    try:
-        subprocess.run([claude, proofread_prompt(source, dest)], cwd=ROOT)
-    except (OSError, subprocess.SubprocessError) as e:
-        print(f"{C_RED}could not run claude: {e}{C_OFF}")
-        return None
-    fresh = [r for r in available_rounds() if r[0] not in before]
-    if not fresh:
-        print(f"\n{C_YEL}No new round in {rel(ROUNDS)} — nothing to apply.{C_OFF}")
-        return None
-    if len(fresh) == 1:
-        path, round_, live = fresh[0]
-        print(f"\n{C_BLD}{round_label(round_)}{C_OFF} — {live} proposed "
-              f"edit{'' if live == 1 else 's'} to {round_['file']}")
-        return path
-    return choose_round()
 
 
 # --------------------------------------------------------------------------
@@ -455,18 +434,22 @@ def do_apply(round_path, round_):
 # --------------------------------------------------------------------------
 # reviewing and reconciling
 # --------------------------------------------------------------------------
-def wait_for_review(round_, dest):
-    """Open the diff and the chapter, then block until the author is done."""
+def announce_review(round_, dest):
+    """Put the diff and the chapter in front of the author and say what to do."""
     opened = open_in_editor(os.path.join(ROOT, round_["file"]), dest)
     print()
     if opened:
         print(f"Opened {C_BLD}{rel(dest)}{C_OFF} and {round_['file']} in VS Code.")
     else:
-        print(f"Read {C_BLD}{rel(dest)}{C_OFF} — just this round's edits, "
-              f"nothing else pending.\n"
+        print(f"Read {C_BLD}{rel(dest)}{C_OFF} — just this round's edits.\n"
               f"  {C_DIM}code {rel(dest)} {round_['file']}{C_OFF}")
     print(f"Revert the edits you don't want, in {round_['file']} — one click per "
           f"hunk\nin the Source Control gutter.")
+
+
+def wait_for_review(round_, dest):
+    """Show the review, then block until the author is done."""
+    announce_review(round_, dest)
     try:
         input(f"\n{C_BLD}Press return when you're done{C_OFF} "
               f"{C_DIM}(Ctrl-C to stop and resume later){C_OFF} ")
@@ -532,14 +515,115 @@ def do_reconcile(round_path, round_):
 
 
 # --------------------------------------------------------------------------
-# the bare command
+# the commands Claude drives
 # --------------------------------------------------------------------------
+def resolve_round(name=None):
+    """The round to act on: one named explicitly, the one in flight, or the
+    single one waiting."""
+    if name:
+        for cand in (name, os.path.join(ROOT, name), os.path.join(ROUNDS, name),
+                     os.path.join(ROUNDS, name + ".json")):
+            if os.path.isfile(cand):
+                return cand
+        sys.exit(f"no such round: {name}")
+    state = load_state()
+    if state is not None:
+        return os.path.join(ROOT, state["round"])
+    return choose_round()
+
+
+def no_rounds():
+    print("No rounds are waiting. Ask Claude for one — `/proofread <Chapter>` "
+          "in a Claude\nsession writes a round into proofread/rounds/ and "
+          "carries the pass through.")
+    return 1
+
+
+def cmd_start(args):
+    """Say which chapter to proofread and where its round file goes. Nothing
+    here reads or touches the chapter — the proofreading itself is Claude's."""
+    state = load_state()
+    if state is not None:
+        round_ = load_round(os.path.join(ROOT, state["round"]))
+        sys.exit(f"{round_label(round_)} is already in flight — finish it with "
+                 f"`proofread.py record`, or drop it with `proofread.py undo`")
+    require_clean_tree(getattr(args, "allow_dirty", False))
+    sources = chapter_sources()
+    if not sources:
+        sys.exit("no chapter sources found")
+    if args.chapter:
+        source = find_chapter(args.chapter)
+        if source is None:
+            sys.exit(f"no such chapter: {args.chapter}")
+    else:
+        source = sources[0]          # the one edited most recently
+    dest = next_round_path(source)
+    print(f"source: {source}")
+    print(f"round:  {rel(dest)}")
+    waiting = [round_ for _, round_, _ in available_rounds()]
+    if waiting:
+        print(f"{C_YEL}note{C_OFF}: unfinished round"
+              f"{'' if len(waiting) == 1 else 's'} already waiting — "
+              + ", ".join(round_label(r) for r in waiting))
+    return 0
+
+
+def cmd_apply(args):
+    """Phase one: make the proposed edits and put the diff in front of the author."""
+    state = load_state()
+    if state is not None and state.get("phase") == "applied":
+        round_path = os.path.join(ROOT, state["round"])
+        round_ = load_round(round_path)
+        print(f"{C_BLD}{round_label(round_)}{C_OFF} is already applied to "
+              f"{round_['file']} — nothing re-applied.")
+        announce_review(round_, diff_path(round_path))
+        return 0
+    require_clean_tree(getattr(args, "allow_dirty", False))
+    round_path = resolve_round(args.round)
+    if round_path is None:
+        return no_rounds()
+    round_ = load_round(round_path)
+    dest = do_apply(round_path, round_)
+    announce_review(round_, dest)
+    print(f"\nWhen the author is done reviewing: "
+          f"{C_BLD}python3 scripts/proofread.py record{C_OFF}")
+    return 0
+
+
+def cmd_record(args):
+    """Phase two: read the chapter back and record what survived."""
+    state = load_state()
+    if state is None or state.get("phase") != "applied":
+        sys.exit("no round is applied — run `proofread.py apply` first")
+    round_path = os.path.join(ROOT, state["round"])
+    if args.round:
+        named = resolve_round(args.round)
+        if os.path.abspath(named) != os.path.abspath(round_path):
+            sys.exit(f"{rel(round_path)} is the round in flight, not {rel(named)}")
+    return do_reconcile(round_path, load_round(round_path))
+
+
+def cmd_check(args):
+    """Guard for a pre-commit hook: a round must not be committed unrecorded."""
+    state = load_state()
+    if state is None or state.get("phase") != "applied":
+        return 0
+    round_ = load_round(os.path.join(ROOT, state["round"]))
+    print(f"{C_RED}{round_label(round_)} is applied to {round_['file']} but not "
+          f"recorded.{C_OFF}\n"
+          f"  Committing now would lose the rejections from this round.\n"
+          f"  Finish the review, then: python3 scripts/proofread.py record\n"
+          f"  Or drop the round:       python3 scripts/proofread.py undo\n"
+          f"  {C_DIM}(git commit --no-verify commits anyway){C_OFF}")
+    return 1
+
+
 def cmd_run(args):
+    """The whole pass by hand, in a terminal, with no Claude session."""
     state = load_state()
 
     if state is not None and state.get("phase") == "applied":
-        # A pass was interrupted mid-review, or this is the second of two
-        # non-interactive invocations.
+        # A pass was interrupted mid-review, or Claude applied the round.
         round_path = os.path.join(ROOT, state["round"])
         round_ = load_round(round_path)
         print(f"{C_BLD}{round_label(round_)}{C_OFF} — edits are already applied "
@@ -548,11 +632,10 @@ def cmd_run(args):
             return 1
         return do_reconcile(round_path, round_)
 
-    round_path = state and os.path.join(ROOT, state["round"]) or choose_round()
+    require_clean_tree(getattr(args, "allow_dirty", False))
+    round_path = resolve_round()
     if round_path is None:
-        round_path = solicit_round()
-    if round_path is None:
-        return 1
+        return no_rounds()
     return run_round(round_path)
 
 
@@ -565,25 +648,11 @@ def run_round(round_path):
         print(f"\n{C_BLD}Next{C_OFF}\n"
               f"  1. Read {rel(dest)}.\n"
               f"  2. Revert the edits you don't want, in {round_['file']}.\n"
-              f"  3. Run this command again to save your choices.")
+              f"  3. Run `proofread.py record` to save your choices.")
         return 0
     if not wait_for_review(round_, dest):
         return 1
     return do_reconcile(round_path, round_)
-
-
-def cmd_propose(args):
-    if load_state() is not None:
-        sys.exit("a round is already in flight; finish it or `proofread.py undo`")
-    source = None
-    if args.chapter:
-        source = find_chapter(args.chapter)
-        if source is None:
-            sys.exit(f"no such chapter: {args.chapter}")
-    round_path = solicit_round(source)
-    if round_path is None:
-        return 1
-    return run_round(round_path)
 
 
 def cmd_undo(args):
@@ -633,7 +702,8 @@ def cmd_status(args):
         if phase == "applied":
             print(f"  edits are in {round_['file']}; "
                   f"diff at {rel(diff_path(round_path))}")
-        print("  run `python3 scripts/proofread.py` to carry on")
+        print("  the author reviews it; then `proofread.py record` saves their "
+              "choices")
     n = len(load_ledger())
     print(f"\n{n} declined edit{'' if n == 1 else 's'} on record")
     return 0
@@ -678,14 +748,37 @@ def cmd_patterns(args):
 
 def main():
     ap = argparse.ArgumentParser(
-        description="Proofread a chapter. With no arguments, runs the whole "
-                    "pass: pick a chapter, apply the proposed edits, review "
-                    "them, save your choices.")
+        description="Mechanism for a proofreading pass over a chapter, driven "
+                    "from a Claude session (`/proofread <Chapter>`). With no "
+                    "arguments, runs the whole pass by hand in a terminal: "
+                    "apply the proposed edits, review them, save your choices.")
+    # SUPPRESS so that a subcommand's copy of the flag does not overwrite the
+    # top-level one with its own default.
+    dirty = argparse.ArgumentParser(add_help=False)
+    dirty.add_argument("--allow-dirty", action="store_true",
+                       default=argparse.SUPPRESS,
+                       help="run even with uncommitted changes in the tree")
+    ap.add_argument("--allow-dirty", action="store_true",
+                    default=argparse.SUPPRESS,
+                    help="run even with uncommitted changes in the tree")
     sub = ap.add_subparsers(dest="cmd")
 
-    p = sub.add_parser("propose", help="have Claude write a round now, then run it")
+    p = sub.add_parser("start", parents=[dirty],
+                       help="name the chapter and the round file to write")
     p.add_argument("chapter", nargs="?", help="chapter source path or name")
-    p.set_defaults(func=cmd_propose)
+    p.set_defaults(func=cmd_start)
+
+    p = sub.add_parser("apply", parents=[dirty],
+                       help="apply a written round and open its diff")
+    p.add_argument("round", nargs="?", help="round file (default: the one waiting)")
+    p.set_defaults(func=cmd_apply)
+
+    p = sub.add_parser("record", help="record what the author kept, after review")
+    p.add_argument("round", nargs="?", help="round file (default: the one in flight)")
+    p.set_defaults(func=cmd_record)
+
+    p = sub.add_parser("check", help="fail while a round is applied but unrecorded")
+    p.set_defaults(func=cmd_check)
 
     p = sub.add_parser("undo", help="revert the applied round and forget it")
     p.set_defaults(func=cmd_undo)

--- a/scripts/proofread.py
+++ b/scripts/proofread.py
@@ -43,7 +43,6 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ROUNDS = os.path.join(ROOT, "proofread", "rounds")
@@ -349,33 +348,54 @@ def diff_path(round_path):
     return re.sub(r"\.json$", "", round_path) + ".diff"
 
 
-def write_isolated_diff(round_path, round_, applied, after):
-    """A diff of just this round's edits, free of any other pending changes."""
+def before_path(round_path, round_):
+    """The chapter as it was before the round — the left pane of the review.
+    It keeps the chapter's extension so the diff is syntax-highlighted."""
+    ext = os.path.splitext(round_["file"])[1]
+    return re.sub(r"\.json$", "", round_path) + ".before" + ext
+
+
+def write_before(round_path, round_, applied, after):
+    """Reconstruct and keep the pre-round text; the review diffs against it."""
     before = after
     for p in applied:
         before = before.replace(p["new"], p["old"], 1)
+    dest = before_path(round_path, round_)
+    if os.path.exists(dest):
+        os.remove(dest)
+    with open(dest, "w") as f:
+        f.write(before)
+    os.chmod(dest, 0o444)        # read-only: only the right pane is the chapter
+    return dest
+
+
+def write_isolated_diff(round_path, round_, before):
+    """A unified diff of just this round's edits, as a record of what was
+    proposed — it stays readable after the author starts reverting hunks."""
     dest = diff_path(round_path)
-    with tempfile.NamedTemporaryFile("w", suffix=".before", delete=False) as tmp:
-        tmp.write(before)
-        tmp_name = tmp.name
-    try:
-        out = subprocess.run(
-            ["diff", "-u", "-U", "2",
-             "--label", round_["file"] + " (before this round)",
-             "--label", round_["file"],
-             tmp_name, os.path.join(ROOT, round_["file"])],
-            capture_output=True, text=True).stdout
-    finally:
-        os.remove(tmp_name)
+    out = subprocess.run(
+        ["diff", "-u", "-U", "2",
+         "--label", round_["file"] + " (before this round)",
+         "--label", round_["file"],
+         before, os.path.join(ROOT, round_["file"])],
+        capture_output=True, text=True).stdout
     with open(dest, "w") as f:
         f.write(out)
     return dest
 
 
-def open_in_editor(*paths):
-    """Open files in the surrounding VS Code window; report whether it worked."""
+def discard_before(round_path, round_):
+    """Drop the snapshot once the round is recorded or undone."""
+    path = before_path(round_path, round_)
+    if os.path.exists(path):
+        os.chmod(path, 0o644)
+        os.remove(path)
+
+
+def open_in_editor(*args):
+    """Run `code` in the surrounding window; report whether it worked."""
     try:
-        r = subprocess.run(["code", "--reuse-window", *paths],
+        r = subprocess.run(["code", "--reuse-window", *args],
                            capture_output=True, text=True, timeout=20)
         return r.returncode == 0
     except (FileNotFoundError, subprocess.SubprocessError):
@@ -410,7 +430,8 @@ def do_apply(round_path, round_):
     with open(path, "w") as f:
         f.write(text)
 
-    dest = write_isolated_diff(round_path, round_, applied, text)
+    before = write_before(round_path, round_, applied, text)
+    dest = write_isolated_diff(round_path, round_, before)
     save_state({"round": rel(round_path), "phase": "applied"})
 
     print(f"\n{C_GRN}{len(applied)} edit{'' if len(applied) == 1 else 's'} "
@@ -434,22 +455,44 @@ def do_apply(round_path, round_):
 # --------------------------------------------------------------------------
 # reviewing and reconciling
 # --------------------------------------------------------------------------
-def announce_review(round_, dest):
-    """Put the diff and the chapter in front of the author and say what to do."""
-    opened = open_in_editor(os.path.join(ROOT, round_["file"]), dest)
+def announce_review(round_path, round_, mode="diff"):
+    """Put the review in front of the author and say what to do with it.
+
+    Default is a real side-by-side diff editor — `code --diff` against the
+    snapshot — because that lands on the two versions in one step, with no
+    dependence on which source-control extension the author uses. `files`
+    opens the chapter and the unified diff as plain tabs instead."""
+    chapter = os.path.join(ROOT, round_["file"])
+    before, dest = before_path(round_path, round_), diff_path(round_path)
+    opened = False
+    if mode == "diff":
+        opened = open_in_editor("--diff", before, chapter)
+    elif mode == "files":
+        opened = open_in_editor(chapter, dest)
+
     print()
-    if opened:
-        print(f"Opened {C_BLD}{rel(dest)}{C_OFF} and {round_['file']} in VS Code.")
+    if opened and mode == "diff":
+        print(f"Opened a side-by-side diff in VS Code: "
+              f"{C_BLD}{os.path.basename(before)}{C_OFF} on the left — the "
+              f"chapter as it\nwas before the round — and the live "
+              f"{C_BLD}{round_['file']}{C_OFF} on the right.")
+    elif opened:
+        print(f"Opened {C_BLD}{round_['file']}{C_OFF} and {rel(dest)} in VS Code.")
     else:
-        print(f"Read {C_BLD}{rel(dest)}{C_OFF} — just this round's edits.\n"
-              f"  {C_DIM}code {rel(dest)} {round_['file']}{C_OFF}")
-    print(f"Revert the edits you don't want, in {round_['file']} — one click per "
-          f"hunk\nin the Source Control gutter.")
+        print(f"Open the review with:\n"
+              f"  {C_DIM}code --diff {rel(before)} {round_['file']}{C_OFF}")
+    print(f"\nRevert what you don't want in the {C_BLD}right-hand pane{C_OFF} — "
+          f"hover a change and click\nthe arrow in the gutter between the panes, "
+          f"or just edit the text. The left pane\nis a read-only snapshot; "
+          f"whatever you leave standing on the right is accepted.")
+    print(f"{C_DIM}Other ways in: the Source Control view — the tree was clean "
+          f"before the round, so\neverything it lists is this round — or "
+          f"{rel(dest)} for the proposals as a list.{C_OFF}")
 
 
-def wait_for_review(round_, dest):
+def wait_for_review(round_path, round_, mode="diff"):
     """Show the review, then block until the author is done."""
-    announce_review(round_, dest)
+    announce_review(round_path, round_, mode)
     try:
         input(f"\n{C_BLD}Press return when you're done{C_OFF} "
               f"{C_DIM}(Ctrl-C to stop and resume later){C_OFF} ")
@@ -483,6 +526,7 @@ def do_reconcile(round_path, round_):
     if rejected:
         record_rejections(rejected, round_)
     clear_state()
+    discard_before(round_path, round_)
     mark_completed(round_path)
 
     print(f"\n{C_BLD}{round_label(round_)}{C_OFF} — "
@@ -576,15 +620,15 @@ def cmd_apply(args):
         round_ = load_round(round_path)
         print(f"{C_BLD}{round_label(round_)}{C_OFF} is already applied to "
               f"{round_['file']} — nothing re-applied.")
-        announce_review(round_, diff_path(round_path))
+        announce_review(round_path, round_, getattr(args, "open", "diff"))
         return 0
     require_clean_tree(getattr(args, "allow_dirty", False))
     round_path = resolve_round(args.round)
     if round_path is None:
         return no_rounds()
     round_ = load_round(round_path)
-    dest = do_apply(round_path, round_)
-    announce_review(round_, dest)
+    do_apply(round_path, round_)
+    announce_review(round_path, round_, getattr(args, "open", "diff"))
     print(f"\nWhen the author is done reviewing: "
           f"{C_BLD}python3 scripts/proofread.py record{C_OFF}")
     return 0
@@ -628,7 +672,8 @@ def cmd_run(args):
         round_ = load_round(round_path)
         print(f"{C_BLD}{round_label(round_)}{C_OFF} — edits are already applied "
               f"to {round_['file']}")
-        if interactive() and not wait_for_review(round_, diff_path(round_path)):
+        if interactive() and not wait_for_review(round_path, round_,
+                                                 getattr(args, "open", "diff")):
             return 1
         return do_reconcile(round_path, round_)
 
@@ -636,10 +681,10 @@ def cmd_run(args):
     round_path = resolve_round()
     if round_path is None:
         return no_rounds()
-    return run_round(round_path)
+    return run_round(round_path, getattr(args, "open", "diff"))
 
 
-def run_round(round_path):
+def run_round(round_path, mode="diff"):
     """Apply a chosen round, hand it to the author, record what they kept."""
     round_ = load_round(round_path)
     dest = do_apply(round_path, round_)
@@ -650,7 +695,7 @@ def run_round(round_path):
               f"  2. Revert the edits you don't want, in {round_['file']}.\n"
               f"  3. Run `proofread.py record` to save your choices.")
         return 0
-    if not wait_for_review(round_, dest):
+    if not wait_for_review(round_path, round_, mode):
         return 1
     return do_reconcile(round_path, round_)
 
@@ -676,6 +721,7 @@ def cmd_undo(args):
     with open(path, "w") as f:
         f.write(text)
     clear_state()
+    discard_before(round_path, round_)
     print(f"reverted {n} edit{'' if n == 1 else 's'} in {round_['file']}; "
           f"{round_label(round_)} left for another day")
     print(f"{C_DIM}nothing was written to the ledger{C_OFF}")
@@ -761,6 +807,14 @@ def main():
     ap.add_argument("--allow-dirty", action="store_true",
                     default=argparse.SUPPRESS,
                     help="run even with uncommitted changes in the tree")
+    opener = argparse.ArgumentParser(add_help=False)
+    opener.add_argument("--open", choices=("diff", "files", "none"),
+                        default=argparse.SUPPRESS,
+                        help="how to show the review: a side-by-side diff "
+                             "editor (default), the chapter and the unified "
+                             "diff as plain tabs, or nothing")
+    ap.add_argument("--open", choices=("diff", "files", "none"),
+                    default=argparse.SUPPRESS, help=argparse.SUPPRESS)
     sub = ap.add_subparsers(dest="cmd")
 
     p = sub.add_parser("start", parents=[dirty],
@@ -768,7 +822,7 @@ def main():
     p.add_argument("chapter", nargs="?", help="chapter source path or name")
     p.set_defaults(func=cmd_start)
 
-    p = sub.add_parser("apply", parents=[dirty],
+    p = sub.add_parser("apply", parents=[dirty, opener],
                        help="apply a written round and open its diff")
     p.add_argument("round", nargs="?", help="round file (default: the one waiting)")
     p.set_defaults(func=cmd_apply)


### PR DESCRIPTION
- Fixes to variable names (stale names in text)
- Formatting improvements in code
- Dropped useless text on writing ALPHA explicitly in a declaration without `: Type` (which we will never do, and already covered was possible for normal types early on).
- Improved presentation of implicit arguments and synthesis

Didn't get all the way through.