### PR TITLE
Tactics: More tidying

### DIFF
--- a/LF/CustomTactics.lean
+++ b/LF/CustomTactics.lean
@@ -163,13 +163,6 @@ elab "apply " t:term " at " i:ident : tactic => withSynthesize <| withMainContex
   let mainGoal ← mainGoal.tryClear ldecl.fvarId
   replaceMainGoal <| [mainGoal] ++ mvs.pop.toList.map (·.mvarId!)
 
-/--
-  `apply t at ⊢` names the goal explicitly with the turnstile symbol `⊢`
-  and applies `t` to it. It is backward reasoning, behaving exactly like
-  ordinary `apply t`.
--/
-elab "apply " t:term " at " "⊢" : tactic => do evalTactic (← `(tactic| apply $t))
-
 structure InversionConfig where
   clear : Bool := false
 
@@ -436,9 +429,5 @@ lemma doubleNegation : ∀ P, P → ¬ ¬ P := by
 
 example (H : Bool → Nat → False) (n : Nat) : False := by
   apply H at n; apply n; exact true
-
-example (p q : Prop) (h : p → q) (hp : p) : q := by
-  apply h at ⊢
-  exact hp
 
 end Tests

--- a/LF/CustomTactics.lean
+++ b/LF/CustomTactics.lean
@@ -163,6 +163,13 @@ elab "apply " t:term " at " i:ident : tactic => withSynthesize <| withMainContex
   let mainGoal ← mainGoal.tryClear ldecl.fvarId
   replaceMainGoal <| [mainGoal] ++ mvs.pop.toList.map (·.mvarId!)
 
+/--
+  `apply t at ⊢` names the goal explicitly with the turnstile symbol `⊢`
+  and applies `t` to it. It is backward reasoning, behaving exactly like
+  ordinary `apply t`.
+-/
+elab "apply " t:term " at " "⊢" : tactic => do evalTactic (← `(tactic| apply $t))
+
 structure InversionConfig where
   clear : Bool := false
 
@@ -429,5 +436,9 @@ lemma doubleNegation : ∀ P, P → ¬ ¬ P := by
 
 example (H : Bool → Nat → False) (n : Nat) : False := by
   apply H at n; apply n; exact true
+
+example (p q : Prop) (h : p → q) (hp : p) : q := by
+  apply h at ⊢
+  exact hp
 
 end Tests

--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -22,6 +22,26 @@ two 80-minute lectures, and the last couple of sections are quite
 meaty.  Pacing is key!
 :::
 
+:::::dev "Mike Hicks (mwhicks1)"
+See about working the following into this chapter.
+
+::::full
+Any tactic that accepts an `at`
+clause can target several locations at once, including the goal, by
+listing them together after `at`.
+::::
+
+::::terse
+More generally, `at` can list several locations at once, including the goal:
+::::
+
+```lean
+example (n m : Nat) (h : n + 0 = m) : n = m + 0 := by
+  rw [Nat.add_zero] at h ⊢
+  assumption
+```
+:::::
+
 :::dev BeforeNextRelease
 Unlike earlier chapters, there are probably too many
 WORKINCLASSes in this chapter.  BCP 20: But conversely some more

--- a/LF/Logic.lean
+++ b/LF/Logic.lean
@@ -42,6 +42,55 @@ variable (a b c : Prop) (n m : Nat) (α : Type) (e1 e2 x y : α)
 ```
 :::
 
+:::dev "Yipeng Liu (berberman)" PotentialImprovement
+
+MWH: This was moved here from `Induction`. Work it in somewhere here, or
+maybe in IndProp or Tactics?
+
+This is an interesting question...
+
+Logically, induction subsumes case analysis —
+you can simply ignore those inductive hypotheses
+so anything provable by case analysis is also provable
+using the induction principle.
+
+However, Lean's `cases` has specialized machinery for indexed inductive families.
+Here are some examples that `cases` can solve while `induction` can't:
+
+```lean
+-- substitution
+example (x : Nat) (h : x = 0) : Nat.succ x = 1 := by
+  -- induction h
+  cases h
+  rfl
+```
+
+```lean
+-- disjointness
+example (h : (0 : Nat) = 1) : False := by
+  -- induction h
+  cases h
+```
+
+```lean
+-- injectivity
+example {m n : Nat} (h : Nat.succ m = Nat.succ n) : m = n := by
+  -- induction h
+  cases h
+  rfl
+```
+
+```lean
+-- acyclicity
+example (n : Nat) (h : n = Nat.succ n) : False := by
+  -- induction h
+  cases h
+```
+
+... and there are more!
+
+:::
+
 ::::hide
 ```
 -- QUIZ

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -167,6 +167,7 @@ example (n m o : Nat)
     rw [h₁, h₃]
 ```
 
+::::::full
 :::::exercise (rating := 3) (name := "injection_ex3")
 ```lean
 theorem injection_ex3 {α : Type} (x y z : α) (l j : List α)
@@ -183,10 +184,11 @@ theorem injection_ex3 {α : Type} (x y z : α) (l j : List α)
 :::gradeTheorem 3 injection_ex3
 :::
 :::::
-
-So much for injectivity of constructors.  What about disjointness?
+::::::
 
 ::::full
+So much for injectivity of constructors.  What about disjointness?
+
 The principle of disjointness says that two terms beginning
 with different constructors (like `0` and {name}`Nat.succ`, or {name}`true` and {name}`false`)
 can never be equal. Therefore, any time we find ourselves
@@ -229,11 +231,17 @@ P -> Q where it is true when P is false and Q is true? It seems like
 maybe this is a computational interpretation so perhaps not.
 :::
 
+::::full
 In the above example, `n + 1` is shorthand for a constructor application `Nat.succ n`
-so contradiction applies to it directly. Sometimes you
+so contradiction applies to it directly.
+::::
+Sometimes you
 need to do a little work to expose a contradictory hypothesis involving
-constructors. For example, recall that {name}`Nat.add` recurses on its
+constructors.
+::::full
+For example, recall that {name}`Nat.add` recurses on its
 second argument, so deriving a contradiction from `1 + n = 0` is not direct.
+::::
 
 ```lean +error
 example (n : Nat)
@@ -569,46 +577,13 @@ example (a b c d : Nat) (hab : a = b) (hcd : c = d) :
 ```
 :::
 
-# More about {tactic}`cases`
+# Using {tactic}`cases` on Expressions
 
+::::full
 We've seen many examples where the {tactic}`cases` tactic is
-used to perform case analysis of the value of some variable.
-The tactic offers more general-purpose functionality, too.
-
-::::full
-For example, it turns
-out that {tactic}`cases` builds in this same reasoning that the {tactic}`injection` and {tactic}`contradiction`
-tactics exploit about the injectivity and disjointness of constructors.
-Here are a few examples.
-::::
-
-::::terse
-The {tactic}`cases` tactic has specialized machinery that lets it solve some goals involving disjointness and injectivity, as well as substitution, of constructors:
-::::
-
-```lean
--- substitution
-example (x : Nat) (h : x = 0) : Nat.succ x = 1 := by
-  cases h
-  rfl
-```
-
-```lean
--- disjointness
-example (h : (0 : Nat) = 1) : 2 = 3 := by
-  cases h
-```
-
-```lean
--- injectivity
-example {m n : Nat} (h : Nat.succ m = Nat.succ n) : m = n := by
-  cases h
-  rfl
-```
-
-::::full
-Sometimes we
-need to reason by cases on the result of some _expression_.  We
+used to perform case analysis of the value of some _variable_, such
+as one of type {name}`Bool` or {name}`Nat`.
+Sometimes we need to reason by cases on the result of some _expression_.  We
 can do so with {tactic}`cases`, directly. Here is an example:
 ::::
 
@@ -628,7 +603,7 @@ theorem chooseIf_self {α : Type} (test : α → Bool) (x : α) :
 ```
 
 ::::full
-After _unfolding_ {name}`chooseIf` in the above proof, we find that
+After unfolding {name}`chooseIf` in the above proof, we find that
 we are stuck on `(if test x = true then x else x) = x`.  But either
 `test x` is `true` or it isn't,
 so we can use `cases (test x)` to let us reason about the two cases.
@@ -812,15 +787,14 @@ theorem bool_fn_iterate_three_eq_one (f : Bool → Bool) (b : Bool) :
 # The {tactic}`apply` Tactic
 
 ::::full
-We often encounter situations where the goal to be proved is
-_exactly_ the same as some hypothesis in the context or some
-previously proved lemma.
+When the goal to be proved is
+_exactly_ the same as a hypothesis or a previously proved lemma, we
+can use the {tactic}`exact` tactic.
 ::::
 
-The {tactic}`apply` tactic is useful when the goal is instead the
-conclusion of an implication.
-If the conclusion of the implication matches the current goal,
-its premises become new subgoals to be proved.
+When the goal to be proved is the conclusion of hypothesis or lemma
+expressing an implication, we can use the {tactic}`apply` tactic.
+When we do, the premises of the implication become new subgoals to be proved.
 
 :::full
 For example, suppose we have a hypothesis
@@ -842,6 +816,10 @@ example (n m o p : Nat) (hnm : n = m) (h : n = m → [n, o] = [m, p]) :
   apply h
   exact hnm
 ```
+
+This process is called _backward reasoning_. We are trying to prove some
+goal `⊢ b` and we know some fact `h : a → b`. So we work backwards by
+applying that fact, which replaces the goal with `⊢ a`.
 
 ::::full
 When we use `apply h`, Lean tries to match the conclusion of the type
@@ -1140,6 +1118,7 @@ example (u v w x y z : Nat)
   _ = [y, z] := by rw [h₂]
 ```
 
+::::::full
 :::::exercise (rating := 3) (name := "trans_eq_exercise") (optional := true)
 ```lean
 theorem trans_eq_exercise (n m o p : Nat)
@@ -1155,8 +1134,11 @@ theorem trans_eq_exercise (n m o p : Nat)
 :::gradeTheorem 3 trans_eq_exercise
 :::
 :::::
+::::::
 
-# Forward Reasoning with {tactic}`apply`
+## Forward Reasoning with {tactic}`apply`
+
+We can also use the {tactic}`apply` tactic to rewrite _hypotheses_.
 
 ::::full
 The tactic `apply t at h` matches an implication `t`
@@ -1165,11 +1147,10 @@ context. Unlike ordinary {tactic}`apply`, which matches the goal against `b`
 and replaces it with the subgoal `a`, `apply t at h` matches the type of `h`
 against `a` and, if successful, replaces `h` with a hypothesis of type `b`.
 
-In other words, `apply t at h` gives us a form of "forward
-reasoning": given `t : a → b` and `h : a`, it replaces `h` with a proof of `b`.
-
-By contrast, ordinary `apply t` is "backward reasoning": given `t : a → b`
-and a goal `⊢ b`, it replaces the goal with `⊢ a`.
+In other words, `apply t at h` gives us a form of _forward
+reasoning_: given `t : a → b` and `h : a`, it replaces `h` with a proof of `b`.
+Contrast this with the backward reasoning done by ordinary {tactic}`apply`: given `t : a → b`
+and a goal `⊢ b`, `apply t` replaces the goal with `⊢ a`.
 
 Here is a proof that uses forward reasoning rather than backward reasoning:
 ::::
@@ -1178,14 +1159,13 @@ Here is a proof that uses forward reasoning rather than backward reasoning:
 :::
 
 ::::terse
-The ordinary {tactic}`apply` tactic is a form of "backward
-reasoning." It says "We are trying to prove `a` and we know
+The ordinary {tactic}`apply` tactic is a form of backward
+reasoning. It says "We are trying to prove `a` and we know
 `b → a`, so if we can prove `b` we'll be done."
 
-By contrast, the variant `apply ... at ...` is "forward reasoning":
+By contrast, the variant `apply ... at ...` is _forward reasoning_:
 it says "We know `b` and we know `b → a`, so we also know `a`."
 ::::
-
 
 ```lean
 example (n m p q : Nat)
@@ -1208,6 +1188,42 @@ use forward reasoning.  In Lean, however, backward reasoning is often more
 idiomatic, though forward reasoning can sometimes be easier to follow or more natural for
 particular proofs.
 
+Note that the {tactic}`apply` tactic, and indeed any tactic, can target
+the goal explicitly rather than implicitly:
+you can name it using the turnstile symbol `⊢`, written `\|-`, `\goal` or `\vdash`.
+Since the goal is exactly what ordinary {tactic}`apply` already works
+on, `apply t at ⊢` behaves exactly like `apply t`.
+::::
+
+::::terse
+The target of `at` can also be the goal itself, named with `⊢`. Since
+that is exactly what ordinary {tactic}`apply` already works on,
+`apply t at ⊢` behaves exactly like `apply t`:
+::::
+
+```lean
+example (p q : Prop) (h : p → q) (hp : p) : q := by
+  apply h at ⊢
+  exact hp
+```
+
+::::full
+This generalizes beyond {tactic}`apply`: any tactic that accepts an `at`
+clause can target several locations at once, including the goal, by
+listing them together after `at`.
+::::
+
+::::terse
+More generally, `at` can list several locations at once, including the goal:
+::::
+
+```lean
+example (n m : Nat) (h : n + 0 = m) : n = m + 0 := by
+  rw [Nat.add_zero] at h ⊢
+  assumption
+```
+
+::::full
 You may be interested to know that the `apply ... at ...` tactic
 is not part of Lean's core set of tactics. However, Lean makes it
 very easy for users to define new tactics that suit their
@@ -1218,31 +1234,14 @@ so we will not import the whole thing here, but we have
 made `apply ... at ...` available because it is quite useful.
 ::::
 
-::::full
-To apply a tactic in multiple places at the same time, you can list multiple hypotheses
-in a row after the `at`. You can also explicitly use a tactic on the goal (usually
-because you are applying the tactic to both a hypothesis and the goal) by including
-it after the `at` with the turnstile symbol `⊢`, written `\|-`, `\goal` or `\vdash`.
-::::
-
-::::terse
-You can apply tactics in multiple places at the same time, including the goal:
-::::
-
-```lean
-example (n m : Nat) (h : n + 0 = m) : n = m + 0 := by
-  rw [Nat.add_zero] at h ⊢
-  assumption
-```
-
 # Specializing Hypotheses
 
-We've already seen how we can use {tactic}`have` to do
-forward reasoning, by letting us state and prove useful facts
-that get us closer to the main goal we're trying to prove. Often,
-though, these facts are just special cases of more general hypotheses
-we already have.
+The {tactic}`have` tactic, which we have already seen, supports
+forward reasoning by letting us state and prove useful facts
+that get us closer to the main goal we're trying to prove.
 
+These facts are often just special cases of more general hypotheses
+we already have.
 If `h` is a quantified hypothesis in the current context — i.e.,
 `h : ∀ (x : α), P x` — then we can use {tactic}`have` to obtain a special
 case of `h` by supplying a value for `x`. For example, `have h := h e`
@@ -1565,6 +1564,7 @@ to _generalize_ `m`, so that the induction hypothesis applies to every `m`
 rather than just the particular `m` in the context.
 
 
+::::::full
 :::::exercise (rating := 3) (name := "add_self_injective")
 
 The following theorem follows the same pattern as {name}`double_injective`.
@@ -1594,7 +1594,9 @@ theorem add_self_injective (n m : Nat)
 :::gradeTheorem 3 add_self_injective
 :::
 :::::
+::::::
 
+:::::full
 ::::exercise (rating := 2) (name := "add_self_injective_informal") (manual := true)
 Give a careful informal proof of {name}`add_self_injective`, stating the induction
 hypothesis explicitly and being as explicit as possible about
@@ -1631,6 +1633,7 @@ GRADE_MANUAL 2: add_self_injective_informal
 ```
 :::
 ::::
+:::::
 
 # Rewriting with Conditional Statements
 
@@ -1676,14 +1679,91 @@ The theorem {name}`double_injective` says {lean}`n = m`
 _provided that_ {lean}`n.double = m.double`, not just {lean}`n = m`.
 When we write `rw [double_injective n m]`, Lean uses the conclusion {lean}`n = m` to rewrite
 the goal, and then asks us to prove the hypothesis needed by {name}`double_injective`.
-Thus we get two goals: the updated main goal, `m + p = q`, which follows from `hm`, and the
-condition from {name}`double_injective`, {lean}`n.double = m.double`, which follows from `h`.
+Thus we get two goals: the updated main goal, `m + p = q`, and the
+condition from {name}`double_injective`, {lean}`n.double = m.double`.
+These goals follow by assumption from `hm` and `h`, respectively.
 :::
 
 If we rewrite with a conditional statement of the form
 `P → a = b`, then Lean tries to rewrite with `a = b`, and then
 asks us to prove `P` in a new subgoal.  If the statement has more
 than one assumption, then we get one subgoal for each assumption.
+
+# Review
+
+::::full
+We've now talked about many of Lean's most fundamental tactics.
+We'll introduce a few more in the coming chapters, and later on
+we'll see some more powerful _automation_ tactics that make Lean
+help us with low-level details.  But basically we've got what we
+need to get work done.
+::::
+
+Here are the tactics we've seen so far.
+
+Managing goals and hypotheses:
+
+  - `intro h`: move an assumption/quantified variable from the goal into the local context
+
+  - `apply thm`: use a theorem, hypothesis, or constructor whose conclusion matches the goal;
+     its premises become new goals
+
+  - `apply thm at h`: use a theorem on a hypothesis in the context, replacing `h` by the resulting
+    fact (forward reasoning)
+
+  - `specialize h ...`: instantiate quantified variables in a hypothesis, modifying `h` in place
+
+  - `replace h := ...`: replace a hypothesis with a newly proved fact
+
+  - `have h : P := ...`: prove a local fact `P` and add it to the context with the name `h`
+
+  - `contradiction`: close the current goal when the context contains contradictory assumptions
+
+Equality, rewriting, and unfolding:
+
+  - `rfl`: close an equality that holds by reflexivity (possibly after computation)
+
+  - `rw [h]`: rewrite the goal using an equality hypothesis or theorem
+
+  - `rw [d]`: unfold a definition in the goal
+
+  - `rw [h] at h'`: rewrite a hypothesis using an equality hypothesis or theorem
+
+  - `rw [d] at h'`: unfold a definition in a hypothesis
+
+  - `symm`: reverse an equality goal, changing `t = u` to `u = t`
+
+  - `symm at h`: reverse an equality hypothesis
+
+  - `calc`: prove a goal about equality or another transitive relation by
+    giving a sequence of intermediate steps
+
+  - `congr`: use congruence to reduce an equality between expressions with the same outer form;
+    for example, a goal `f x = f y` may be reduced to `x = y`
+
+  - `injection h with ...`: use injectivity of constructors to extract equalities from equations
+    between constructor applications
+
+  - `injections`: repeatedly use constructor injectivity on suitable equalities in the context
+
+Case analysis:
+
+  - `cases x`: reason separately about the possible constructors of an inductively defined value
+
+  - `cases h : e`: perform case analysis on an expression `e` and add an equation named `h`
+    recording the result of the case analysis
+
+Induction:
+
+  - `induction x`: prove the goal by induction on an inductively defined value
+
+  - `induction x generalizing y`: induction on `x` while generalizing the listed local variables,
+    giving a more general induction hypothesis
+
+## Additional Exercises
+
+:::suppressPreviousHeaderWhenTerse
+:::
 
 ::::::full
 :::::exercise (rating := 3) (name := "nth?_after_last")
@@ -1708,6 +1788,7 @@ theorem nth?_after_last {α : Type}
 :::::
 ::::::
 
+::::::full
 :::::exercise (rating := 3) (name := "length_append_cons") (optional := true)
 
 Prove this by induction on `l₁`, without using {name}`List.length_append`.
@@ -1826,85 +1907,7 @@ theorem diagonal_induction (p : Nat → Nat → Prop)
 :::gradeTheorem 3 diagonal_induction
 :::
 :::::
-
-# Review
-
-:::suppressPreviousHeaderWhenTerse
-:::
-
-::::full
-We've now talked about many of Lean's most fundamental tactics.
-We'll introduce a few more in the coming chapters, and later on
-we'll see some more powerful _automation_ tactics that make Lean
-help us with low-level details.  But basically we've got what we
-need to get work done.
-
-Here are the ones we've seen so far.
-
-Managing goals and hypotheses:
-
-  - `intro h`: move an assumption/quantified variable from the goal into the local context
-
-  - `apply thm`: use a theorem, hypothesis, or constructor whose conclusion matches the goal;
-     its premises become new goals
-
-  - `apply thm at h`: use a theorem on a hypothesis in the context, replacing `h` by the resulting
-    fact (forward reasoning)
-
-  - `specialize h ...`: instantiate quantified variables in a hypothesis, modifying `h` in place
-
-  - `replace h := ...`: replace a hypothesis with a newly proved fact
-
-  - `have h : P := ...`: prove a local fact `P` and add it to the context with the name `h`
-
-  - `contradiction`: close the current goal when the context contains contradictory assumptions
-
-Equality, rewriting, and unfolding:
-
-  - `rfl`: close an equality that holds by reflexivity (possibly after computation)
-
-  - `rw [h]`: rewrite the goal using an equality hypothesis or theorem
-
-  - `rw [d]`: unfold a definition in the goal
-
-  - `rw [h] at h'`: rewrite a hypothesis using an equality hypothesis or theorem
-
-  - `rw [d] at h'`: unfold a definition in a hypothesis
-
-  - `symm`: reverse an equality goal, changing `t = u` to `u = t`
-
-  - `symm at h`: reverse an equality hypothesis
-
-  - `calc`: prove a goal about equality or another transitive relation by
-    giving a sequence of intermediate steps
-
-  - `congr`: use congruence to reduce an equality between expressions with the same outer form;
-    for example, a goal `f x = f y` may be reduced to `x = y`
-
-  - `injection h with ...`: use injectivity of constructors to extract equalities from equations
-    between constructor applications
-
-  - `injections`: repeatedly use constructor injectivity on suitable equalities in the context
-
-Case analysis:
-
-  - `cases x`: reason separately about the possible constructors of an inductively defined value
-
-  - `cases h : e`: perform case analysis on an expression `e` and add an equation named `h`
-    recording the result of the case analysis
-
-Induction:
-
-  - `induction x`: prove the goal by induction on an inductively defined value
-
-  - `induction x generalizing y`: induction on `x` while generalizing the listed local variables,
-    giving a more general induction hypothesis
-::::
-
-## Additional Exercises
-
-:::suppressPreviousHeaderWhenTerse
-:::
+::::::
 
 ::::::full
 :::::exercise (rating := 2) (name := "append_left_cancel")

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1188,42 +1188,6 @@ use forward reasoning.  In Lean, however, backward reasoning is often more
 idiomatic, though forward reasoning can sometimes be easier to follow or more natural for
 particular proofs.
 
-Note that the {tactic}`apply` tactic, and indeed any tactic, can target
-the goal explicitly rather than implicitly:
-you can name it using the turnstile symbol `⊢`, written `\|-`, `\goal` or `\vdash`.
-Since the goal is exactly what ordinary {tactic}`apply` already works
-on, `apply t at ⊢` behaves exactly like `apply t`.
-::::
-
-::::terse
-The target of `at` can also be the goal itself, named with `⊢`. Since
-that is exactly what ordinary {tactic}`apply` already works on,
-`apply t at ⊢` behaves exactly like `apply t`:
-::::
-
-```lean
-example (p q : Prop) (h : p → q) (hp : p) : q := by
-  apply h at ⊢
-  exact hp
-```
-
-::::full
-This generalizes beyond {tactic}`apply`: any tactic that accepts an `at`
-clause can target several locations at once, including the goal, by
-listing them together after `at`.
-::::
-
-::::terse
-More generally, `at` can list several locations at once, including the goal:
-::::
-
-```lean
-example (n m : Nat) (h : n + 0 = m) : n = m + 0 := by
-  rw [Nat.add_zero] at h ⊢
-  assumption
-```
-
-::::full
 You may be interested to know that the `apply ... at ...` tactic
 is not part of Lean's core set of tactics. However, Lean makes it
 very easy for users to define new tactics that suit their

--- a/LF/Tactics.lean
+++ b/LF/Tactics.lean
@@ -1760,7 +1760,7 @@ Induction:
   - `induction x generalizing y`: induction on `x` while generalizing the listed local variables,
     giving a more general induction hypothesis
 
-## Additional Exercises
+# Additional Exercises
 
 :::suppressPreviousHeaderWhenTerse
 :::


### PR DESCRIPTION
- Update forward reasoning with `apply` to make sudden appearance of `rw` tactic flow better. Updated `apply at` custom tactic to help
- Removed bits I added to `cases`, realizing they did not make sense; moved back to Logic
- Showed Review in terse build
- Hide exercises from terse build
- Added “Additional Exercises” section, since final exercises were not associated with the final section
- A little bit of polishing text