### PR TITLE
Tactics: Polishing pass

### DIFF
--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -42,55 +42,6 @@ variable (a b c : Prop) (n m : Nat) (α : Type) (e1 e2 x y : α)
 ```
 :::
 
-:::dev "Yipeng Liu (berberman)" PotentialImprovement
-
-MWH: This was moved here from `Induction`. Work it in somewhere here, or
-maybe in IndProp or Tactics?
-
-This is an interesting question...
-
-Logically, induction subsumes case analysis —
-you can simply ignore those inductive hypotheses
-so anything provable by case analysis is also provable
-using the induction principle.
-
-However, Lean's `cases` has specialized machinery for indexed inductive families.
-Here are some examples that `cases` can solve while `induction` can't:
-
-```lean
--- substitution
-example (x : Nat) (h : x = 0) : Nat.succ x = 1 := by
-  -- induction h
-  cases h
-  rfl
-```
-
-```lean
--- disjointness
-example (h : (0 : Nat) = 1) : False := by
-  -- induction h
-  cases h
-```
-
-```lean
--- injectivity
-example {m n : Nat} (h : Nat.succ m = Nat.succ n) : m = n := by
-  -- induction h
-  cases h
-  rfl
-```
-
-```lean
--- acyclicity
-example (n : Nat) (h : n = Nat.succ n) : False := by
-  -- induction h
-  cases h
-```
-
-... and there are more!
-
-:::
-
 ::::hide
 ```
 -- QUIZ

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -62,6 +62,8 @@ previously proved lemma.
 
 The {tactic}`apply` tactic is useful when the goal is instead the
 conclusion of an implication.
+If the conclusion of the implication matches the current goal,
+its premises become new subgoals to be proved.
 
 :::full
 For example, suppose we have a hypothesis
@@ -75,19 +77,7 @@ example (p q : Prop) (h : p → q) (hp : p) : q := by
   exact hp
 ```
 
-::::full
-The {tactic}`apply` tactic also works with hypotheses
-and lemmas whose types are implications.
-If the conclusion of the implication matches the current goal,
-its premises become new subgoals to be proved.
-::::
-
-:::slidebreak
-:::
-
-::::terse
-{tactic}`apply` also works with hypotheses whose types are implications:
-::::
+Here is another example:
 
 ```lean
 example (n m o p : Nat) (hnm : n = m) (h : n = m → [n, o] = [m, p]) :
@@ -167,6 +157,12 @@ example (n m : Nat) (h : n = 0 → n = m) (hn : n = 0) : m = n := by
   exact hn
 ```
 
+:::dev "Mike Hicks (mwhicks1)"
+The above example introduces the `symm` tactic as a sort of aside.
+It would be nice if this were made more evident in the TOC for the
+chapter, for easier searching.
+:::
+
 ::::::full
 :::::exercise (rating := 2) (name := "apply_exercise1")
 You can use {tactic}`apply` with previously defined theorems, not
@@ -201,8 +197,7 @@ other.
 
 The {tactic}`apply` tactic works backward from a known fact.
 It takes a hypothesis, theorem, or constructor whose conclusion
-can be matched with the current goal. Lean uses the goal to infer
-as many of its arguments as possible, and any remaining premises
+can be matched with the current goal, and any remaining premises
 that still need to be proved become new subgoals.
 :::
 :::::
@@ -211,13 +206,13 @@ that still need to be proved become new subgoals.
 ## Supplying arguments to {tactic}`apply`
 
 The following silly example uses two rewrites in a row to
-get from `[a, b]` to `[e, f]`.
+get from `[u, v]` to `[y, z]`.
 
 ```lean
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
   rw [h₁, h₂]
 ```
 
@@ -229,8 +224,8 @@ lemma that records, once and for all, the fact that equality is
 _transitive_.
 
 ```lean
-theorem trans_eq {α : Type} (x y z : α) :
-    x = y → y = z → x = z := by
+theorem trans_eq {α : Type} (a b c : α) :
+    a = b → b = c → a = c := by
   intro h₁ h₂
   rw [h₁, h₂]
 ```
@@ -245,73 +240,82 @@ Lean already provides exactly this theorem as {name}`Eq.trans`:
 Eq.trans.{u} {α : Sort u} {a b c : α} (h₁ : a = b) (h₂ : b = c) : a = c
 ```
 
-In Lean's version, the arguments corresponding to `x`, `y`, and `z` are implicit,
-since they can usually be inferred from the equality hypotheses and the goal.
+:::dev "Mike Hicks (mwhicks1)"
+The above `#check` shows Lean's use of _sorts_, which we have seen before and
+not explained. When is a good time to actually explain this? The `Logic`
+chapter, maybe?
+:::
+
+Notice that in Lean's version, the arguments `a`, `b`, and `c` are implicit.
+::::full
+This is because they can usually be inferred from the equality hypotheses and the goal.
 
 Now let's use our {name}`trans_eq` to prove the example above.
-
-
-::::full
-If we simply write `apply trans_eq`, Lean can infer some arguments from the goal,
-but not the intermediate list or the hypotheses needed for the lemma's premises.
-If you inspect the proof state after {tactic}`apply`, you will see that Lean has created three goals:
-
-1. `[a, b] = ?y`
-2. `?y = [e, f]`
-3. `List Nat`
-
-Recall that {name}`trans_eq` has five arguments.
-From the goal, Lean can infer the endpoints `x` and `z`,
-namely `[a, b]` and `[e, f]`. But it still needs an intermediate term `y`.
-
-We want to prove `[a, b] = [e, f]`.
-By transitivity, it's enough to prove `[a, b] = ?y` and `?y = [e, f]`, for some intermediate list `?y`.
-Here `?y` is a _metavariable_: a placeholder for a value Lean has not yet determined.
-Before we provide the hypothesis `h₂`, Lean doesn't know that this intermediate list should be `[c, d]`.
 ::::
 
-```lean +error (name := trans_err1)
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
+If we simply write `apply trans_eq`, Lean can infer some arguments from the goal,
+but not the intermediate list or the hypotheses needed for the lemma's premises.
+```lean +error (name := trans_eq_one)
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
   apply trans_eq
 ```
 
-```leanOutput trans_err1
+Here is the proof state after {tactic}`apply`:
+
+```leanOutput trans_eq_one
 unsolved goals
 case a
-a b c d e f : Nat
-h₁ : [a, b] = [c, d]
-h₂ : [c, d] = [e, f]
-⊢ [a, b] = ?y
+u v w x y z : Nat
+h₁ : [u, v] = [w, x]
+h₂ : [w, x] = [y, z]
+⊢ [u, v] = ?b
 
 case a
-a b c d e f : Nat
-h₁ : [a, b] = [c, d]
-h₂ : [c, d] = [e, f]
-⊢ ?y = [e, f]
+u v w x y z : Nat
+h₁ : [u, v] = [w, x]
+h₂ : [w, x] = [y, z]
+⊢ ?b = [y, z]
 
-case y
-a b c d e f : Nat
-h₁ : [a, b] = [c, d]
-h₂ : [c, d] = [e, f]
+case b
+u v w x y z : Nat
+h₁ : [u, v] = [w, x]
+h₂ : [w, x] = [y, z]
 ⊢ List Nat
 ```
 
-One way to resolve this is to supply all the arguments and hypotheses explicitly:
+::::full
+Notice that we have three goals:
+
+1. `[u, v] = ?b`
+2. `?b = [y, z]`
+3. `List Nat`
+
+Recall that {name}`trans_eq` has five arguments.
+From the goal, Lean can infer the endpoints `a` and `c`,
+namely `[u, v]` and `[y, z]`. But it still needs an intermediate term `b`.
+
+We want to prove `[u, v] = [y, z]`.
+By transitivity, it's enough to prove `[u, v] = ?b` and `?b = [y, z]`, for some intermediate list `?b`.
+Here `?b` is a _metavariable_: a placeholder for a value Lean has not yet determined.
+Before we provide the hypothesis `h₂`, Lean doesn't know that this intermediate list should be `[w, x]`.
+::::
+
+One way to resolve this is to supply the arguments and hypotheses explicitly:
 
 ```lean
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
-  apply trans_eq [a, b] [c, d] [e, f] h₁ h₂
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
+  apply trans_eq [u, v] [w, x] [y, z] h₁ h₂
 ```
 
 :::full
-In the previous example, we had to specify the `x` and `z` arguments
-to {name}`trans_eq` before we could supply `[c, d]` for `y` or `h₁` and `h₂` for
+In the previous example, we had to specify the `a` and `c` arguments
+to {name}`trans_eq` before we could supply `[w, x]` for `b` or `h₁` and `h₂` for
 the premises. However, we just said that Lean was able to infer these arguments, so it's
 a bit redundant (and wordy) for us to do it.
 :::
@@ -319,35 +323,31 @@ a bit redundant (and wordy) for us to do it.
 Thankfully, Lean allows us to use `_`s for positional arguments that it can infer.
 
 ```lean
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
   apply trans_eq _ _ _ h₁ h₂
 ```
 
-If we know the name of the argument we are supplying (in this case `y`), we can
+If we know the name of the argument we are supplying (in this case `b`), we can
 name it directly and avoid typing any `_`s. This feature is called _named arguments_.
 Named arguments can be used in function applications generally, not just with {tactic}`apply`.
 
 ```lean
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
-  apply trans_eq (y := [c, d])
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
+  apply trans_eq (b := [w, x])
   apply h₁
   apply h₂
 ```
 
 ::::full
-Like any other kind of software, there are conventions and best practices associated
-with writing proofs in Lean. One of these conventions concerns the use of the {tactic}`exact`
-tactic. When fully applying another theorem like in the previous examples,
-it is considered good practice to use the {tactic}`exact` tactic instead of {tactic}`apply`. This signals to
-a reader of the proof that the proof is "exactly" an instance of another lemma, and that nothing
-of particular interest is happening here. This achieves a similar goal as when
-a mathematician says that one result is "just" an instance of another.
+When fully applying another theorem or hypothesis to conclude a proof,
+it is good practice to use the {tactic}`exact` tactic instead of {tactic}`apply`. Doing so signals to
+a reader that the proof is solved _exactly_ by this fact, and nothing more.
 ::::
 
 ::::terse
@@ -356,15 +356,15 @@ with a single application.
 ::::
 
 ```lean
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
   exact trans_eq _ _ _ h₁ h₂
 ```
 
 ::::full
-Recall the {tactic}`calc` we have learned in the {ref "UsingLean"}[UsingLean] chapter.
+Recall the {tactic}`calc` we saw in the {ref "UsingLean"}[UsingLean] chapter.
 It works by chaining equalities together using transitivity,
 serving the same purpose here as applying {name}`trans_eq`.
 ::::
@@ -374,13 +374,13 @@ We can also use {tactic}`calc`.
 ::::
 
 ```lean
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
   calc
-  [a, b] = [c, d] := by rw [h₁]
-  [c, d] = [e, f] := by rw [h₂]
+  [u, v] = [w, x] := by rw [h₁]
+  _ = [y, z] := by rw [h₂]
 ```
 
 :::::exercise (rating := 3) (name := "trans_eq_exercise") (optional := true)
@@ -399,7 +399,7 @@ theorem trans_eq_exercise (n m o p : Nat)
 :::
 :::::
 
-# The {tactic}`injection` and {tactic}`contradiction` Tactics
+# Tactics {tactic}`injection` and {tactic}`contradiction`
 
 ::::full
 Recall the definition of natural numbers:

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -52,7 +52,7 @@ import LF.Poly
 import LF.CustomTactics
 ```
 
-# The `apply` Tactic
+# The {tactic}`apply` Tactic
 
 ::::full
 We often encounter situations where the goal to be proved is
@@ -410,11 +410,10 @@ inductive Nat : Type where
   | succ (n : Nat)
 ```
 
-It is obvious from this definition that every number has one of
+By this definition, every number has exactly one of
 two forms: either it is the constructor `0` or it is built by
-applying the constructor `.succ` to another number.  But there is more
-here than meets the eye: implicit in the definition are two
-additional facts:
+applying the constructor `.succ` to another number.
+There are two important consequences of this definition:
 
 - The constructor `.succ` is _injective_ (or _one-to-one_).
   That is, if `n + 1 = m + 1`, it must also be that `n = m`.
@@ -432,13 +431,11 @@ neither here nor there.)  And so on.
 ::::
 
 ::::terse
-The constructors of inductive types are _injective_ (or _one-to-one_) and _disjoint_.
-
+The constructors of inductive types are _injective_ (aka _one-to-one_) and _disjoint_.
 E.g., for {name}`Nat`:
 
 - if `n + 1 = m + 1` then it must be that `n = m`
 - `0` is not equal to `n + 1` for any `n`
-
 ::::
 
 ## Injectivity
@@ -475,32 +472,24 @@ exploit injectivity of any constructor (not just {name}`Nat.succ`).
 example (n m : Nat)
     (h : n + 1 = m + 1) :
     n = m := by
-  injection h with hmn
+  injection h
 ```
 
 ::::full
-By writing `injection h with hmn` at this point, we are asking Lean
-to generate all equations that it can infer from `h` using the
-injectivity of constructors (in the present example, the equation
-`n = m`). This equation is added as a hypothesis (called
-`hmn` in this case) into the context. Because this equation is exactly our goal,
-in this case the {tactic}`injection` tactic is able to automatically close the goal.
+Writing `injection h` asks Lean to generate all equations
+that it can infer from `h` using the injectivity of constructors,
+adding them to the context.
+In the present example, Lean can infer that `n = m` from `n + 1 = m + 1`.
+When a generated equation satisfies the goal, as is the case here,
+the {tactic}`injection` tactic automatically closes the goal.
 ::::
-
-`with ...` can be omitted if the generated equations are not used.
-
-```lean
-example (n m : Nat)
-    (h : n + 1 = m + 1) :
-    n = m := by
-  injection h
-```
 
 :::slidebreak
 :::
 
-Here's a more interesting example that shows how {tactic}`injection` can
-derive multiple equations at once.
+When generated equations do not immediately close the goal,
+we can add `with` to name the equations to be added to the context
+(otherwise Lean generates names for us).
 
 ```lean
 example (n m o : Nat)
@@ -513,8 +502,8 @@ example (n m o : Nat)
 ```
 
 There is also a related tactic, {tactic}`injections`, that applies the {tactic}`injection`
-tactic to all your hypotheses at once, as many times in a row as it can. Using this
-tactic can avoid needing to repeatedly use {tactic}`injection` on lists. For example:
+tactic to all hypotheses, repeatedly. Using it simplifies the proof
+of the above example.
 
 ```lean
 example (n m o : Nat)
@@ -547,7 +536,7 @@ So much for injectivity of constructors.  What about disjointness?
 ::::full
 The principle of disjointness says that two terms beginning
 with different constructors (like `0` and {name}`Nat.succ`, or {name}`true` and {name}`false`)
-can never be equal. This means that, any time we find ourselves
+can never be equal. Therefore, any time we find ourselves
 in a context where we've _assumed_ that two such terms are equal,
 we are justified in concluding anything we want, since the
 assumption is nonsensical.
@@ -562,9 +551,8 @@ Two terms beginning with different constructors (like
 :::
 
 The {tactic}`contradiction` tactic embodies this principle. If the context
-contains a contradictory hypothesis, such as an equality between different
-constructors (e.g., {lean}`false = true`), {tactic}`contradiction` solves the
-current goal immediately. Some examples:
+contains a contradictory hypothesis, such as {lean}`false = true`,
+{tactic}`contradiction` solves the current goal immediately. Some examples:
 
 ```lean
 example (n m : Nat)
@@ -582,8 +570,17 @@ These examples are instances of a logical principle known as the
 _principle of explosion_, which asserts that a contradictory
 hypothesis entails anything (even manifestly false things!).
 
-Notice that due to the way addition on naturals is defined,
-deriving a contradiction from `1 + n = 0` is not as trivial as it seems.
+:::dev "Mike Hicks (mwhicks1)"
+Is there a way to relate this to the interpretation of implication
+P -> Q where it is true when P is false and Q is true? It seems like
+maybe this is a computational interpretation so perhaps not.
+:::
+
+In the above example, `n + 1` is shorthand for a constructor application `Nat.succ n`
+so contradiction applies to it directly. Sometimes you
+need to do a little work to expose a contradictory hypothesis involving
+constructors. For example, recall that {name}`Nat.add` recurses on its
+second argument, so deriving a contradiction from `1 + n = 0` is not direct.
 
 ```lean +error
 example (n : Nat)
@@ -803,23 +800,34 @@ Therefore it doesn't reduce to `x.succ`, so injectivity of constructors can't be
 :::slidebreak
 :::
 
+## Tactic {tactic}`congr`
+
 The injectivity of constructors allows us to reason that
 {lean}`∀ (n m : Nat), n + 1 = m + 1 → n = m`.  The converse of this
-implication is an instance of a more general fact about both
-constructors and functions:
+implication is also true:
 
 ```lean
-example {α β : Type} (f : α → β) (x y : α)
-    (h : x = y) : f x = f y := by
-  rw [h]
-
 example (n m : Nat) (h : n = m) :
     n + 1 = m + 1 := by
   rw [h]
 ```
 
+::::dev "Mike Hicks (mwhicks1)"
+Is the general "fact" highlighted below a _principle_ of _congruence_ ?
+Let's say so if that's the case.
+::::
+
+This is an instance of a more general fact about both
+constructors _and_ functions:
+
+```lean
+example {α β : Type} (f : α → β) (x y : α)
+    (h : x = y) : f x = f y := by
+  rw [h]
+```
+
 ::::full
-Indeed, there is also a tactic named {tactic}`congr` that can
+There is a tactic named {tactic}`congr` that can
 prove such goals directly.  Given a goal of the form
 `f a₁ ... aₙ = g b₁ ... bₙ`, the tactic {tactic}`congr` will produce subgoals
 of the form `f = g`, `a₁ = b₁`, ..., `aₙ = bₙ`. At the same time,
@@ -909,6 +917,17 @@ example (a b c d : Nat) (hab : a = b) (hcd : c = d) :
 :::
 
 # Using {tactic}`apply` on Hypotheses
+
+::::dev "Mike Hicks (mwhicks1)"
+Should this section be part of the section that introduces `apply` in
+the first place? I could imagine that goes here only if it relies on
+injectivity, etc. that have just been presented, but come after the
+introduction of `apply`. If so, I wonder if you could move the `apply`
+introduction here instead.
+
+Separate point: If this section is really about forward reasoning
+(and we use more than `apply` to show that), we should rename it.
+::::
 
 ::::full
 The tactic `apply t at h` matches an implication `t`
@@ -1061,11 +1080,11 @@ Using these tactics before {tactic}`apply` gives us yet another way to
 control where {tactic}`apply` does its work.
 
 ```lean
-example (a b c d e f : Nat)
-    (h₁ : [a, b] = [c, d])
-    (h₂ : [c, d] = [e, f]) :
-    [a, b] = [e, f] := by
-  have h := trans_eq (y := [c, d])
+example (u v w x y z : Nat)
+    (h₁ : [u, v] = [w, x])
+    (h₂ : [w, x] = [y, z]) :
+    [u, v] = [y, z] := by
+  have h := trans_eq (b := [w, x])
   apply h
   /- This tactic closes a goal if it appears anywhere in the context.
      In this case we could also write `exact h₁` ... -/
@@ -1573,6 +1592,54 @@ theorem diagonal_induction (p : Nat → Nat → Prop)
 :::::
 
 # Using {tactic}`cases` on Expressions
+
+:::dev "Mike Hicks (mwhicks1))"
+
+Is this worth adding somewhere around here, given that we have
+just introduced injectivity and disjointness tactics, and that we are
+now talking about the generalized use of `cases` ?
+
+Logically, induction subsumes case analysis —
+you can simply ignore those inductive hypotheses
+so anything provable by case analysis is also provable
+using the induction principle.
+
+However, Lean's `cases` has specialized machinery for indexed inductive families.
+Here are some examples that `cases` can solve while `induction` can't:
+
+```lean
+-- substitution
+example (x : Nat) (h : x = 0) : Nat.succ x = 1 := by
+  -- induction h
+  cases h
+  rfl
+```
+
+```lean
+-- disjointness
+example (h : (0 : Nat) = 1) : False := by
+  -- induction h
+  cases h
+```
+
+```lean
+-- injectivity
+example {m n : Nat} (h : Nat.succ m = Nat.succ n) : m = n := by
+  -- induction h
+  cases h
+  rfl
+```
+
+```lean
+-- acyclicity
+example (n : Nat) (h : n = Nat.succ n) : False := by
+  -- induction h
+  cases h
+```
+
+... and there are more!
+
+:::
 
 ::::full
 We have seen many examples where {tactic}`cases` is used to


### PR DESCRIPTION
- Remove some textual redundancy when introducing `apply`
- Made our `trans_eq` match the variable names of the built-in; updated example
- Prose polish