### PR TITLE
Speed up CI by staging building and grading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
 # Continuous integration for Software Foundations in Lean.
 #
 # WHAT THIS DOES
-#   On every pull request, and on every push to `main`, it builds the book and
-#   then runs `make`, which regenerates the extracted `_out/<variant>/lean`
-#   projects and compiles each one. If anything fails to compile the check turns
-#   red; with branch protection enabled (see README.md) a red check blocks
-#   merging, so `main` always builds.
+#   On every pull request, and on every push to `main`, it builds the book,
+#   generates the extracted `_out/<variant>/lean` projects, and then checks
+#   grading in a dependent job. If anything fails to compile the check turns red;
+#   with branch protection enabled (see README.md) a red check blocks merging, so
+#   `main` always builds.
 #
 # RUN THE SAME CHECK LOCALLY
-#   make              # build the book, regenerate _out, and compile it
+#   make grading-check # build the book, regenerate _out, and check grading
 #
 # MAINTAINING THIS FILE
 #   It is deliberately tiny. To add a check, add another step below.
@@ -21,6 +21,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,27 +36,72 @@ jobs:
       # caching) and run `lake build`, which builds the book.
       - uses: leanprover/lean-action@v1
 
+      # Restore only generated-project dependencies. Generated sources and build
+      # outputs remain fresh for every CI run.
+      - name: Restore generated project dependencies
+        id: generated-packages
+        uses: actions/cache/restore@v6
+        with:
+          path: _out/*/*/lean/.lake/packages
+          key: generated-packages-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+
       # Regenerate the extracted `_out/<variant>/lean` projects and compile each
       # one. The `make` targets run the `lf_*` executables, which write the
       # extracted Lean sources and then `lake build` them; a compile failure in
       # any variant turns the executable's exit code (and so this step) red.
-      - run: make
-      # Test that autograding solutions passes and that autograding student results only in "illegal axiom" failures
-      - run: make grading-check
-      # Upload the build artifact to CI
+      - run: make all
+
+      - name: Save generated project dependencies
+        if: ${{ success() && steps.generated-packages.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: _out/*/*/lean/.lake/packages
+          key: ${{ steps.generated-packages.outputs.cache-primary-key }}
+
+      # Upload public generated outputs without grading projects or Lake state.
       - name: Upload generated outputs
         uses: actions/upload-artifact@v7
         if: ${{ success() }}
         with:
           name: sfl-out
-          path: _out/
+          path: |
+            _out/
+            !_out/*/grading/**
+            !_out/**/.lake/**
           if-no-files-found: error
           retention-days: 7
-      
-    # When several commits are pushed to the same PR in quick succession, cancel the
-    # in-progress run for the older commit so runners aren't wasted and the latest
-    # result arrives sooner. Only cancel for pull requests: never interrupt a `main`
-    # push build, which must always complete so `main`'s status stays accurate.
-    concurrency:
-        group: ci-${{ github.workflow }}-${{ github.ref }}
-        cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+      # Supply grading only the generated source/configuration trees it reads.
+      - name: Upload grading inputs
+        uses: actions/upload-artifact@v7
+        if: ${{ success() }}
+        with:
+          name: grading-inputs
+          path: |
+            _out/*/{grading,student,solutions}/lean/**
+            !_out/**/.lake/**
+          if-no-files-found: error
+          retention-days: 1
+
+  grading:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # The first wildcard in the uploaded path omits `_out`, so restore there.
+      - name: Download grading inputs
+        uses: actions/download-artifact@v8
+        with:
+          name: grading-inputs
+          path: _out
+
+      # Set up the root Lean environment without another root build or cache.
+      - uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          use-github-cache: false
+
+      - run: make grading-tools
+      - run: make grading-check-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
         with:
           name: grading-inputs
           path: |
-            _out/*/{grading,student,solutions}/lean/**
+            _out/*/grading/lean/**
+            _out/*/student/lean/**
+            _out/*/solutions/lean/**
             !_out/**/.lake/**
           if-no-files-found: error
           retention-days: 1

--- a/Makefile
+++ b/Makefile
@@ -15,27 +15,23 @@ default: all
 # ── Volume target template ────────────────────────────────────────────────────
 # Usage: $(eval $(call VOLUME_template,slug))
 #   slug   lowercase short name used in make targets and CLI args, e.g. lf
-#          Each volume has its own executable, called as: lake exe sfl-<slug> <mode>
+#          Each volume has its own executable, called as:
+#          lake env .lake/build/bin/sfl-<slug> <mode>
 define VOLUME_template
 
-.PHONY: $(1) $(1)-build $(1)-student $(1)-solutions $(1)-terse
+.PHONY: $(1) $(1)-student $(1)-solutions $(1)-terse $(1)-grading
 
-# Build this volume's executable before running any variant.  Lake detects
-# nothing changed on subsequent calls and skips quickly.
-$(1)-build: ensure-build-symlink
-	lake build sfl-$(1)
+$(1)-student: book-build
+	lake env .lake/build/bin/sfl-$(1) student
 
-$(1)-student: $(1)-build
-	lake exe sfl-$(1) student
+$(1)-solutions: book-build
+	lake env .lake/build/bin/sfl-$(1) solutions
 
-$(1)-solutions: $(1)-build
-	lake exe sfl-$(1) solutions
+$(1)-terse: book-build
+	lake env .lake/build/bin/sfl-$(1) terse
 
-$(1)-terse: $(1)-build
-	lake exe sfl-$(1) terse
-
-$(1)-grading: $(1)-build
-	lake exe sfl-$(1) grading
+$(1)-grading: book-build
+	lake env .lake/build/bin/sfl-$(1) grading
 
 $(1): $(1)-student $(1)-solutions $(1)-terse $(1)-grading
 
@@ -49,7 +45,12 @@ $(eval $(call VOLUME_template,ts))
 
 # ── Top-level targets ─────────────────────────────────────────────────────────
 
-.PHONY: all student solutions terse grading serve clean ensure-build-symlink style style-check style-checklist release
+.PHONY: all student solutions terse grading grading-tools grading-check-only grading-check serve clean ensure-build-symlink book-build style style-check style-checklist release
+
+# Compile all volume executables once before any generator starts.  A single
+# Lake frontend avoids races on the shared `.lake/build` directory.
+book-build: ensure-build-symlink
+	lake build sfl-lf sfl-hl sfl-ts
 
 all: lf hl ts
 
@@ -62,8 +63,18 @@ terse: lf-terse hl-terse ts-terse
 
 grading: lf-grading hl-grading ts-grading
 
+grading-tools:
+	lake build lean4export comparatorautograder
+
+# Check existing generated roots without generating books or building tools.
+grading-check-only:
+	python3 scripts/grading_check.py --volumes LF HL TS --variants student solutions --stats --no-make --no-build
+
+# Local convenience target. Run these documented targets separately in CI.
 grading-check:
-	python3 scripts/grading_check.py --volumes LF HL TS --variants student solutions --stats
+	$(MAKE) all
+	$(MAKE) grading-tools
+	$(MAKE) grading-check-only
 
 # Mechanical conformance checks for the style guides — STYLE-CODE.md and
 # STYLE-WRITING.md (auto checks fail the run; assisted ones are advisory).


### PR DESCRIPTION
The previous CI workflow generated the whole book twice: once in `make`, and once in `make grading-check`. This caused the workflow took up to 19 minutes to success. This PR splits the grading check into a separate job depending on the building job with layered caching. Moreover, it adds a specific `book-build` target in Makefile for building all executables together at once, and replaces each variant target from `lake exe ...` to `lake env .lake/build/bin/...` to avoid contention. We'll see how much the run time improves.

I used gpt-5.6 to carry out the changes.