### PR TITLE
Fix autograder directives; fix gradescope autograder

### DIFF
--- a/LF/Basics.lean
+++ b/LF/Basics.lean
@@ -2742,8 +2742,6 @@ theorem and_eq_or (b c : Bool) : (b && c) = (b || c) → b = c := by
       rfl
 ```
 
-:::gradeTheorem 3 and_eq_or
-:::
 ::::
 :::::
 

--- a/LF/Lists.lean
+++ b/LF/Lists.lean
@@ -244,8 +244,6 @@ theorem fst_swap_is_snd (p : NatProd) :
   solution!
     cases p; rfl
 ```
-:::gradeTheorem 1 fst_swap_is_snd
-:::
 :::::
 
 ::::::
@@ -873,7 +871,7 @@ theorem test_member2 : member 2 [1, 4, 1] = false := solution!(by rfl)
 :::
 
 ::::::full
-:::::exercise (rating := 3) (name := "removing") (optional := true)
+:::::exercise (rating := 3) (name := "removeOne")
 Here are some more {name}`NatList` functions for you to practice with.
 
 When `removeOne` is applied to a list without the number to
@@ -917,6 +915,10 @@ theorem test_removeOne2 : count 5 (removeOne 5 [1, 5, 5, 4]) = 1 := solution!(by
 
 :::gradeTheorem "0.5" test_removeOne1 test_removeOne2
 :::
+:::::
+
+:::::exercise (rating := 3) (name := "removeAll") (optional := true)
+
 
 ```lean
 def removeAll (n : Nat) (l : NatList) : NatList := solution!(
@@ -939,8 +941,6 @@ theorem removeAll_cons_diff (n₁ n₂ : Nat) (t : NatList)
     rw [removeAll, h, cond_false]
 ```
 
-:::autogradedHole removeAll
-:::
 
 ```lean
 example : count 5 (removeAll 5 [5, 1]) = 0 := by
@@ -957,8 +957,6 @@ theorem test_removeAll1 : count 4 (removeAll 5 [4, 5, 4]) = 2 := solution!(by rf
 theorem test_removeAll2 : count 5 (removeAll 5 [2, 5, 5, 5, 1]) = 0 := solution!(by rfl)
 ```
 
-:::gradeTheorem "0.5" test_removeAll1 test_removeAll2
-:::
 
 :::::
 ::::::
@@ -987,8 +985,6 @@ def included (l₁ l₂ : NatList) : Bool := solution!(
   | h :: t => member h l₂ && included t (removeOne h l₂))
 ```
 
-:::autogradedHole included
-:::
 
 ```lean
 theorem included_nil (l₂ : NatList) : included nil l₂ = true := solution!(by rfl)
@@ -1024,8 +1020,6 @@ theorem test_included1 : included [1, 2] [2, 1, 4, 1] = true := solution!(by rfl
 theorem test_included2 : included [1, 2, 2] [2, 1, 4, 1] = false := solution!(by rfl)
 ```
 
-:::gradeTheorem "0.5" test_included1 test_included2
-:::
 :::::
 ::::::
 
@@ -1722,8 +1716,6 @@ theorem ble_self_succ (n : Nat) :
   | succ n' ih => rw [Nat.ble]; exact ih
 ```
 
-Before doing the next exercise, make sure you've filled in the
-definition of `removeOne` above.
 ::::::
 
 ::::dev "Daniel Sainati (dsainati)" PotentialImprovement
@@ -2011,8 +2003,6 @@ theorem option_elim_head? (l : NatList) (default : Nat) :
       rw [head_cons, head?_cons, NatOption.elim_some]
 ```
 
-:::gradeTheorem 1 option_elim_head?
-:::
 :::::
 
 ::::::

--- a/LF/Poly.lean
+++ b/LF/Poly.lean
@@ -979,8 +979,6 @@ theorem head?_cons {α : Type} {head : α} {tail : List α} : head? (head :: tai
   solution!(by rfl)
 ```
 
-:::autogradedHole head?
-:::
 
 ```lean
 theorem test_head?1 : head? [1, 2] = some 1 := solution!(by rfl)
@@ -988,8 +986,6 @@ theorem test_head?1 : head? [1, 2] = some 1 := solution!(by rfl)
 theorem test_head?2 : head? [[1], [2]] = some [1] := solution!(by rfl)
 ```
 
-:::gradeTheorem "0.5" test_head?1 test_head?2
-:::
 :::::
 ::::::
 

--- a/gradescope/package.py
+++ b/gradescope/package.py
@@ -9,7 +9,7 @@
 
 Run `make` first: both are assembled from the extracted chapters in _out/.
 """
-import argparse, json, os, re, shutil, subprocess, sys, tempfile, zipfile
+import argparse, json, os, re, shlex, shutil, subprocess, sys, tempfile, zipfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -186,6 +186,23 @@ def stage(vol, chapters, dest):
           f"{', '.join(sorted(graded))}; the rest from solutions")
 
 
+def verify_env(path, env):
+    """Read config.env back the way the shell will.
+
+    A value that does not survive the round trip breaks `setup.sh` and
+    `run_autograder`, which source this file -- and it breaks them on
+    Gradescope, minutes into an image build, not here."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        key, _, raw = line.partition("=")
+        try:
+            parsed = shlex.split(raw)
+        except ValueError as e:
+            sys.exit(f"config.env: {key} is not valid shell ({e}): {line}")
+        if parsed != [env[key]]:
+            sys.exit(f"config.env: {key} does not survive quoting: "
+                     f"wrote {env[key]!r}, reads back as {parsed!r}")
+
+
 def assemble(vol, chapters, dest, sandbox=True):
     """Everything the archive holds except its own version stamp."""
     toolchain = (REPO / "lean-toolchain").read_text().strip()
@@ -193,11 +210,18 @@ def assemble(vol, chapters, dest, sandbox=True):
     stage(vol, chapters, dest / "context")
     (dest / "context" / "lakefile.toml").write_text(lakefile())
     (dest / "context" / "lean-toolchain").write_text(toolchain)
-    (dest / "config.env").write_text(
-        f"VOLUME={vol}\nCHAPTER={','.join(chapters)}\nLEAN_TOOLCHAIN={toolchain}\n"
-        f"COMPARATOR_AUTOGRADER_URL={url}\nCOMPARATOR_AUTOGRADER_REV={rev}\n"
-        f"MANUAL={','.join(manual_exercises(vol, chapters))}\n"
-        + ("" if sandbox else "SFL_LANDRUN=/opt/grader/bin/fake-landrun.sh\n"))
+    # setup.sh and run_autograder source this file, so every value is quoted for
+    # the shell: Lean names may contain an apostrophe (`succ_mul_succ'`), which
+    # unquoted would open a string the file never closes.
+    env = {"VOLUME": vol, "CHAPTER": ",".join(chapters),
+           "LEAN_TOOLCHAIN": toolchain,
+           "COMPARATOR_AUTOGRADER_URL": url, "COMPARATOR_AUTOGRADER_REV": rev,
+           "MANUAL": ",".join(manual_exercises(vol, chapters))}
+    if not sandbox:
+        env["SFL_LANDRUN"] = "/opt/grader/bin/fake-landrun.sh"
+    config = dest / "config.env"
+    config.write_text("".join(f"{k}={shlex.quote(v)}\n" for k, v in env.items()))
+    verify_env(config, env)
     for f in ("setup.sh", "run_autograder", "grade.py"):
         shutil.copyfile(HERE / f, dest / f)
 


### PR DESCRIPTION
Changes:
- Lists: Split exercise `Removal` to `removeOne` (non-optional) and `removeAll` (optional), so a non-optional exercise (`remove_does_not_increase_count`) will not depend on an optional one (`removeOne`).

- Chapters up to Poly: Remove `gradeTheorem` directives on optional exercises.

- Fix autograder building failure on exercise names with `'`